### PR TITLE
Add waitlist support in RSVPs

### DIFF
--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -62,11 +62,9 @@ create table rsvps (
     user_id uuid references  users(id),
     event_id uuid references events(id),
     date timestamptz not null,
-    on_waitlist boolean not null,
+    on_waitlist boolean not null default FALSE,
     primary key (user_id, event_id)
 );
-
-alter table rsvps alter column on_waitlist set default FALSE;
 
 create table user_bans (
     user_id uuid references users(id),

--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -61,8 +61,12 @@ create table user_groups (
 create table rsvps (
     user_id uuid references  users(id),
     event_id uuid references events(id),
+    date timestamptz not null,
+    in_waitlist boolean not null,
     primary key (user_id, event_id)
 );
+
+alter table rsvps alter column in_waitlist set default FALSE;
 
 create table user_bans (
     user_id uuid references users(id),

--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -62,11 +62,11 @@ create table rsvps (
     user_id uuid references  users(id),
     event_id uuid references events(id),
     date timestamptz not null,
-    in_waitlist boolean not null,
+    on_waitlist boolean not null,
     primary key (user_id, event_id)
 );
 
-alter table rsvps alter column in_waitlist set default FALSE;
+alter table rsvps alter column on_waitlist set default FALSE;
 
 create table user_bans (
     user_id uuid references users(id),


### PR DESCRIPTION
Adds `in_waitlist` column that will help implement a whitelist system as the one that meetup.com has right now.