### PR TITLE
fix(docs) - Docker installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Ensure you are installing Node 10 or greater and npm 6 or greater.
 
 ### Installing Docker
 
-Click [here](https://docs.docker.com/v17.12/install/) for the Docker installation site.  Scroll down to "Supported Platforms" and follow the instructions to download & install Docker Desktop for your operating system (or Docker CE for linux).
+Click [here](https://docs.docker.com/install/#supported-platforms) for the Docker installation site and follow the instructions to download & install Docker Desktop for your operating system (or Docker CE for linux).
 
 You can find more resources on Docker here:
 - [Docker: What and Why](https://stackoverflow.com/questions/28089344/docker-what-is-it-and-what-is-the-purpose)


### PR DESCRIPTION
The Docker Compose file format used here is version 3.7:
https://github.com/freeCodeCamp/chapter/blob/af99bb496dea8e5699c68f1bf03796851bdadc16/docker-compose.yml#L1

[This requires version 18.06.0+ of Docker Engine](https://docs.docker.com/compose/compose-file/#compose-and-docker-compatibility-matrix).

However, the installation instructions link to installing Docker Engine 17.12, **which is incompatible with Docker Compose file format version 3.7!**

This pull request proposes instead linking to the latest release of Docker Engine.

-----

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.