### PR TITLE
Creates a combined npm run command called lint-and-test, per #525 con…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ You are almost ready to make changes to files, but before that you should **alwa
 
 5. Always Run Code Quality Tools 
 
-    Verify all automated code quality check will pass before submitting a pull request because PRs with failures will not be merged.
+    Verify all automated code quality checks will pass before submitting a pull request because PRs with failures will not be merged.
 
     * When using _Docker Mode_, run `NODE_ENV=test docker-compose exec app npm run lint-and-test` OR `NODE_ENV=test docker-compose exec app npm run test:watch` to start "watch" mode.
     * When using _Manual Mode_, run `npm run lint-and-test` OR `npm run test:watch` to start "watch" mode.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,11 +200,13 @@ You are almost ready to make changes to files, but before that you should **alwa
         modified:   README.md
         ...
 
-5. Test your code **Always!** 
+5. Always Run Code Quality Tools 
 
-    * If you started the application using the _Docker Mode_, then tests are run using `NODE_ENV=test docker-compose exec app npm run test` OR if you want to use the "watch" mode run `NODE_ENV=test docker-compose exec app npm run test:watch`
-    * If you started the application using the _Manual Mode_ (without Docker), then tests are run using `npm run test` OR if you want to use the "watch" mode run `npm run test:watch`
+    Verify all automated code quality check will pass before submitting a pull request because PRs with failures will not be merged.
 
+    * When using _Docker Mode_, run `NODE_ENV=test docker-compose exec app npm run lint-and-test` OR `NODE_ENV=test docker-compose exec app npm run test:watch` to start "watch" mode.
+    * When using _Manual Mode_, run `npm run lint-and-test` OR `npm run test:watch` to start "watch" mode.
+ 
 6. Stage the changes and make a commit
 
     In this step, you should only mark files that you have edited or added yourself. You can perform a reset and resolve files that you did not intend to change if needed.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:watch": "npx jest --watchAll",
     "postinstall": "node scripts/postInstall.js",
     "lint": "eslint './**/*.{ts,tsx,js,jsx}'",
+    "lint-and-test": "npm run lint && npm run test",
     "lint:fix": "eslint './**/*.{ts,tsx,js,jsx}' --fix",
     "pretty": "prettier --write client/**/*.ts* server/**/*.ts"
   },


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

Closes #525 
Closes #524 

@NorthDecoder I tried to push this into your open #525 PR, but I was following the wrong GH docs and it pushed as a new branch, which I've deleted.

@ojeytonwilliams and @NorthDecoder This PR includes a new _lint-and-test_ command to package.json.  Could you check that it looks good? It runs for me, but generates a lint error, which seems to be in issue with the lint tool and not the new command itself.

The proposed changes to CONTRIBUTING.md now reference running _lint-and-test_ for the Docker Mode and Manual Mode 