### PR TITLE
Add organizer feat: required info

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ So far we have only two user roles: participants and group organizers
 
 - I can email the entire list of participants.
 
+- I can add required info fields besides attendee name, like id
+
 - I can ban a participant whom I believe is toxic or who has previously broken my organization's code of conduct.
 
 - I can add a venue sponsor to the event with a link to their website as a way of thanking them for hosting.


### PR DESCRIPTION
This feature is a must for us (https://github.com/freeCodeCampBA) as some venues ask for this.

[Eventbrite](https://www.eventbrite.com/support/articles/en_US/How_To/how-to-create-custom-questions-for-attendees) has this feature. 

Meetup gives you the chance to add a question that appears when someone completes the RSVP, but you can't make it mandatory, some people sometimes don't complete it, it's annoying and a waste of time to be messaging them, besides [sometimes it just don't work](https://www.meetup.com/Slow-and-Steady-Hikers/messages/boards/thread/50216291).