### PR TITLE
fix/feat/api/swagger.json fix/feat/data/ddl.sql Added category label of types tring to the schemas closes #71

### DIFF
--- a/api/swagger.json
+++ b/api/swagger.json
@@ -30,7 +30,9 @@
   "paths": {
     "/locations": {
       "post": {
-        "tags": ["location"],
+        "tags": [
+          "location"
+        ],
         "summary": "Add a new location to the map",
         "description": "",
         "operationId": "addLocation",
@@ -75,7 +77,9 @@
         }
       },
       "get": {
-        "tags": ["location"],
+        "tags": [
+          "location"
+        ],
         "summary": "Finds Locations by city, country etc",
         "description": "Multiple status values can be provided as query params",
         "operationId": "findLocations",
@@ -142,7 +146,9 @@
     },
     "/locations/{locationId}": {
       "get": {
-        "tags": ["location"],
+        "tags": [
+          "location"
+        ],
         "summary": "Find location by ID",
         "description": "Returns a single location",
         "operationId": "getLocationById",
@@ -169,7 +175,6 @@
               }
             }
           },
-
           "404": {
             "description": "Location not found"
           },
@@ -186,7 +191,9 @@
         }
       },
       "patch": {
-        "tags": ["location"],
+        "tags": [
+          "location"
+        ],
         "summary": "Update an existing location",
         "description": "",
         "operationId": "updateLocation",
@@ -243,7 +250,9 @@
         }
       },
       "delete": {
-        "tags": ["location"],
+        "tags": [
+          "location"
+        ],
         "summary": "Deletes a location",
         "description": "",
         "operationId": "deleteLocation",
@@ -281,7 +290,9 @@
     },
     "/chapters": {
       "post": {
-        "tags": ["chapter"],
+        "tags": [
+          "chapter"
+        ],
         "summary": "Add a new chapter",
         "description": "",
         "operationId": "addChapter",
@@ -325,7 +336,9 @@
     },
     "/chapters/{chapterId}": {
       "get": {
-        "tags": ["chapter"],
+        "tags": [
+          "chapter"
+        ],
         "summary": "Retreive the details of a chapter",
         "description": "",
         "operationId": "findChapterById",
@@ -355,7 +368,6 @@
           "401": {
             "description": "Not authorized"
           },
-
           "404": {
             "description": "Chapter not found"
           },
@@ -374,7 +386,9 @@
     },
     "/chapters/{chapterId}/events": {
       "get": {
-        "tags": ["chapter"],
+        "tags": [
+          "chapter"
+        ],
         "summary": "Retreive the events belonging to a chapter",
         "description": "",
         "operationId": "findEventsInChapter",
@@ -410,7 +424,6 @@
           "401": {
             "description": "Not authorized"
           },
-
           "404": {
             "description": "Chapter not found"
           },
@@ -429,7 +442,9 @@
     },
     "/chapters/{chapterId}/events/{eventId}": {
       "get": {
-        "tags": ["chapter"],
+        "tags": [
+          "chapter"
+        ],
         "summary": "Retreive an event by id",
         "description": "",
         "operationId": "findEventById",
@@ -488,7 +503,9 @@
         }
       },
       "delete": {
-        "tags": ["chapter"],
+        "tags": [
+          "chapter"
+        ],
         "summary": "Delete an event by id",
         "description": "",
         "operationId": "deleteEventById",
@@ -549,7 +566,9 @@
     },
     "/chapters/{chapterId}/events/{eventId}/sponsors": {
       "get": {
-        "tags": ["chapter"],
+        "tags": [
+          "chapter"
+        ],
         "summary": "Retreive list of sponsors by event",
         "description": "",
         "operationId": "findSponsorsByEvent",
@@ -605,7 +624,9 @@
         }
       },
       "post": {
-        "tags": ["chapter"],
+        "tags": [
+          "chapter"
+        ],
         "summary": "Add a new food, venue or other sponsor",
         "description": "",
         "operationId": "addSponsorToEvent",
@@ -677,7 +698,9 @@
     },
     "/chapters/{chapterId}/events/{eventId}/sponsors/{sponsorId}": {
       "get": {
-        "tags": ["chapter"],
+        "tags": [
+          "chapter"
+        ],
         "summary": "Retreive sponsor by ID",
         "description": "",
         "operationId": "findSponsorById",
@@ -746,7 +769,9 @@
         }
       },
       "delete": {
-        "tags": ["chapter"],
+        "tags": [
+          "chapter"
+        ],
         "summary": "Delete a sponsor by id",
         "description": "",
         "operationId": "deleteSponsorById",
@@ -815,7 +840,9 @@
         }
       },
       "patch": {
-        "tags": ["chapter"],
+        "tags": [
+          "chapter"
+        ],
         "summary": "Update a sponsor by id",
         "description": "",
         "operationId": "updateSponsorById",
@@ -886,7 +913,9 @@
     },
     "/users": {
       "post": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "summary": "Add a new user",
         "description": "",
         "operationId": "addUser",
@@ -925,7 +954,9 @@
     },
     "/users/{userId}": {
       "get": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "summary": "Retreive the details of a user",
         "description": "",
         "operationId": "findUserById",
@@ -968,7 +999,9 @@
         }
       },
       "patch": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "summary": "Edit an existing user",
         "description": "",
         "operationId": "updateUser",
@@ -1022,7 +1055,9 @@
     },
     "/users/{userId}/ban": {
       "patch": {
-        "tags": ["user"],
+        "tags": [
+          "user"
+        ],
         "summary": "Ban a user",
         "description": "",
         "operationId": "banUserById",
@@ -1134,6 +1169,9 @@
           "description": {
             "type": "string"
           },
+          "category": {
+            "type": "string"
+          },
           "details": {
             "type": "string"
           },
@@ -1152,7 +1190,6 @@
             "type": "string",
             "format": "uuid"
           },
-
           "name": {
             "type": "string"
           },
@@ -1181,7 +1218,11 @@
       },
       "SponsorType": {
         "type": "string",
-        "enum": ["FOOD", "VENUE", "OTHER"]
+        "enum": [
+          "FOOD",
+          "VENUE",
+          "OTHER"
+        ]
       },
       "Event": {
         "type": "object",
@@ -1221,7 +1262,10 @@
       },
       "Error": {
         "type": "object",
-        "required": ["code", "message"],
+        "required": [
+          "code",
+          "message"
+        ],
         "properties": {
           "code": {
             "type": "integer",

--- a/data/ddl.sql
+++ b/data/ddl.sql
@@ -43,6 +43,7 @@ create table chapters
   id uuid primary key ,
   name text unique not null,
   description text not null,
+  category text not null,
   details jsonb,
   location_id uuid references locations(id) not null,
   creator_id uuid references users(id) not null,


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #71

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
I added the "Category" label to the Chapter schema on both the SQL file and on the JSON file. This makes it easier for the end-user to filter the Chapters by the desired categories, and not only by location. The other changes were spacing added by linter for readability purposes, but I can undo them if necessary. 