### PR TITLE
add serverside testing [WIP]

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,4 +14,7 @@ module.exports = {
       diagnostics: false,
     },
   },
+  watchPathIgnorePatterns: ['/node_modules'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  testMatch: ['/**/*.test.(ts|js|tsx|jsx)'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  moduleDirectories: ['node_modules', 'server'],
+  moduleNameMapper: {
+    '^server/(.*)': '<rootDir>/server/$1',
+  },
+  globals: {
+    'ts-jest': {
+      diagnostics: false,
+    },
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1338,6 +1338,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1369,6 +1375,15 @@
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/get-port": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-4.2.0.tgz",
+      "integrity": "sha512-Iv2FAb5RnIk/eFO2CTu8k+0VMmIR15pKbcqRWi+s3ydW+aKXlN2yemP92SrO++ERyJx+p6Ie1ggbLBMbU1SjiQ==",
+      "dev": true,
+      "requires": {
+        "get-port": "*"
       }
     },
     "@types/glob": {
@@ -1556,6 +1571,25 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/superagent": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.3.tgz",
+      "integrity": "sha512-vy2licJQwOXrTAe+yz9SCyUVXAkMgCeDq9VHzS5CWJyDU1g6CI4xKb4d5sCEmyucjw5sG0y4k2/afS0iv/1D0Q==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/supertest": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.8.tgz",
+      "integrity": "sha512-wcax7/ip4XSSJRLbNzEIUVy2xjcBIZZAuSd2vtltQfRK7kxhx5WMHbLHkYdxN3wuQCrwpYrg86/9byDjPXoGMA==",
+      "dev": true,
+      "requires": {
+        "@types/superagent": "*"
+      }
     },
     "@types/tapable": {
       "version": "1.0.4",
@@ -2968,6 +3002,15 @@
         "node-releases": "^1.1.36"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
@@ -3612,6 +3655,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -5202,6 +5251,12 @@
       "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=",
       "dev": true
     },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+      "dev": true
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -5280,13 +5335,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5299,18 +5352,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5413,8 +5463,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5424,7 +5473,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5437,20 +5485,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5467,7 +5512,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5540,8 +5584,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5551,7 +5594,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5657,7 +5699,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5743,6 +5784,23 @@
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
       "integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==",
       "dev": true
+    },
+    "get-port": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.0.0.tgz",
+      "integrity": "sha512-imzMU0FjsZqNa6BqOjbbW6w5BivHIuQKopjpPqcnx0AVHJQKCxK1O+Ab3OrVXhrekqfVMjwA9ZYu062R+KcIsQ==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.3.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -8015,6 +8073,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -12001,6 +12065,51 @@
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
       "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
     },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
