### PR TITLE
fix: module-not-found error for typeorm cli

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { pathsToModuleNameMapper } = require('ts-jest/utils');
+const { compilerOptions } = require('./tsconfig');
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
@@ -6,9 +10,9 @@ module.exports = {
     '^.+\\.tsx?$': 'babel-jest',
   },
   moduleDirectories: ['node_modules', 'server'],
-  moduleNameMapper: {
-    '^server/(.*)': '<rootDir>/server/$1',
-  },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: '<rootDir>/',
+  }),
   globals: {
     'ts-jest': {
       diagnostics: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1797,6 +1797,11 @@
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
       "dev": true
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -9684,11 +9689,6 @@
         "react-lifecycles-compat": "^3.0.2"
       }
     },
-    "module-alias": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
-      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
-    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -14374,6 +14374,27 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.4.tgz",
       "integrity": "sha512-1J/vefLC+BWSo+qe8OnJQfWTYRS6ingxjwqmHMqaMxXMj7kFtKLgAaYW3JeX3mktjgUL+etlU8/B4VUAUI9QGw=="
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
+      }
     },
     "tslib": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
     "doc": "docs"
   },
   "scripts": {
-    "dev:server": "ts-node --files  --transpile-only --project ./tsconfig.server.json ./server/index.ts",
+    "dev:server": "ts-node --files  --transpile-only --project ./tsconfig.server.json -r tsconfig-paths/register ./server/index.ts",
     "dev": "cross-env TSC_WATCHFILE=UseFsEventsWithFallbackDynamicPolling npx nodemon --watch 'server/**/*.ts' --exec 'npm run dev:server'",
     "lint": "eslint './**/*.{ts,tsx,js,jsx}'",
     "lint:fix": "eslint './**/*.{ts,tsx,js,jsx}' --fix",
     "next:build": "next build",
     "nodemon": "npx nodemon",
-    "typeorm": "ts-node -P tsconfig.server.json node_modules/typeorm/cli.js",
+    "typeorm": "ts-node -P tsconfig.server.json -r tsconfig-paths/register node_modules/typeorm/cli.js",
     "pretty": "prettier --write client/**/*.ts* server/**/*.ts",
-    "prod:server": "NODE_ENV=production ts-node --files --transpile-only ./server/index.ts",
-    "seed": "ts-node -P tsconfig.server.json ./node_modules/typeorm-seeding/dist/cli.js seed --config ormconfig.json",
+    "prod:server": "NODE_ENV=production ts-node --files --transpile-only -r tsconfig-paths/register ./server/index.ts",
+    "seed": "ts-node -P tsconfig.server.json -r tsconfig-paths/register ./node_modules/typeorm-seeding/dist/cli.js seed --config ormconfig.json",
     "speccy:watch": "npx nodemon --watch 'api/swagger.json' --exec 'npm run speccy'",
     "speccy": "npx speccy serve -p 8001 api/swagger.json",
     "start": "npm run prod:server",
@@ -51,7 +51,6 @@
     "express-response-errors": "^1.0.4",
     "fork-ts-checker-webpack-plugin": "^1.5.1",
     "immer": "^3.2.0",
-    "module-alias": "^2.2.2",
     "morgan": "^1.9.1",
     "next": "^9.1.1",
     "nodemailer": "^6.3.1",
@@ -66,6 +65,7 @@
     "reflect-metadata": "^0.1.13",
     "styled-components": "^4.4.0",
     "ts-node": "^8.4.1",
+    "tsconfig-paths": "^3.9.0",
     "typeorm": "^0.2.20",
     "typescript": "^3.7.4"
   },
@@ -126,10 +126,6 @@
   "prettier": {
     "trailingComma": "all",
     "singleQuote": true
-  },
-  "_moduleAliases": {
-    "server": "server",
-    "client": "client"
   },
   "engines": {
     "node": "10.x",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,4 @@
 import dotenv from 'dotenv';
-import 'module-alias/register';
 import express from 'express';
 import morgan from 'morgan';
 import { responseErrorHandler } from 'express-response-errors';

--- a/server/testUtils/App.ts
+++ b/server/testUtils/App.ts
@@ -1,4 +1,3 @@
-import 'module-alias/register';
 import express from 'express';
 import getPort from 'get-port';
 import request from 'supertest';


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

# Details 
<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
I have been facing this issue due to module-alias lib used for typescript project. This lib doesn't work properly with ts-node and typeorm cli. Issue was raised in TypeORM - here https://github.com/typeorm/typeorm/issues/3645

`tsconfig-paths` solves this issue, by directly aliasing modules from `tsconfig.json`. This relieves us from  maintaining aliases in multiple places (_`package.json` was keeping a duplicate alias map_).

Also, jest doesn't need configuration for aliases anymore, as I have updated `jest.config.js` to get aliases automatically, as mentioned [here](https://github.com/dividab/tsconfig-paths/issues/97)