### PR TITLE
Adapt users to be external ID providers friendly

### DIFF
--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -6,14 +6,14 @@ create table users (
     password_digest text
 );
 
-create table social_provider (
+create table social_providers (
     id uuid primary key,
     name text
 );
 
-create table social_provider_user (
+create table social_provider_users (
     id uuid primary key,
-    provider_id uuid references social_provider(id) not null,
+    provider_id uuid references social_providers(id) not null,
     provider_user_id text not null,
     user_id uuid references users(id) not null
 );

--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -3,9 +3,19 @@ create table users (
     first_name text not null ,
     last_name text,
     email text not null,
-    provider text,
-    provider_id text,
     password_digest text
+);
+
+create table social_provider (
+    id uuid primary key,
+    name text
+);
+
+create table social_provider_user (
+    id uuid primary key,
+    provider_id uuid references social_provider(id) not null,
+    provider_user_id text not null,
+    user_id uuid references users(id) not null
 );
 
 create table locations (

--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -1,9 +1,11 @@
 create table users (
     id uuid primary key,
     first_name text not null ,
-    last_name text not null,
+    last_name text,
     email text not null,
-    password text not null
+    provider text,
+    provider_id text,
+    password_digest text
 );
 
 create table locations (


### PR DESCRIPTION
- [x] Making `last_name` not required since it is not required in Meetup.com right now.
- [x] Adding `provider` as a way to track external ID providers like Google, Facebook, Auth0 when the user uses one of them.
- [x] Adding `provider_id` as a way to track which user is on one of those external providers.
- [x] Renaming `password` to `password_digest` to make clear that we'll need to use a hash instead of the actual plain text password, and making it optional in case of Social/IdP signup.