### PR TITLE
Add UI / UX section and helpful links to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Quincy Larson is the project lead. [FreeCodeCamp](https://www.freecodecamp.org) 
 
 Here's an out-dated example of an app with similar functionality: [The freeCodeCamp Study Group Directory](https://study-group-directory.freecodecamp.org).
 
+## UI / UX / Design References
+- [Prototype](https://www.figma.com/proto/q7DikyL3N0c4CUWxHNa97i/Chapter-Prototype?node-id=1%3A2&scaling=scale-down)
+- [User Role Workflows](https://www.figma.com/file/ehgBfxoLKrlSZH0uftD6dA/Chapter-Trial?node-id=0%3A1)
+- [UI / UX Issues](https://github.com/freeCodeCamp/chapter/issues?q=is%3Aopen+is%3Aissue+label%3AUI%2FUX)
 
 ## Contributing
 


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

Closes: Nothing

The README does not provide much direction or reference for UI / UX so this adds a heading and links to the two main Figma assets and the open UI / UX Github issues.

Quincy suggested adding as a Wiki page, but I think having these links upfront in the README will help the more visual people connect with the direction of the project.

We can build out a full Wiki page or .md file for the front-end if/as there's more than a few links of info.