### PR TITLE
fix: make automerges push directly, not create PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchCurrentVersion": "!/^0/",
-      "automerge": true
+      "automerge": true,
+      "automergeType": "branch"
     }
   ],
   "rangeStrategy": "pin"


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Prior to this PR renovate would create PRs for all changes, including ones it would automatically merge.  Since dev input is not necessary for automerged PRs, this changes the config so that they will not be notified either.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
