### PR TITLE
Change the schema image path in the README to a relative path 

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ npm run test:watch
 
 ## Schema
 
-![a diagram illustrating the proposed schema for chapter](https://github.com/freeCodeCamp/chapter/raw/master/data/schema.png)
+![a diagram illustrating the proposed schema for chapter](data/schema.png)
 
 ## User stories so far
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

Closes: nothing, just a fix

The previous commit used an absolute path that would always point at the main repo's master branch image, which can cause confusion when someone updates the schema.png on their fork.

Github Markdown is smart enough to convert data/schema.png to a path that's relative to the active fork and branch.