### PR TITLE
Bump actions/checkout version

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         node-version: [10.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with: 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

Proposing a quick version bump to the `actions/checkout` version used in the CI workflow - `v2` is the latest.
