### PR TITLE
fix(build): npm install failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2972,9 +2972,9 @@
       }
     },
     "@types/node": {
-      "version": "13.13.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.25.tgz",
-      "integrity": "sha512-6ZMK4xRcF2XrPdKmPYQxZkdHKV18xKgUFVvhIgw2iwaaO6weleLPHLBGPZmLhjo+m1N+MZXRAoBEBCCVqgO2zQ==",
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@types/jest": "^25.1.4",
     "@types/morgan": "^1.7.37",
     "@types/next": "^8.0.6",
-    "@types/node": "^14.15.0",
+    "@types/node": "^14.14.6",
     "@types/nodemailer": "^6.2.2",
     "@types/pg": "^7.14.5",
     "@types/react": "^16.9.9",


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->
<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
@dtwilliams10 on Discord informed us about a error on `npx resursive-install`. The issue was with @types/node package being versioned wrongly in package.json. It has been fixed with this PR. 