### PR TITLE
fix(docs): issue template rendering

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,6 @@
 ---
 name: 'Bug Report: Issues with Chapter software'
-about: Report an issue or flaw in chapter software's schema,
-architecture, APIs, UI or anything related to our software.
+about: Report an issue or flaw in chapter software's schema, architecture, APIs, UI or anything related to our software.
 title: ''
 labels: 'type: bug'
 assignees: ''
@@ -9,9 +8,9 @@ assignees: ''
 ---
 
 ### Describe the bug:
-Please describe the bug in as much detail as possible.
+<!-- Please describe the bug in as much detail as possible. -->
 
 
 ### Tell us about your browser and operating system:
-- **Browser(s) name and version**: 
-- **Operating System**: 
+- Browser(s) name and version: 
+- Operating System: 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,8 @@
-<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. 
-     It will ensure that our team takes your pull request seriously. -->
+<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->
 
-- [ ] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
-- [ ] My pull request has a descriptive title (not a vague title like `Update README.md`).
-- [ ] My pull request targets the `master` branch of Chapter.
+- [] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
+- [] My pull request has a descriptive title (not a vague title like `Update README.md`).
+- [] My pull request targets the `master` branch of Chapter.
 
 <!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->
 


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. 
     It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #XXXXX

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
While testing the issue and PR templates I observed that the `bug-report.md` template wasn't rendering. So it has been fixed. There was a small formatting error in the YAML.