### PR TITLE
Feat(api, client): update events

### DIFF
--- a/client/src/generated/index.tsx
+++ b/client/src/generated/index.tsx
@@ -405,6 +405,26 @@ export type CreateEventMutation = { __typename?: 'Mutation' } & {
     };
 };
 
+export type UpdateEventMutationVariables = Exact<{
+  id: Scalars['Int'];
+  data: UpdateEventInputs;
+}>;
+
+export type UpdateEventMutation = { __typename?: 'Mutation' } & {
+  updateEvent: { __typename?: 'Event' } & Pick<
+    Event,
+    | 'id'
+    | 'name'
+    | 'canceled'
+    | 'description'
+    | 'url'
+    | 'video_url'
+    | 'capacity'
+  > & {
+      tags?: Maybe<Array<{ __typename?: 'Tag' } & Pick<Tag, 'id' | 'name'>>>;
+    };
+};
+
 export type CancelEventMutationVariables = Exact<{
   id: Scalars['Int'];
 }>;
@@ -783,6 +803,67 @@ export type CreateEventMutationResult = ApolloReactCommon.MutationResult<
 export type CreateEventMutationOptions = ApolloReactCommon.BaseMutationOptions<
   CreateEventMutation,
   CreateEventMutationVariables
+>;
+export const UpdateEventDocument = gql`
+  mutation updateEvent($id: Int!, $data: UpdateEventInputs!) {
+    updateEvent(id: $id, data: $data) {
+      id
+      name
+      canceled
+      description
+      url
+      video_url
+      capacity
+      tags {
+        id
+        name
+      }
+    }
+  }
+`;
+export type UpdateEventMutationFn = ApolloReactCommon.MutationFunction<
+  UpdateEventMutation,
+  UpdateEventMutationVariables
+>;
+
+/**
+ * __useUpdateEventMutation__
+ *
+ * To run a mutation, you first call `useUpdateEventMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateEventMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateEventMutation, { data, loading, error }] = useUpdateEventMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useUpdateEventMutation(
+  baseOptions?: ApolloReactHooks.MutationHookOptions<
+    UpdateEventMutation,
+    UpdateEventMutationVariables
+  >,
+) {
+  return ApolloReactHooks.useMutation<
+    UpdateEventMutation,
+    UpdateEventMutationVariables
+  >(UpdateEventDocument, baseOptions);
+}
+export type UpdateEventMutationHookResult = ReturnType<
+  typeof useUpdateEventMutation
+>;
+export type UpdateEventMutationResult = ApolloReactCommon.MutationResult<
+  UpdateEventMutation
+>;
+export type UpdateEventMutationOptions = ApolloReactCommon.BaseMutationOptions<
+  UpdateEventMutation,
+  UpdateEventMutationVariables
 >;
 export const CancelEventDocument = gql`
   mutation cancelEvent($id: Int!) {

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -100,6 +100,24 @@ export const createEvent = gql`
   }
 `;
 
+export const updateEvent = gql`
+  mutation updateEvent($id: Int!, $data: UpdateEventInputs!) {
+    updateEvent(id: $id, data: $data) {
+      id
+      name
+      canceled
+      description
+      url
+      video_url
+      capacity
+      tags {
+        id
+        name
+      }
+    }
+  }
+`;
+
 export const cancelEvent = gql`
   mutation cancelEvent($id: Int!) {
     cancelEvent(id: $id) {

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -41,7 +41,7 @@ export const EditEventPage: NextPage = () => {
       });
 
       if (event.data) {
-        await router.replace('/dashboard/events');
+        await router.push('/dashboard/events');
       }
     } catch (err) {
       console.error(err);

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -6,55 +6,47 @@ import { IEventFormData } from '../components/EventFormUtils';
 import Layout from '../../shared/components/Layout';
 import Skeleton from '../../Venues/components/Skeleton';
 import EventForm from '../components/EventForm';
-import { useCreateEventMutation, useEventQuery } from '../../../../generated';
+import { useEventQuery, useUpdateEventMutation } from '../../../../generated';
 import { EVENTS } from '../graphql/queries';
 import { getId } from '../../../../helpers/getId';
 
 export const EditEventPage: NextPage = () => {
   const router = useRouter();
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loadingUpdate, setLoadingUpdate] = useState<boolean>(false);
   const id = getId(router.query) || -1;
 
   const { loading: eventLoading, error, data } = useEventQuery({
     variables: { id },
   });
 
-  const [createEvent] = useCreateEventMutation({
+  const [updateEvent] = useUpdateEventMutation({
     refetchQueries: [{ query: EVENTS }],
   });
 
   const onSubmit = async (data: IEventFormData) => {
     // TODO: load chapter from url or something like that
-    setLoading(true);
+    setLoadingUpdate(true);
 
     try {
-      const HARD_CODE = { chapterId: 1 };
-
-      console.log(data.start_at);
-
       const eventData = {
         ...data,
         capacity: parseInt(String(data.capacity)),
         start_at: new Date(data.start_at).toISOString(),
         ends_at: new Date(data.ends_at).toISOString(),
-        ...HARD_CODE,
         tags: undefined,
       };
 
-      const event = await createEvent({
-        variables: { data: { ...eventData } },
+      const event = await updateEvent({
+        variables: { id, data: { ...eventData } },
       });
 
       if (event.data) {
-        router.replace(
-          `/dashboard/events/[id]`,
-          `/dashboard/events/${event.data.createEvent.id}`,
-        );
+        await router.replace('/dashboard/events');
       }
     } catch (err) {
       console.error(err);
     } finally {
-      setLoading(false);
+      setLoadingUpdate(false);
     }
   };
 
@@ -62,7 +54,7 @@ export const EditEventPage: NextPage = () => {
     return (
       <Layout>
         <Skeleton>
-          <h1>{loading ? 'Loading...' : 'Error...'}</h1>
+          <h1>{loadingUpdate ? 'Loading...' : 'Error...'}</h1>
           {error && <div>{error}</div>}
         </Skeleton>
       </Layout>
@@ -78,7 +70,7 @@ export const EditEventPage: NextPage = () => {
             venueId: data.event.venue.id,
             tags: data.event.tags || [],
           }}
-          loading={loading}
+          loading={loadingUpdate}
           onSubmit={onSubmit}
           submitText={'Update event'}
         />

--- a/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
@@ -37,7 +37,7 @@ export const EditVenuePage: NextPage = () => {
       await updateVenue({
         variables: { id, data: { ...data, latitude, longitude } },
       });
-      router.replace('/dashboard/venues');
+      await router.replace('/dashboard/venues');
     } catch (err) {
       console.error(err);
     } finally {

--- a/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
@@ -37,7 +37,7 @@ export const EditVenuePage: NextPage = () => {
       await updateVenue({
         variables: { id, data: { ...data, latitude, longitude } },
       });
-      await router.replace('/dashboard/venues');
+      await router.push('/dashboard/venues');
     } catch (err) {
       console.error(err);
     } finally {


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #425

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
Wrote an update event query, updated the client to use the update event query instead of the create event query on the editEventPage.

Note: I thought this was a bug when I filed the original issue, but it turned out the functionality just hadn't yet been built