### PR TITLE
FIX: moved Resolver test into common server/tests directory

### DIFF
--- a/server/tests/Resolver.test.ts
+++ b/server/tests/Resolver.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import faker from 'faker';
-import { callSchema } from '../../testUtils/callSchema';
-import longString from './longString';
+import { callSchema } from '../testUtils/callSchema';
+import longString from '../controllers/Messages/longString';
 import { ArgumentValidationError } from 'type-graphql/dist/errors/ArgumentValidationError';
 import { GraphQLError } from 'graphql';
 


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

Looking at the current tests would suggest keeping all the tests together, i.e. `server/tests` and `client/tests`.
Although it did not take me long I had to dig around to locate the random test in  `server/controllers/Messages/resolver.test.ts`.

I realize this not moving the needle for the MVP other than agreement of placing all the tests in one location.

