### PR TITLE
Mock search bar with Material UI. refs #349

### DIFF
--- a/client/src/components/PageLayout/Header.tsx
+++ b/client/src/components/PageLayout/Header.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import Link from 'next/link';
 import { makeStyles, Grid } from '@material-ui/core';
+import InputBase from '@material-ui/core/InputBase';
+import SearchIcon from '@material-ui/icons/Search';
 
 import { headerLinks } from '../../constants/Header';
+import theme from '../../styles/theme';
 
 const useStyles = makeStyles({
   link: {
@@ -11,6 +14,31 @@ const useStyles = makeStyles({
   },
   cursorPointer: {
     cursor: 'pointer',
+  },
+  // c.f. https://material-ui.com/components/app-bar/#app-bar-with-search-field
+  inputInput: {
+    width: '100%',
+    color: theme.palette.secondary.main,
+  },
+  inputRoot: {
+    color: 'inherit',
+    width: '90%',
+    fontSize: '0.83rem',
+  },
+  search: {
+    position: 'relative',
+    width: '100%',
+    backgroundColor: theme.palette.background.default,
+    margin: '0.5rem 0',
+  },
+  searchIcon: {
+    height: '100%',
+    color: theme.palette.secondary.main,
+    position: 'absolute',
+    pointerEvents: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });
 
@@ -24,9 +52,6 @@ const Header: React.FC<{ classes: Record<string, any> }> = ({ classes }) => {
       component="header"
       alignItems="center"
     >
-      <Grid item xs={12} md={4}>
-        Search Bar here
-      </Grid>
       <Link href="/">
         <Grid
           item
@@ -38,6 +63,21 @@ const Header: React.FC<{ classes: Record<string, any> }> = ({ classes }) => {
           md={4}
         />
       </Link>
+      <Grid item xs={12} md={4}>
+        <div className={styles.search}>
+          <div className={styles.searchIcon}>
+            <SearchIcon />
+          </div>
+          <InputBase
+            placeholder="Enter your city, state or country to search for events"
+            classes={{
+              root: styles.inputRoot,
+              input: styles.inputInput,
+            }}
+            inputProps={{ 'aria-label': 'search' }}
+          />
+        </div>
+      </Grid>
       <Grid component="nav" item xs={12} md={4}>
         <Grid container direction="row" spacing={2} justify="center">
           {headerLinks.map(headerLink => (


### PR DESCRIPTION
This will require a call to `makeStyles()` in the future.
Also, the logo is too large when compared to the Prototype.
The spacing could be improved, if the placeholder text would be
shorter.
I'd suggest to apply a Floating Label pattern in the future for
accessibility and UX reasons:
https://csslayout.io/patterns/floating-label

My React + Material UI knowledge isn't strong enough yet to do so
on my own.

Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #XXXXX

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

See above. I mainly oriented myself on [the prototype](https://www.figma.com/proto/q7DikyL3N0c4CUWxHNa97i/Chapter-Prototype?node-id=1%3A2&scaling=scale-down), but the UI lacks backend functionality.

Since I found other links ending in a 404, I think, it should be „good enough” for now.
A next iteration could be the creation of a search result page, which shows no results yet.
Then, the search bar could be made a form, which redirects to the search results page. The latter should show the search term then.
At that point, the actual backend API call could be made.

What do you think?