### PR TITLE
fix: remove unused className props

### DIFF
--- a/client/src/modules/dashboard/Events/pages/EventsPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventsPage.tsx
@@ -47,7 +47,6 @@ export const EventsPage: NextPage = () => {
             <div className={styles.grid}>
               {data?.events.map(event => (
                 <EventItem
-                  className={styles.gridItem}
                   event={event}
                   loading={loading}
                   key={`events-${event.id}`}

--- a/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
@@ -46,7 +46,6 @@ export const VenuesPage: NextPage = () => {
             <div className={styles.grid}>
               {data?.venues.map(venue => (
                 <VenueItem
-                  className={styles.gridItem}
                   venue={venue}
                   loading={loading}
                   key={`venue-${venue.id}`}


### PR DESCRIPTION
npm run build:client was failing as className was not part of the
interfaces for EventItem and VenueItem, but it also wasn't used in those
components so can safely be removed.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #454

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

Edit: I should have said: it was exactly as @tomnoland pointed out in chat.