### PR TITLE
fix next config syntax and linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules/
 .next/
+next.config.js

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,10 @@
-import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
-export function webpack(config, options) {
-  config.resolve.alias.client = './client';
-  config.resolve.alias.server = './server';
-  config.plugins.push(new ForkTsCheckerWebpackPlugin());
-  return config;
-}
+module.exports = {
+  webpack(config, options) {
+    config.resolve.alias.client = './client';
+    config.resolve.alias.server = './server';
+    config.plugins.push(new ForkTsCheckerWebpackPlugin());
+    return config;
+  },
+};


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

This PR does the following:
* Uses commonjs imports for `next.config.js` (as `next` doesnt transpile when building)
* ignore `next.config.js` when linting so it doesn't yell at us for using commonjs imports