### PR TITLE
fix: event dashboard edit bugs

### DIFF
--- a/client/src/components/Form/TextArea.tsx
+++ b/client/src/components/Form/TextArea.tsx
@@ -1,57 +1,32 @@
 import React, { forwardRef } from 'react';
 import {
-  Input as ChakraInput,
-  InputProps as ChakraInputProps,
+  TextareaProps as ChakraTextareaProps,
   FormControl,
   FormLabel,
   FormErrorMessage,
   FormControlProps,
+  Textarea as ChakraTextarea,
 } from '@chakra-ui/react';
 
 const capitalize = (s: string) =>
   s.slice(0, 1).toUpperCase() + s.slice(1).toLowerCase();
 
-const allowed_types = [
-  'text',
-  'password',
-  'current_password',
-  'confirm_password',
-  'email',
-  'number',
-] as const;
-
-function isSpecifiedType(name: string): name is AllowedTypes {
-  return (allowed_types as any).includes(name);
-}
-
-const resoleType = (name: string) => {
-  if (isSpecifiedType(name)) {
-    if (name === 'confirm_password' || name === 'current_password') {
-      return 'password';
-    }
-
-    return name;
-  }
-
-  return 'text';
-};
+const allowed_types = ['text'] as const;
 
 type AllowedTypes = typeof allowed_types[number];
 
-export interface InputProps extends Omit<ChakraInputProps, 'type'> {
+export interface TextAreaProps extends Omit<ChakraTextareaProps, 'type'> {
   label?: string;
   noLabel?: boolean;
   error?: string;
   name?: string;
   type?: AllowedTypes | string;
   outerProps?: FormControlProps;
-
-  isTextArea?: boolean;
 }
 
-export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+export const TextArea = forwardRef<any, TextAreaProps>((props, ref) => {
   const {
-    name: baseName = 'Input Field',
+    name: baseName = 'TextArea Field',
     isInvalid,
     isRequired,
     label,
@@ -72,11 +47,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       {!noLabel && (
         <FormLabel htmlFor={baseName}>{label || capitalize(name)}</FormLabel>
       )}
-      <ChakraInput
-        type={resoleType(baseName)}
+      <ChakraTextarea
         id={baseName}
         name={baseName}
-        ref={ref}
+        ref={ref as any}
         placeholder={placeholder || label || capitalize(name)}
         {...rest}
       />

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -16,6 +16,7 @@ import {
 import useFormStyles from '../../shared/components/formStyles';
 import { useVenuesQuery } from '../../../../generated/graphql';
 import { Input } from '../../../../components/Form/Input';
+import { TextArea } from '../../../../components/Form/TextArea';
 import { VStack } from '@chakra-ui/layout';
 
 const EventForm: React.FC<EventFormProps> = (props) => {
@@ -49,17 +50,27 @@ const EventForm: React.FC<EventFormProps> = (props) => {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
       <VStack>
-        {fields.map((field) => (
-          <Input
-            key={field.key}
-            label={field.label}
-            placeholder={field.placeholder}
-            isRequired
-            isTextArea={field.type === 'textarea'}
-            {...register(field.key)}
-            defaultValue={formatValue(field, data)}
-          />
-        ))}
+        {fields.map((field) =>
+          field.type === 'textarea' ? (
+            <TextArea
+              key={field.key}
+              label={field.label}
+              placeholder={field.placeholder}
+              isRequired
+              {...register(field.key)}
+              defaultValue={formatValue(field, data)}
+            />
+          ) : (
+            <Input
+              key={field.key}
+              label={field.label}
+              placeholder={field.placeholder}
+              isRequired
+              {...register(field.key)}
+              defaultValue={formatValue(field, data)}
+            />
+          ),
+        )}
       </VStack>
 
       {loadingVenues ? (

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -26,14 +26,20 @@ const EventForm: React.FC<EventFormProps> = (props) => {
     data: dataVenues,
   } = useVenuesQuery();
 
-  const defaultValues = useMemo(
-    () => ({
-      ...(data || {}),
-      tags: (data?.tags || []).map((t) => t.name).join(', '),
-      venue: data?.venue?.id,
-    }),
-    [],
-  );
+  const defaultValues = useMemo(() => {
+    if (!data) return {};
+    return {
+      name: data.name,
+      description: data.description,
+      url: data.url,
+      video_url: data.video_url,
+      capacity: data.capacity,
+      start_at: data.start_at,
+      ends_at: data.ends_at,
+      tags: (data.tags || []).map((t) => t.name).join(', '),
+      venueId: data.venueId,
+    };
+  }, []);
 
   const { control, register, handleSubmit } = useForm<EventFormData>({
     defaultValues,


### PR DESCRIPTION
The defaultValues get merged with the new form values, so cannot include
anything that is not expected by updateEvent

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

It's a shame that `data` can be `undefined`.  It would be nice if there were two forms (one for new events and one for updating them), so we could have type safe defaultValues, but this seems reasonable for now.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
