### PR TITLE
fix: Make the site/app header look more like the mockup

### DIFF
--- a/client/src/components/PageLayout/Header.tsx
+++ b/client/src/components/PageLayout/Header.tsx
@@ -4,6 +4,10 @@ import { makeStyles, Grid } from '@material-ui/core';
 
 import { headerLinks } from '../../constants/Header';
 
+import TextField from '@material-ui/core/TextField';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import Search from '@material-ui/icons/Search';
+
 const useStyles = makeStyles({
   link: {
     textDecoration: 'none',
@@ -11,6 +15,9 @@ const useStyles = makeStyles({
   },
   cursorPointer: {
     cursor: 'pointer',
+  },
+  searchBox: {
+    backgroundColor: 'white',
   },
 });
 
@@ -23,10 +30,9 @@ const Header: React.FC<{ classes: Record<string, any> }> = ({ classes }) => {
       container
       component="header"
       alignItems="center"
+      spacing={2}
+      xs={12}
     >
-      <Grid item xs={12} md={4}>
-        Search Bar here
-      </Grid>
       <Link href="/">
         <Grid
           item
@@ -38,6 +44,20 @@ const Header: React.FC<{ classes: Record<string, any> }> = ({ classes }) => {
           md={4}
         />
       </Link>
+      <Grid item xs={12} md={4}>
+        <TextField
+          fullWidth
+          className={styles.searchBox}
+          placeholder="Enter your city, state or country to search for events"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Search style={{ color: '#a0a0a0' }} />
+              </InputAdornment>
+            ),
+          }}
+        />
+      </Grid>
       <Grid component="nav" item xs={12} md={4}>
         <Grid container direction="row" spacing={2} justify="center">
           {headerLinks.map(headerLink => (

--- a/client/src/components/PageLayout/Header.tsx
+++ b/client/src/components/PageLayout/Header.tsx
@@ -31,7 +31,10 @@ const Header: React.FC<{ classes: Record<string, any> }> = ({ classes }) => {
       component="header"
       alignItems="center"
       spacing={2}
-      xs={12}
+      style={{
+        margin: 0,
+        width: '100%',
+      }}
     >
       <Link href="/">
         <Grid


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

Updated the site header to look more like the mockup [here](https://www.figma.com/proto/q7DikyL3N0c4CUWxHNa97i/Chapter-Prototype?node-id=332%3A355&scaling=scale-down).

Swapped the placeholder for the search box with the logo.  Replaced the "search" placeholder with a TextField pre-pended with a search icon. Adjusted the spacing a bit.

Relates to issue #445 and #414. Making some minor style changes to get the app looking more like the mockup for the "Golden Path".
