### PR TITLE
fix: get renovate to pin all dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,6 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true
     }
-  ]
+  ],
+  "rangeStrategy": "pin"
 }


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

PRs like https://github.com/freeCodeCamp/chapter/pull/534 should not be automerging.  This change to the config should prevent that.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
