### PR TITLE
Changes to RSVP model

### DIFF
--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -79,8 +79,8 @@ create table user_groups (
 );
 
 create table rsvps (
-    user_id uuid references users(id) not null,
-    event_id uuid references events(id) not null,
+    user_id uuid references users(id),
+    event_id uuid references events(id),
     accepted_at timestamptz,
     declined_at timestamptz,
     on_waitlist boolean not null default FALSE,

--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -79,9 +79,10 @@ create table user_groups (
 );
 
 create table rsvps (
-    user_id uuid references  users(id),
-    event_id uuid references events(id),
-    date timestamptz not null,
+    user_id uuid references users(id) not null,
+    event_id uuid references events(id) not null,
+    accepted_at timestamptz,
+    declined_at timestamptz,
     on_waitlist boolean not null default FALSE,
     primary key (user_id, event_id)
 );


### PR DESCRIPTION
- Replace `date` with `accepted_at`/`declined_at`
    - I think we should keep things flexible allow for both declining and accepting. For instance someone could initially accept and subsequently decline later on.
- Fix whitespace

I did not add not null constraints to `accepted_at`/`declined_at` as we could potentially allow for invites, meaning we could have RSVPs without either in a pending state.

 Happy to hear people's thoughts on this one though.