+      "integrity": "sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^3.8.3"
+      }
+    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -12648,6 +12757,50 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
+    "ts-jest": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.1.0.tgz",
+      "integrity": "sha512-HEGfrIEAZKfu1pkaxB9au17b1d9b56YZSqz5eCVE8mX68+5reOvlM93xGOzzCREIov9mdH7JBG+s0UyNAqr0tQ==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "0.x",
+        "resolve": "1.x",
+        "semver": "^5.5",
+        "yargs-parser": "10.x"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+          "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
     },
     "ts-node": {
       "version": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "speccy:watch": "npx nodemon --watch 'api/swagger.json' --exec 'npm run speccy'",
     "speccy": "npx speccy serve -p 8001 api/swagger.json",
     "start": "npm run prod:server",
-    "test": "NODE_ENV=test npx jest --coverage --verbose",
-    "test:watch": "NODE_ENV=test npx jest --watch"
+    "test": "NODE_ENV=test docker-compose exec app npx jest --coverage --verbose",
+    "test:watch": "NODE_ENV=test docker-compose exec app npx jest --watch"
   },
   "repository": {
     "type": "git",
@@ -53,12 +53,14 @@
   "devDependencies": {
     "@testing-library/react": "^9.3.0",
     "@types/express": "^4.17.1",
+    "@types/get-port": "^4.2.0",
     "@types/jest": "^24.0.19",
     "@types/morgan": "^1.7.37",
     "@types/next": "^8.0.6",
     "@types/node": "^12.11.1",
     "@types/react": "^16.9.9",
     "@types/react-dom": "^16.9.2",
+    "@types/supertest": "^2.0.8",
     "@typescript-eslint/eslint-plugin": "^2.4.0",
     "@typescript-eslint/parser": "^2.4.0",
     "eslint": "^6.5.1",
@@ -67,13 +69,16 @@
     "eslint-plugin-jest": "^22.20.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
+    "get-port": "^5.0.0",
     "husky": "^3.0.9",
     "jest": "^24.9.0",
     "lint-staged": "^9.4.2",
     "node-typescript": "^0.1.3",
     "nodemon": "^1.19.4",
     "prettier": "^1.18.2",
-    "speccy": "^0.11.0"
+    "speccy": "^0.11.0",
+    "supertest": "^4.0.2",
+    "ts-jest": "^24.1.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "speccy": "npx speccy serve -p 8001 api/swagger.json",
     "start": "npm run prod:server",
     "test": "NODE_ENV=test docker-compose exec app npx jest --coverage --verbose",
-    "test:watch": "NODE_ENV=test docker-compose exec app npx jest --watch"
+    "test:watch": "NODE_ENV=test docker-compose exec app npx jest --watchAll"
   },
   "repository": {
     "type": "git",
@@ -90,20 +90,6 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  },
-  "jest": {
-    "watchPathIgnorePatterns": [
-      "/node_modules"
-    ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx"
-    ],
-    "testMatch": [
-      "/**/*.test.(ts|js|tsx|jsx)"
-    ]
   },
   "prettier": {
     "trailingComma": "all",

--- a/server/routers/tests/exampleRouter.test.ts
+++ b/server/routers/tests/exampleRouter.test.ts
@@ -1,0 +1,73 @@
+import App from 'server/testUtils/App';
+import exampleRouter from 'server/routers/exampleRouter';
+
+describe('router: sampleRouter', () => {
+  const app = new App();
+
+  beforeAll(async () => {
+    await app.initialize({ withRouter: exampleRouter });
+  });
+
+  describe('/api/sample-route', () => {
+    it('returns a simple response', async () => {
+      const res = await app.request.get('/api/sample-route');
+
+      expect(res.body).toEqual({
+        message: 'Response from the server',
+        query: {},
+      });
+    });
+
+    it('returns a response with a query', async () => {
+      const res = await app.request.get('/api/sample-route?x=1');
+
+      expect(res.body).toEqual({
+        message: 'Response from the server',
+        query: {
+          x: '1',
+        },
+      });
+    });
+  });
+
+  describe('/api/sample-async', () => {
+    it('returns a simple delayed response', async () => {
+      const timerStart = Date.now();
+      const res = await app.request.get('/api/sample-async-route');
+      const timerEnd = Date.now();
+
+      expect(res.body).toEqual({
+        message: 'Delayed response from the server',
+        query: {},
+      });
+
+      expect(timerEnd - timerStart).toBeGreaterThan(3000);
+    });
+
+    it('returns a simple delayed response with query', async () => {
+      const timerStart = Date.now();
+      const res = await app.request.get('/api/sample-async-route?x=2&y=a');
+      const timerEnd = Date.now();
+
+      expect(res.body).toEqual({
+        message: 'Delayed response from the server',
+        query: {
+          x: '2',
+          y: 'a',
+        },
+      });
+
+      expect(timerEnd - timerStart).toBeGreaterThan(3000);
+    });
+  });
+
+  describe('/api/sample-errored-route', () => {
+    it('returns a 400 error', async () => {
+      await app.request.get('/api/sample-errored-route').expect(400);
+    });
+  });
+
+  afterAll(() => {
+    app.destroy();
+  });
+});

--- a/server/testUtils/App.ts
+++ b/server/testUtils/App.ts
@@ -5,9 +5,12 @@ import request from 'supertest';
 import { responseErrorHandler } from 'express-response-errors';
 import { Server } from 'http';
 
+type InitProps = {
+  withRouter?: express.Router;
+};
+
 class App {
   server: express.Application;
-  router: express.Router;
   request: request.SuperTest<request.Test>;
   _server: Server;
 
@@ -16,12 +19,12 @@ class App {
     this.server = app;
   }
 
-  async initialize() {
+  async initialize({ withRouter }: InitProps = {}) {
     this.server.use(express.json());
     this.server.use(express.static('public'));
 
-    if (this.router) {
-      this.server.use(this.router);
+    if (withRouter) {
+      this.server.use(withRouter);
     }
 
     this.server.use(responseErrorHandler);

--- a/server/testUtils/App.ts
+++ b/server/testUtils/App.ts
@@ -1,0 +1,42 @@
+import 'module-alias/register';
+import express from 'express';
+import getPort from 'get-port';
+import request from 'supertest';
+import { responseErrorHandler } from 'express-response-errors';
+import { Server } from 'http';
+
+class App {
+  server: express.Application;
+  router: express.Router;
+  request: request.SuperTest<request.Test>;
+  _server: Server;
+
+  constructor() {
+    const app = express();
+    this.server = app;
+  }
+
+  async initialize() {
+    this.server.use(express.json());
+    this.server.use(express.static('public'));
+
+    if (this.router) {
+      this.server.use(this.router);
+    }
+
+    this.server.use(responseErrorHandler);
+
+    const server = this.server.listen(
+      await getPort({ port: getPort.makeRange(9000, 10000) }),
+    );
+
+    this._server = server;
+    this.request = request(this.server);
+  }
+
+  destroy() {
+    this._server.close();
+  }
+}
+
+export default App;


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

Adds serverside testing:
* Adds custom `App` class with all the setup/takedown for tests
* Adds tests for the three routes defined in `exampleRouter.ts`
* Pulls out jest config from `package.json` into external `jest.config.js` since it was getting quite long
* Uses docker-compose for testing since we will need it once the database is integrated

I'm not sure what best practices are for this so let me know how this pattern looks and any feedback you might have.  Thanks!

WIP until the following todos are done

TODOS: 
- [ ] fix client tests
- [ ] update docs