### PR TITLE
Add user story: Save RSVP'd events to calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Our goal is to keep things simple and not reinvent wheels. So far we have only t
 
 - I can click the "RSVP" button. When I do, I will be prompted to sign in. Then I will receive an email with a ticket and add me to the public list of event attendees.
 
+- I can save RSVP'd events to my calendar of choice. The calendar invites would contain: Event Name, Venue, Date & Time, and the Description of the event (if applicable).
+
 - I will receive a second email the day before the event to remind me.
 
 - After the event, I will automatically get emails notifying me of subsequent events.


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

I love calendars. When using any kind of event scheduling tool, I make sure I can send some form of an invitation to them!

It would be great to consider adding this feature -which would be optional- to users who desire to save these invites in their calendars (without having to type them manually).