### PR TITLE
Add spacing to checkboxes in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 <!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->
 
-- [] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
-- [] My pull request has a descriptive title (not a vague title like `Update README.md`).
-- [] My pull request targets the `master` branch of Chapter.
+- [ ] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
+- [ ] My pull request has a descriptive title (not a vague title like `Update README.md`).
+- [ ] My pull request targets the `master` branch of Chapter.
 
 <!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->
 


### PR DESCRIPTION
- [ ] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [ ] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [ ] My pull request targets the `master` branch of Chapter.

Proposing a quick change to the pull request template - need a space in between these brackets for them to render as checkboxes.
