### PR TITLE
Use wrapper components for material UI form elements

### DIFF
--- a/client/components/AddSponsor.tsx
+++ b/client/components/AddSponsor.tsx
@@ -39,8 +39,6 @@ const AddSponsor: React.FC = () => {
     try {
       // await dispatch(sponsorActions.submit(eventId, chapterId));
       setResponseMsg(`${data.name} has been added as a ${data.type} sponsor.`);
-
-      console.log(data);
     } catch (e) {
       setResponseMsg('Uh oh, something went wrong.');
       // TODO: more descriptive error messages

--- a/client/components/AddSponsor.tsx
+++ b/client/components/AddSponsor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import useForm from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 
 import {
   Button,
@@ -29,7 +29,7 @@ const AddSponsor: React.FC = () => {
   const [responseMsg, setResponseMsg] = useState('');
   const styles = useStyles();
 
-  const { register, handleSubmit } = useForm();
+  const { control, handleSubmit } = useForm();
 
   // TODO: Get data from store
   // const eventId = useSelector(state => state.selectedChapter.eventId);
@@ -39,6 +39,8 @@ const AddSponsor: React.FC = () => {
     try {
       // await dispatch(sponsorActions.submit(eventId, chapterId));
       setResponseMsg(`${data.name} has been added as a ${data.type} sponsor.`);
+
+      console.log(data);
     } catch (e) {
       setResponseMsg('Uh oh, something went wrong.');
       // TODO: more descriptive error messages
@@ -50,32 +52,50 @@ const AddSponsor: React.FC = () => {
       {responseMsg && <div className={styles.responseDiv}>{responseMsg}</div>}
       <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
         <FormControl className={styles.item}>
-          <TextField
-            label="Sponsor Name"
+          <Controller
+            control={control}
+            as={
+              <TextField
+                name="name"
+                type="text"
+                label="Sponsor Name"
+                placeholder="Glitter and Sparkle Co"
+              />
+            }
             name="name"
-            type="text"
-            placeholder="Glitter and Sparkle Co"
-            ref={register}
-            required
+            options={{ required: true }}
           />
         </FormControl>
         <FormControl className={styles.item}>
-          <TextField
-            label="Sponsor Website"
+          <Controller
+            control={control}
+            as={
+              <TextField
+                label="Sponsor Website"
+                name="website"
+                type="text"
+                placeholder="www.glitter.co"
+              />
+            }
             name="website"
-            type="text"
-            placeholder="www.glitter.co"
-            ref={register}
-            required
+            options={{ required: true }}
           />
         </FormControl>
         <FormControl className={styles.item}>
           <InputLabel id="sponsor-type-label">Sponsor Type</InputLabel>
-          <Select labelId="sponsor-type-label" ref={register} required>
-            <MenuItem value={'FOOD'}>Food</MenuItem>
-            <MenuItem value={'BEVERAGE'}>Beverage</MenuItem>
-            <MenuItem value={'OTHER'}>Other</MenuItem>
-          </Select>
+          <Controller
+            control={control}
+            as={
+              <Select labelId="sponsor-type-label">
+                <MenuItem value={'FOOD'}>Food</MenuItem>
+                <MenuItem value={'BEVERAGE'}>Beverage</MenuItem>
+                <MenuItem value={'OTHER'}>Other</MenuItem>
+              </Select>
+            }
+            name="type"
+            defaultValue={'OTHER'}
+            options={{ required: true }}
+          />
         </FormControl>
         <Button
           className={styles.item}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12007,9 +12007,9 @@
       "integrity": "sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q=="
     },
     "react-hook-form": {
-      "version": "3.28.13",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-3.28.13.tgz",
-      "integrity": "sha512-9FZ1j6dsEcd2QgT5rXGVvbwm0y4tQCUVuEsxPpSU58d9mOrkSO8EXDk0bQCh2y2i9qaDkkxgPQh6KX24fqmJMQ=="
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-4.9.3.tgz",
+      "integrity": "sha512-TPjOl5Hyq1O8VFBxxz9lnbuP/KreJD07GRUI2G8K/JnWy0pln/QaZ/p1fsnJ+8BAwQQB2fhEXSR5XrX2mxYBtw=="
     },
     "react-hot-loader": {
       "version": "4.12.15",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "pg-hstore": "^2.3.3",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
-    "react-hook-form": "^3.28.1",
+    "react-hook-form": "^4.9.3",
     "react-redux": "^7.1.0",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",


### PR DESCRIPTION
So I accidentally broke the form on AddSponsor when I added MaterialUI, the problem is that `react-hook-form` doesn't store date but read live inputs there was a problem with MaterialUI

[More info](https://stackoverflow.com/a/59005842)