### PR TITLE
Refactor: extract routes in folder

### DIFF
--- a/server/routers/exampleRouter.ts
+++ b/server/routers/exampleRouter.ts
@@ -1,26 +1,13 @@
 import express from 'express';
-import asyncHandler from 'express-async-handler';
-import { BadRequestError } from 'express-response-errors';
+
+import sampleRoute from 'server/routers/routes/sampleRoute';
+import sampleAsyncRoute from 'server/routers/routes/sampleAsyncRoute';
+import sampleErroredRoute from 'server/routers/routes/sampleErroredRoute';
 
 const router = express.Router();
 
-router.get('/api/sample-route', (req, res) => {
-  const { query } = req;
-  res.json({ message: 'Response from the server', query });
-});
-
-router.get(
-  '/api/sample-async-route',
-  asyncHandler(async (req, res) => {
-    await new Promise(resolve => setTimeout(resolve, 3000));
-
-    const { query } = req;
-    res.json({ message: 'Delayed response from the server', query });
-  }),
-);
-
-router.get('/api/sample-errored-route', () => {
-  throw new BadRequestError('This route will always error with code 400');
-});
+router.get('/api/sample-route', sampleRoute);
+router.get('/api/sample-async-route', sampleAsyncRoute);
+router.get('/api/sample-errored-route', sampleErroredRoute);
 
 export default router;

--- a/server/routers/routes/sampleAsyncRoute.ts
+++ b/server/routers/routes/sampleAsyncRoute.ts
@@ -1,0 +1,8 @@
+import asyncHandler from 'express-async-handler';
+
+export default asyncHandler(async (req, res) => {
+  await new Promise(resolve => setTimeout(resolve, 3000));
+
+  const { query } = req;
+  res.json({ message: 'Delayed response from the server', query });
+});

--- a/server/routers/routes/sampleErroredRoute.ts
+++ b/server/routers/routes/sampleErroredRoute.ts
@@ -1,0 +1,5 @@
+import { BadRequestError } from 'express-response-errors';
+
+export default () => {
+  throw new BadRequestError('This route will always error with code 400');
+};

--- a/server/routers/routes/sampleRoute.ts
+++ b/server/routers/routes/sampleRoute.ts
@@ -1,0 +1,4 @@
+export default (req, res) => {
+  const { query } = req;
+  res.json({ message: 'Response from the server', query });
+};


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

This is a followup PR to #128.

I'm proposing an intermediate version between the existing solution and what we have in #128.

We are not introducing objects but we are separating functions in files, so we retain a clean router and smaller route files.

I haven't any strong preference between this or #128, I like both :) Maybe this is just a bit simpler?