### PR TITLE
feat: add chapters to dashboard

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -440,7 +440,14 @@ export type ChapterQuery = { __typename?: 'Query' } & {
   chapter?: Maybe<
     { __typename?: 'Chapter' } & Pick<
       Chapter,
-      'id' | 'name' | 'description'
+      | 'id'
+      | 'name'
+      | 'description'
+      | 'details'
+      | 'category'
+      | 'city'
+      | 'region'
+      | 'country'
     > & {
         events: Array<
           { __typename?: 'Event' } & Pick<
@@ -461,6 +468,29 @@ export type ChaptersQueryVariables = Exact<{ [key: string]: never }>;
 export type ChaptersQuery = { __typename?: 'Query' } & {
   chapters: Array<
     { __typename?: 'Chapter' } & Pick<Chapter, 'id' | 'name' | 'description'>
+  >;
+};
+
+export type CreateChapterMutationVariables = Exact<{
+  data: CreateChapterInputs;
+}>;
+
+export type CreateChapterMutation = { __typename?: 'Mutation' } & {
+  createChapter: { __typename?: 'Chapter' } & Pick<
+    Chapter,
+    'id' | 'name' | 'description' | 'city' | 'region' | 'country'
+  >;
+};
+
+export type UpdateChapterMutationVariables = Exact<{
+  id: Scalars['Int'];
+  data: UpdateChapterInputs;
+}>;
+
+export type UpdateChapterMutation = { __typename?: 'Mutation' } & {
+  updateChapter: { __typename?: 'Chapter' } & Pick<
+    Chapter,
+    'id' | 'name' | 'description' | 'city' | 'region' | 'country'
   >;
 };
 
@@ -916,6 +946,11 @@ export const ChapterDocument = gql`
       id
       name
       description
+      details
+      category
+      city
+      region
+      country
       events {
         id
         name
@@ -1026,6 +1061,117 @@ export type ChaptersLazyQueryHookResult = ReturnType<
 export type ChaptersQueryResult = Apollo.QueryResult<
   ChaptersQuery,
   ChaptersQueryVariables
+>;
+export const CreateChapterDocument = gql`
+  mutation createChapter($data: CreateChapterInputs!) {
+    createChapter(data: $data) {
+      id
+      name
+      description
+      city
+      region
+      country
+    }
+  }
+`;
+export type CreateChapterMutationFn = Apollo.MutationFunction<
+  CreateChapterMutation,
+  CreateChapterMutationVariables
+>;
+
+/**
+ * __useCreateChapterMutation__
+ *
+ * To run a mutation, you first call `useCreateChapterMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateChapterMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createChapterMutation, { data, loading, error }] = useCreateChapterMutation({
+ *   variables: {
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useCreateChapterMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CreateChapterMutation,
+    CreateChapterMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    CreateChapterMutation,
+    CreateChapterMutationVariables
+  >(CreateChapterDocument, options);
+}
+export type CreateChapterMutationHookResult = ReturnType<
+  typeof useCreateChapterMutation
+>;
+export type CreateChapterMutationResult =
+  Apollo.MutationResult<CreateChapterMutation>;
+export type CreateChapterMutationOptions = Apollo.BaseMutationOptions<
+  CreateChapterMutation,
+  CreateChapterMutationVariables
+>;
+export const UpdateChapterDocument = gql`
+  mutation updateChapter($id: Int!, $data: UpdateChapterInputs!) {
+    updateChapter(id: $id, data: $data) {
+      id
+      name
+      description
+      city
+      region
+      country
+    }
+  }
+`;
+export type UpdateChapterMutationFn = Apollo.MutationFunction<
+  UpdateChapterMutation,
+  UpdateChapterMutationVariables
+>;
+
+/**
+ * __useUpdateChapterMutation__
+ *
+ * To run a mutation, you first call `useUpdateChapterMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateChapterMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateChapterMutation, { data, loading, error }] = useUpdateChapterMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      data: // value for 'data'
+ *   },
+ * });
+ */
+export function useUpdateChapterMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateChapterMutation,
+    UpdateChapterMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UpdateChapterMutation,
+    UpdateChapterMutationVariables
+  >(UpdateChapterDocument, options);
+}
+export type UpdateChapterMutationHookResult = ReturnType<
+  typeof useUpdateChapterMutation
+>;
+export type UpdateChapterMutationResult =
+  Apollo.MutationResult<UpdateChapterMutation>;
+export type UpdateChapterMutationOptions = Apollo.BaseMutationOptions<
+  UpdateChapterMutation,
+  UpdateChapterMutationVariables
 >;
 export const EventsDocument = gql`
   query events {

--- a/client/src/modules/chapters/graphql/queries.ts
+++ b/client/src/modules/chapters/graphql/queries.ts
@@ -6,6 +6,11 @@ export const CHAPTER = gql`
       id
       name
       description
+      details
+      category
+      city
+      region
+      country
       events {
         id
         name

--- a/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
+++ b/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { Button, FormControl } from '@material-ui/core';
+
+import useFormStyles from '../../shared/components/formStyles';
+import type { Chapter, ChapterQuery } from '../../../../generated/graphql';
+import { Field } from '../../../../components/Form/Fields';
+
+export type ChapterFormData = Omit<
+  Chapter,
+  | 'id'
+  | 'created_at'
+  | 'updated_at'
+  | 'events'
+  | 'creator'
+  | 'users'
+  | 'banned_users'
+>;
+
+interface ChapterFormProps {
+  loading: boolean;
+  onSubmit: (data: ChapterFormData) => Promise<void>;
+  data?: ChapterQuery;
+  submitText: string;
+}
+
+type Fields =
+  | [keyof ChapterFormData, boolean, boolean]
+  | [keyof ChapterFormData, boolean]
+  | [keyof ChapterFormData];
+
+const fields: Fields[] = [
+  ['name', true],
+  ['description', true],
+  ['city', true],
+  ['region', true],
+  ['country', true],
+];
+
+const ChapterForm: React.FC<ChapterFormProps> = (props) => {
+  const { loading, onSubmit, data, submitText } = props;
+  const chapter = data?.chapter;
+  const styles = useFormStyles();
+
+  const defaultValues: ChapterFormData = {
+    name: chapter?.name ?? '',
+    description: chapter?.description ?? '',
+    city: chapter?.city ?? '',
+    region: chapter?.region ?? '',
+    country: chapter?.country ?? '',
+  };
+  const { control, handleSubmit } = useForm<ChapterFormData>({
+    defaultValues,
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+      {fields.map(([name, required, number]) => (
+        <FormControl className={styles.item} key={name}>
+          <Field
+            {...{ control, name }}
+            type={number ? 'number' : 'text'}
+            required={required}
+          />
+        </FormControl>
+      ))}
+      <Button
+        className={styles.item}
+        variant="contained"
+        color="primary"
+        type="submit"
+        disabled={loading}
+      >
+        {submitText}
+      </Button>
+    </form>
+  );
+};
+
+export default ChapterForm;

--- a/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
+++ b/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
@@ -32,9 +32,11 @@ type Fields =
 const fields: Fields[] = [
   ['name', true],
   ['description', true],
+  ['details', true],
   ['city', true],
   ['region', true],
   ['country', true],
+  ['category', true],
 ];
 
 const ChapterForm: React.FC<ChapterFormProps> = (props) => {
@@ -45,9 +47,11 @@ const ChapterForm: React.FC<ChapterFormProps> = (props) => {
   const defaultValues: ChapterFormData = {
     name: chapter?.name ?? '',
     description: chapter?.description ?? '',
+    details: chapter?.details ?? '',
     city: chapter?.city ?? '',
     region: chapter?.region ?? '',
     country: chapter?.country ?? '',
+    category: chapter?.category ?? '',
   };
   const { control, handleSubmit } = useForm<ChapterFormData>({
     defaultValues,

--- a/client/src/modules/dashboard/Chapters/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Chapters/graphql/mutations.ts
@@ -1,0 +1,27 @@
+import { gql } from '@apollo/client';
+
+export const createChapter = gql`
+  mutation createChapter($data: CreateChapterInputs!) {
+    createChapter(data: $data) {
+      id
+      name
+      description
+      city
+      region
+      country
+    }
+  }
+`;
+
+export const updateChapter = gql`
+  mutation updateChapter($id: Int!, $data: UpdateChapterInputs!) {
+    updateChapter(id: $id, data: $data) {
+      id
+      name
+      description
+      city
+      region
+      country
+    }
+  }
+`;

--- a/client/src/modules/dashboard/Chapters/index.ts
+++ b/client/src/modules/dashboard/Chapters/index.ts
@@ -1,0 +1,4 @@
+export { ChapterPage } from './pages/ChapterPage';
+export { ChaptersPage } from './pages/ChaptersPage';
+export { NewChapterPage } from './pages/NewChapterPage';
+export { EditChapterPage } from './pages/EditChapterPage';

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { NextPage } from 'next';
+import { makeStyles, Card, Typography } from '@material-ui/core';
+import { useRouter } from 'next/router';
+
+import { Layout } from '../../shared/components/Layout';
+import { useChapterQuery } from '../../../../generated/graphql';
+import { getId } from '../../../../helpers/getId';
+import { ProgressCardContent } from '../../../../components';
+
+const useStyles = makeStyles(() => ({
+  responseDiv: {
+    margin: '15px 0',
+  },
+}));
+
+export const ChapterPage: NextPage = () => {
+  const styles = useStyles();
+  const router = useRouter();
+  const id = getId(router.query) || -1;
+
+  const { loading, error, data } = useChapterQuery({ variables: { id } });
+
+  if (loading || error || !data?.chapter) {
+    return (
+      <Layout>
+        <h1>{loading ? 'Loading...' : 'Error...'}</h1>
+        {error && <div className={styles.responseDiv}>{error}</div>}
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <Card style={{ marginTop: '12px' }}>
+        <ProgressCardContent>
+          <Typography gutterBottom variant="h5" component="h2">
+            {data.chapter.name}
+          </Typography>
+        </ProgressCardContent>
+      </Card>
+      <h3>Placeholder for events...</h3>
+    </Layout>
+  );
+};

--- a/client/src/modules/dashboard/Chapters/pages/ChaptersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChaptersPage.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { NextPage } from 'next';
+
+import { useChaptersQuery } from '../../../../generated/graphql';
+import { Layout } from '../../shared/components/Layout';
+import { VStack, Flex, Text, Heading } from '@chakra-ui/react';
+import { DataTable } from 'chakra-data-table';
+import { LinkButton } from 'chakra-next-link';
+
+export const ChaptersPage: NextPage = () => {
+  const { loading, error, data } = useChaptersQuery();
+
+  return (
+    <Layout>
+      <VStack>
+        <Flex w="full" justify="space-between">
+          <Heading>Chapters</Heading>
+          <LinkButton href="/dashboard/chapters/new">Add new</LinkButton>
+        </Flex>
+        {loading ? (
+          <Heading>Loading...</Heading>
+        ) : error || !data?.chapters ? (
+          <>
+            <Heading>Error</Heading>
+            <Text>
+              {error?.name}: {error?.message}
+            </Text>
+          </>
+        ) : (
+          <DataTable
+            data={data.chapters}
+            keys={['name', 'actions'] as const}
+            mapper={{
+              name: (chapter) => (
+                <LinkButton href={`/dashboard/chapters/${chapter.id}`}>
+                  {chapter.name}
+                </LinkButton>
+              ),
+              actions: (chapter) => (
+                <LinkButton
+                  colorScheme="green"
+                  size="xs"
+                  href={`/dashboard/chapters/${chapter.id}/edit`}
+                >
+                  Edit
+                </LinkButton>
+              ),
+            }}
+          />
+        )}
+      </VStack>
+    </Layout>
+  );
+};

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../generated/graphql';
 import { getId } from '../../../../helpers/getId';
 import { makeStyles } from '@material-ui/core';
-import { CHAPTERS } from '../graphql/queries';
+import { CHAPTERS } from '../../../chapters/graphql/queries';
 
 const useStyles = makeStyles(() => ({
   responseDiv: {

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { NextPage } from 'next';
+
+import { Layout } from '../../shared/components/Layout';
+import ChapterForm, { ChapterFormData } from '../components/ChapterForm';
+import { useRouter } from 'next/router';
+import {
+  useChapterQuery,
+  useUpdateChapterMutation,
+} from '../../../../generated/graphql';
+import { getId } from '../../../../helpers/getId';
+import { makeStyles } from '@material-ui/core';
+import { CHAPTERS } from '../graphql/queries';
+
+const useStyles = makeStyles(() => ({
+  responseDiv: {
+    margin: '15px 0',
+  },
+}));
+
+export const EditChapterPage: NextPage = () => {
+  const [loadingUpdate, setLoadingUpdate] = useState(false);
+
+  const styles = useStyles();
+  const router = useRouter();
+  const id = getId(router.query) || -1;
+
+  const { loading, error, data } = useChapterQuery({ variables: { id } });
+  const [updateChapter] = useUpdateChapterMutation({
+    refetchQueries: [{ query: CHAPTERS }],
+  });
+
+  const onSubmit = async (data: ChapterFormData) => {
+    setLoadingUpdate(true);
+    try {
+      await updateChapter({
+        variables: { id, data: { ...data } },
+      });
+      await router.push('/dashboard/chapters');
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoadingUpdate(false);
+    }
+  };
+
+  if (loading || error || !data?.chapter) {
+    return (
+      <Layout>
+        <h1>{loading ? 'Loading...' : 'Error...'}</h1>
+        {error && <div className={styles.responseDiv}>{error}</div>}
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <ChapterForm
+        data={data}
+        loading={loadingUpdate}
+        onSubmit={onSubmit}
+        submitText={'Update chapter'}
+      />
+    </Layout>
+  );
+};

--- a/client/src/modules/dashboard/Chapters/pages/NewChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/NewChapterPage.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { NextPage } from 'next';
+
+import { Layout } from '../../shared/components/Layout';
+import ChapterForm, { ChapterFormData } from '../components/ChapterForm';
+import { useRouter } from 'next/router';
+import { useCreateChapterMutation } from '../../../../generated/graphql';
+import { CHAPTERS } from '../graphql/queries';
+
+export const NewChapterPage: NextPage = () => {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const [createChapter] = useCreateChapterMutation({
+    refetchQueries: [{ query: CHAPTERS }],
+  });
+
+  const onSubmit = async (data: ChapterFormData) => {
+    setLoading(true);
+    try {
+      await createChapter({
+        variables: { data: { ...data } },
+      });
+      router.replace('/dashboard/chapters');
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Layout>
+      <ChapterForm
+        loading={loading}
+        onSubmit={onSubmit}
+        submitText={'Add chapter'}
+      />
+    </Layout>
+  );
+};

--- a/client/src/modules/dashboard/Chapters/pages/NewChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/NewChapterPage.tsx
@@ -5,7 +5,7 @@ import { Layout } from '../../shared/components/Layout';
 import ChapterForm, { ChapterFormData } from '../components/ChapterForm';
 import { useRouter } from 'next/router';
 import { useCreateChapterMutation } from '../../../../generated/graphql';
-import { CHAPTERS } from '../graphql/queries';
+import { CHAPTERS } from '../../../chapters/graphql/queries';
 
 export const NewChapterPage: NextPage = () => {
   const [loading, setLoading] = useState(false);

--- a/client/src/modules/dashboard/Venues/components/VenueForm.tsx
+++ b/client/src/modules/dashboard/Venues/components/VenueForm.tsx
@@ -42,15 +42,21 @@ const fields: Fields[] = [
 
 const VenueForm: React.FC<VenueFormProps> = (props) => {
   const { loading, onSubmit, data, submitText } = props;
-
+  const venue = data?.venue;
   const styles = useFormStyles();
+
+  const defaultValues: VenueFormData = {
+    name: venue?.name ?? '',
+    street_address: venue?.street_address ?? undefined,
+    city: venue?.city ?? '',
+    postal_code: venue?.postal_code ?? '',
+    region: venue?.region ?? '',
+    country: venue?.country ?? '',
+    latitude: venue?.latitude ?? undefined,
+    longitude: venue?.longitude ?? undefined,
+  };
   const { control, handleSubmit } = useForm<VenueFormData>({
-    defaultValues: {
-      ...data?.venue,
-      street_address: data?.venue?.street_address ?? undefined,
-      latitude: data?.venue?.latitude ?? undefined,
-      longitude: data?.venue?.longitude ?? undefined,
-    },
+    defaultValues,
   });
 
   return (

--- a/client/src/modules/dashboard/Venues/components/VenueForm.tsx
+++ b/client/src/modules/dashboard/Venues/components/VenueForm.tsx
@@ -3,19 +3,13 @@ import { useForm } from 'react-hook-form';
 import { Button, FormControl } from '@material-ui/core';
 
 import useFormStyles from '../../shared/components/formStyles';
-import { Venue, VenueQuery } from '../../../../generated/graphql';
+import type { Venue, VenueQuery } from '../../../../generated/graphql';
 import { Field } from '../../../../components/Form/Fields';
 
-export interface VenueFormData {
-  name: string;
-  street_address?: string;
-  city: string;
-  postal_code: string;
-  region: string;
-  country: string;
-  latitude?: number;
-  longitude?: number;
-}
+export type VenueFormData = Omit<
+  Venue,
+  'id' | 'created_at' | 'updated_at' | 'events'
+>;
 
 interface VenueFormProps {
   loading: boolean;
@@ -25,9 +19,9 @@ interface VenueFormProps {
 }
 
 type Fields =
-  | [keyof Venue, boolean, boolean]
-  | [keyof Venue, boolean]
-  | [keyof Venue];
+  | [keyof VenueFormData, boolean, boolean]
+  | [keyof VenueFormData, boolean]
+  | [keyof VenueFormData];
 
 const fields: Fields[] = [
   ['name', true],

--- a/client/src/modules/dashboard/shared/components/Layout.tsx
+++ b/client/src/modules/dashboard/shared/components/Layout.tsx
@@ -4,6 +4,7 @@ import { LinkButton } from 'chakra-next-link';
 import { useRouter } from 'next/router';
 
 const links = [
+  { text: 'Chapters', link: '/dashboard/chapters' },
   { text: 'Events', link: '/dashboard/events' },
   { text: 'Venues', link: '/dashboard/venues' },
 ];

--- a/client/src/pages/dashboard/chapters/[id]/edit.tsx
+++ b/client/src/pages/dashboard/chapters/[id]/edit.tsx
@@ -1,0 +1,2 @@
+import { EditChapterPage } from '../../../../modules/dashboard/Chapters/';
+export default EditChapterPage;

--- a/client/src/pages/dashboard/chapters/[id]/index.tsx
+++ b/client/src/pages/dashboard/chapters/[id]/index.tsx
@@ -1,0 +1,2 @@
+import { ChapterPage } from '../../../../modules/dashboard/Chapters/';
+export default ChapterPage;

--- a/client/src/pages/dashboard/chapters/index.tsx
+++ b/client/src/pages/dashboard/chapters/index.tsx
@@ -1,0 +1,2 @@
+import { ChaptersPage } from '../../../modules/dashboard/Chapters/';
+export default ChaptersPage;

--- a/client/src/pages/dashboard/chapters/new.tsx
+++ b/client/src/pages/dashboard/chapters/new.tsx
@@ -1,0 +1,2 @@
+import { NewChapterPage } from '../../../modules/dashboard/Chapters/';
+export default NewChapterPage;


### PR DESCRIPTION
This is basically a copy-paste of the Venue tab, with a few tweaks to make it work. The /dashboard page is still rather basic.  I didn't try to implement any of @megajon's designs and focused on getting it up and running, rather than looking good.

Nonetheless, it's now possible to edit and update chapters from the dashboard view.  @allella I'd love to get your feedback, even though it's a bit rough.

I based it off of https://github.com/freeCodeCamp/chapter/pull/627, so that I could easily make use of those changes.  Might be easier if we merged that first, or we could just merge this and close that.