### PR TITLE
Add capacity to events

### DIFF
--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -59,7 +59,8 @@ create table events (
     group_id uuid references groups(id) not null ,
     venue_id uuid references venues(id),
     tag_id uuid references tags(id),
-    canceled boolean default false
+    canceled boolean default false,
+    capacity int not null
 );
 
 create table tags (


### PR DESCRIPTION
https://github.com/freeCodeCamp/chapter/issues/17

> @QuincyLarson Looks like the Event table will need 'capacity' to be added

@QuincyLarson Could you please take a look?
@ScottBrenner, vaibhavsingh97: Previous PR(https://github.com/freeCodeCamp/chapter/pull/62) was messed up for some reason - this should be good