### PR TITLE
fix(tools): remove interface rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,10 +29,6 @@
   "rules": {
     "@typescript-eslint/camelcase": 0,
     "@typescript-eslint/explicit-function-return-type": 0,
-    "@typescript-eslint/interface-name-prefix": [
-      2,
-      { "prefixWithI": "always" }
-    ],
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/no-unused-vars": [
       "error",


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- X] My pull request has a descriptive title (not a vague title like `Update README.md`).
- X] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #468 

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

This PR removes the linter rule that expects interface declaration names to be prefaced with `I`. Instead, it now asserts that they are *not* prefaced with `I`. 

If we would prefer the linter not care either way, I can push a commit to disable the rule instead of removing it.