### PR TITLE
fix: use next's Html component

### DIFF
--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ServerStyleSheets } from '@material-ui/core/styles';
-import Document, { Head, Main, NextScript } from 'next/document';
+import Document, { Head, Html, Main, NextScript } from 'next/document';
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx: any) {
@@ -26,7 +26,7 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <html lang="en">
+      <Html lang="en">
         <Head>
           <link
             rel="stylesheet"
@@ -37,7 +37,7 @@ export default class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }


### PR DESCRIPTION

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Removes the warning https://nextjs.org/docs/messages/missing-document-component

The Html component renders <html> with a few additional attributes: https://github.com/vercel/next.js/blob/15133b47ec7bfc413aa068d92fb678626cf47571/packages/next/pages/_document.tsx#L118

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
