### PR TITLE
Add the owner role and vocabulary tweaks to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 After several years of being dissatisfied with existing group event tools (Meetup, Facebook events) we decided to build our own.
 
-This will be a self-hosted Docker container that you can one-click deploy to the cloud, then configure through an admin panel. No coding required.
+This will be a self-hosted Docker container deployed to the cloud with a one-click and then configured by the _owner_. No coding required.
 
-Your organization can host an instance of _Chapter_ under a sub-domain of your website, such as `chapter.sierraclub.org` or `chapter.womenwhocode.org`.
+Your organization can host an _instance_ of _Chapter_ under a sub-domain of your website, such as `chapter.sierraclub.org` or `chapter.womenwhocode.org`.
 
-You can use your own authentication tools. And all your user data will stay on your own server.
+All of an _organization_'s user data will remain under their control.
 
-Our [Vision statement](https://github.com/freeCodeCamp/chapter/wiki/Vision) provides more details on the reasons for  _Chapter_.
+Our [Vision statement](https://github.com/freeCodeCamp/chapter/wiki/Vision) provides more details on the reasons for _Chapter_.
 
 ## Terminology
 To better communicate and more easily build an API and UI, the current contributors have decided on a collection of terminology to clarify discussions surrounding the Chapter project:
@@ -22,8 +22,9 @@ To better communicate and more easily build an API and UI, the current contribut
 | _event_ | a meeting with a specific location and time to which _users_ can RSVP | Coffee And Code - BistroOne, New York City, NY - April 9, 2020 |
 | _user_ | an authenticated _user_ who is authorized based on their _role(s)_ | Sally Gold - SallyG@example.com |
 | _visitor_ | an non-authenticated web browser session with view-only access to public content | Anonymous Web Browser Client |
-| _administrator_ | the _role_ of a _user_ to manage the entire ["Chapter" application](https://github.com/freeCodeCamp/chapter/) _instance_ for an _organization_ | Women Who Code - Global Chapter Administrator |
-| _organizer_ | the _role_ of a _user_ who can manage a _chapter's_ _events_, RSVPs, communications, and _users_ | Women Who Code - New York City, Local Organizer |
+| _owner_ | the _role_ of a _user_ who can configure the ["Chapter" application](https://github.com/freeCodeCamp/chapter/) _instance_ and manage _administrator_s for an entire _organization_ | Women Who Code - Global IT |
+| _administrator_ | the _role_ of a _user_ who can setup and manage _chapter_s and _organizer_s for an _organization_ | Women Who Code - National Administrator |
+| _organizer_ | the _role_ of a _user_ who can manage a _chapter's_ _events_, RSVPs, communications, and _members_ | Women Who Code - New York City, Local Organizer |
 | _member_ | the _role_ of a _user_ who can follow and receive notifications from a _chapter_ and RSVP to _events_  | Women Who Code - New York City, Local Member |
 
 ## Tech Stack
@@ -43,7 +44,7 @@ We are planning to use the following tools:
 
 A lot of people know these tools, and they're proven to work well at scale.
 
-We will focus on building an open API first. Then developers can use the API to build their own mobile clients and voice interface clients.
+We will focus on building an open API first. Then, developers can use the API to build their own mobile clients and voice interface clients.
 
 ## Development Setup
 
@@ -162,7 +163,7 @@ Here's an out-dated example of an app with similar functionality: [The freeCodeC
 
 ## Contributing
 
-* You should [join our Discord server](https://discord.gg/PXqYtEh) to get connected with people interested in this project and to be aware of our future announcements.
+* You should [join our Discord server](https://discord.gg/PXqYtEh) to get connected and follow announcements.
 * Please read the [**suggested steps to contribute code to the Chapter project**](CONTRIBUTING.md) before creating issues, forking, or submitting any pull requests.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ After several years of being dissatisfied with existing group event tools (Meetu
 
 This will be a self-hosted Docker container deployed to the cloud with a one-click and then configured by the _owner_. No coding required.
 
-Your organization can host an _instance_ of _Chapter_ under a sub-domain of your website, such as `chapter.sierraclub.org` or `chapter.womenwhocode.org`.
+Your _organization_ can host an _instance_ of _Chapter_ under a sub-domain of your website, such as `chapter.sierraclub.org` or `chapter.womenwhocode.org`.
 
 All of an _organization_'s user data will remain under their control.
 
@@ -22,10 +22,10 @@ To better communicate and more easily build an API and UI, the current contribut
 | _event_ | a meeting with a specific location and time to which _users_ can RSVP | Coffee And Code - BistroOne, New York City, NY - April 9, 2020 |
 | _user_ | an authenticated _user_ who is authorized based on their _role(s)_ | Sally Gold - SallyG@example.com |
 | _visitor_ | an non-authenticated web browser session with view-only access to public content | Anonymous Web Browser Client |
-| _owner_ | the _role_ of a _user_ who can configure the ["Chapter" application](https://github.com/freeCodeCamp/chapter/) _instance_ and manage _administrator_s for an entire _organization_ | Women Who Code - Global IT |
-| _administrator_ | the _role_ of a _user_ who can setup and manage _chapter_s and _organizer_s for an _organization_ | Women Who Code - National Administrator |
-| _organizer_ | the _role_ of a _user_ who can manage a _chapter's_ _events_, RSVPs, communications, and _members_ | Women Who Code - New York City, Local Organizer |
-| _member_ | the _role_ of a _user_ who can follow and receive notifications from a _chapter_ and RSVP to _events_  | Women Who Code - New York City, Local Member |
+| _owner_ | the _role_ of a _user_ who can configure the ["Chapter" application](https://github.com/freeCodeCamp/chapter/) _instance_ and manage _administrators_ for an entire _organization_ | Women Who Code - Global IT |
+| _administrator_ | the _role_ of a _user_ who can setup and manage _chapters_ and _organizers_ for an _organization_ | Women Who Code - European Administrator |
+| _organizer_ | the _role_ of a _user_ who can manage a _chapter's_ _events_, RSVPs, communications, and _members_ | Women Who Code - Edinburgh, Local Organizer |
+| _member_ | the _role_ of a _user_ who can follow and receive notifications from a _chapter_ and RSVP to _events_  | Women Who Code - Edinburgh, Local Member |
 
 ## Tech Stack
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

Documentation. Closes nothing.

The _owner_ role was added via https://github.com/freeCodeCamp/chapter/issues/296

The README was updated to differentiate the _owner_ from the _administrator_. 

Other minor tweaks and examples were updated.