### PR TITLE
feat: email all interested users on event creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ EMAIL_HOST=localhost
 # change this variable to at least 32 random characters
 # to enforce 256-bit cryto security on Auth0's JsonWebToken 
 JWT_SECRET=SetThisTo32orMoreRandomCharacters
+
+# When running remotely, this should be the full url of the landing page
+CLIENT_LOCATION=http://localhost:3000

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -1803,6 +1803,39 @@
             "deprecationReason": null
           },
           {
+            "name": "sendEventInvite",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sendEmail",
             "description": null,
             "args": [

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -143,6 +143,7 @@ export type Mutation = {
   updateEvent: Event;
   cancelEvent: Event;
   deleteEvent: Scalars['Boolean'];
+  sendEventInvite: Scalars['Boolean'];
   sendEmail: Email;
   register: User;
   login: LoginType;
@@ -201,6 +202,10 @@ export type MutationCancelEventArgs = {
 };
 
 export type MutationDeleteEventArgs = {
+  id: Scalars['Int'];
+};
+
+export type MutationSendEventInviteArgs = {
   id: Scalars['Int'];
 };
 
@@ -675,6 +680,15 @@ export type DeleteRsvpMutationVariables = Exact<{
 export type DeleteRsvpMutation = { __typename?: 'Mutation' } & Pick<
   Mutation,
   'deleteRsvp'
+>;
+
+export type SendEventInviteMutationVariables = Exact<{
+  id: Scalars['Int'];
+}>;
+
+export type SendEventInviteMutation = { __typename?: 'Mutation' } & Pick<
+  Mutation,
+  'sendEventInvite'
 >;
 
 export type VenuesQueryVariables = Exact<{ [key: string]: never }>;
@@ -1760,6 +1774,54 @@ export type DeleteRsvpMutationResult =
 export type DeleteRsvpMutationOptions = Apollo.BaseMutationOptions<
   DeleteRsvpMutation,
   DeleteRsvpMutationVariables
+>;
+export const SendEventInviteDocument = gql`
+  mutation sendEventInvite($id: Int!) {
+    sendEventInvite(id: $id)
+  }
+`;
+export type SendEventInviteMutationFn = Apollo.MutationFunction<
+  SendEventInviteMutation,
+  SendEventInviteMutationVariables
+>;
+
+/**
+ * __useSendEventInviteMutation__
+ *
+ * To run a mutation, you first call `useSendEventInviteMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useSendEventInviteMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [sendEventInviteMutation, { data, loading, error }] = useSendEventInviteMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useSendEventInviteMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    SendEventInviteMutation,
+    SendEventInviteMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    SendEventInviteMutation,
+    SendEventInviteMutationVariables
+  >(SendEventInviteDocument, options);
+}
+export type SendEventInviteMutationHookResult = ReturnType<
+  typeof useSendEventInviteMutation
+>;
+export type SendEventInviteMutationResult =
+  Apollo.MutationResult<SendEventInviteMutation>;
+export type SendEventInviteMutationOptions = Apollo.BaseMutationOptions<
+  SendEventInviteMutation,
+  SendEventInviteMutationVariables
 >;
 export const VenuesDocument = gql`
   query venues {

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -7,6 +7,7 @@ import {
   Event,
   useCancelEventMutation,
   useDeleteEventMutation,
+  useSendEventInviteMutation,
 } from 'generated/graphql';
 import { EVENT, EVENTS } from '../graphql/queries';
 
@@ -19,6 +20,7 @@ interface ActionsProps {
 const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
   const [cancel] = useCancelEventMutation();
   const [remove] = useDeleteEventMutation();
+  const [publish] = useSendEventInviteMutation();
 
   const data = useMemo(
     () => ({
@@ -53,6 +55,19 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
     }
   };
 
+  const confirmPublish = useConfirm({
+    title: 'Are you ready to publicize this?',
+    body: 'This will email all your users',
+    buttonColor: 'green',
+  });
+
+  const clickPublish = async () => {
+    const ok = await confirmPublish();
+    if (ok) {
+      await publish(data);
+    }
+  };
+
   return (
     <HStack spacing="1">
       <Button size="sm" colorScheme="red" onClick={clickDelete}>
@@ -70,6 +85,9 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
           Cancel
         </Button>
       )}
+      <Button size="sm" colorScheme="blue" onClick={clickPublish}>
+        Email users
+      </Button>
     </HStack>
   );
 };

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -7,7 +7,6 @@ import {
   Event,
   useCancelEventMutation,
   useDeleteEventMutation,
-  useSendEventInviteMutation,
 } from 'generated/graphql';
 import { EVENT, EVENTS } from '../graphql/queries';
 
@@ -20,7 +19,6 @@ interface ActionsProps {
 const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
   const [cancel] = useCancelEventMutation();
   const [remove] = useDeleteEventMutation();
-  const [publish] = useSendEventInviteMutation();
 
   const data = useMemo(
     () => ({
@@ -55,19 +53,6 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
     }
   };
 
-  const confirmPublish = useConfirm({
-    title: 'Are you ready to publicize this?',
-    body: 'This will email all your users',
-    buttonColor: 'green',
-  });
-
-  const clickPublish = async () => {
-    const ok = await confirmPublish();
-    if (ok) {
-      await publish(data);
-    }
-  };
-
   return (
     <HStack spacing="1">
       <Button size="sm" colorScheme="red" onClick={clickDelete}>
@@ -85,9 +70,6 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
           Cancel
         </Button>
       )}
-      <Button size="sm" colorScheme="blue" onClick={clickPublish}>
-        Email users
-      </Button>
     </HStack>
   );
 };

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -158,3 +158,9 @@ export const deleteRSVP = gql`
     deleteRsvp(id: $id)
   }
 `;
+
+export const sendEventInvite = gql`
+  mutation sendEventInvite($id: Int!) {
+    sendEventInvite(id: $id)
+  }
+`;

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -1,10 +1,13 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import { NextPage } from 'next';
 import { EventFormData } from '../components/EventFormUtils';
 import { Layout } from '../../shared/components/Layout';
 import EventForm from '../components/EventForm';
-import { useCreateEventMutation } from '../../../../generated/graphql';
+import {
+  useCreateEventMutation,
+  useSendEventInviteMutation,
+} from '../../../../generated/graphql';
 import { EVENTS } from '../graphql/queries';
 
 export const NewEventPage: NextPage = () => {
@@ -14,6 +17,8 @@ export const NewEventPage: NextPage = () => {
   const [createEvent] = useCreateEventMutation({
     refetchQueries: [{ query: EVENTS }],
   });
+
+  const [publish] = useSendEventInviteMutation();
 
   const onSubmit = async (data: EventFormData) => {
     // TODO: load chapter from url or something like that
@@ -38,6 +43,7 @@ export const NewEventPage: NextPage = () => {
       });
 
       if (event.data) {
+        publish({ variables: { id: event.data.createEvent.id } });
         router.replace(
           `/dashboard/events/[id]`,
           `/dashboard/events/${event.data.createEvent.id}`,

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import { NextPage } from 'next';
 import { EventFormData } from '../components/EventFormUtils';

--- a/db/generator/factories/user.factory.ts
+++ b/db/generator/factories/user.factory.ts
@@ -1,6 +1,5 @@
 import { name, internet } from 'faker';
 import { User } from '../../../server/models';
-import { random } from '../lib/random';
 
 const createUsers = async (): Promise<[User, User[]]> => {
   // TODO: add seeding admin
@@ -11,7 +10,7 @@ const createUsers = async (): Promise<[User, User[]]> => {
   });
 
   const others = Array.from(
-    new Array(random(5)),
+    new Array(10),
     () =>
       new User({
         email: internet.email(),

--- a/db/generator/lib/util.ts
+++ b/db/generator/lib/util.ts
@@ -1,0 +1,8 @@
+export const makeBooleanIterator = (flip = false) => {
+  return {
+    next() {
+      flip = !flip;
+      return { value: flip, done: false };
+    },
+  };
+};

--- a/db/generator/setupRoles.ts
+++ b/db/generator/setupRoles.ts
@@ -30,7 +30,12 @@ const setupRoles = async (
     ucr.push(ban);
   }
 
-  await Promise.all(ucr);
+  try {
+    await Promise.all(ucr.map((user) => user.save()));
+  } catch (e) {
+    console.error(e);
+    throw new Error('Error seeding roles');
+  }
 };
 
 export default setupRoles;

--- a/db/generator/setupRoles.ts
+++ b/db/generator/setupRoles.ts
@@ -1,4 +1,5 @@
 import { User, Chapter, UserChapterRole, UserBan } from '../../server/models';
+import { makeBooleanIterator } from './lib/util';
 
 const setupRoles = async (
   admin: User,
@@ -7,21 +8,28 @@ const setupRoles = async (
 ): Promise<void> => {
   const ucr: (UserChapterRole | UserBan)[] = [];
 
+  const chapterIterator = makeBooleanIterator();
   for (const chapter of chapters) {
     const chapterUser = new UserChapterRole({
       chapterId: chapter.id,
       userId: admin.id,
       roleName: 'organizer',
+      interested: true,
     });
 
     const [banned, ...others] = users;
     const ban = new UserBan({ chapter, user: banned });
-
+    // makes sure half of each chapter's users are interested, but
+    // alternates which half.
+    const interestedIterator = makeBooleanIterator(
+      chapterIterator.next().value,
+    );
     for (const user of others) {
       const chapterUser = new UserChapterRole({
         chapterId: chapter.id,
         userId: user.id,
         roleName: 'member',
+        interested: interestedIterator.next().value,
       });
       ucr.push(chapterUser);
     }

--- a/server/controllers/Chapter/resolver.ts
+++ b/server/controllers/Chapter/resolver.ts
@@ -11,7 +11,9 @@ export class ChapterResolver {
 
   @Query(() => Chapter, { nullable: true })
   chapter(@Arg('id', () => Int) id: number) {
-    return Chapter.findOne(id, { relations: ['events'] });
+    return Chapter.findOne(id, {
+      relations: ['events', 'users', 'users.user'],
+    });
   }
 
   @Mutation(() => Chapter)

--- a/server/controllers/Events/resolver.ts
+++ b/server/controllers/Events/resolver.ts
@@ -217,16 +217,32 @@ To add this event to your calendar(s) you can use these links:
   @Mutation(() => Boolean)
   async sendEventInvite(@Arg('id', () => Int) id: number) {
     const event = await Event.findOne(id, {
-      relations: ['chapter', 'chapter.users', 'chapter.users.user'],
+      relations: ['venue', 'chapter', 'chapter.users', 'chapter.users.user'],
     });
 
     if (!event) throw new Error("Can't find event");
 
     // TODO: the default should probably be to bcc everyone.
     const addresses = event.chapter.users.map(({ user }) => user.email);
-    const subject = `Invitation: new event, ${event.name}, with ${event.chapter.name}.`;
+    const subject = `Invitation to ${event.name}.`;
+
+    const chapterURL = `${process.env.CLIENT_LOCATION}/chapters/${event.chapter.id}`;
+    const eventURL = `${process.env.CLIENT_LOCATION}/events/${event.id}`;
     // TODO: this needs to include an ical file
-    const body = 'TBD';
+    // TODO: it needs a link to unsubscribe from just this event.  See
+    // https://github.com/freeCodeCamp/chapter/issues/276#issuecomment-596913322
+    const body =
+      `When: ${event.start_at} to ${event.ends_at}<br>` +
+      (event.venue ? `Where: ${event.venue?.name}<br>` : '') +
+      `Event Details: <a href="${eventURL}">${eventURL}</a><br>
+<br>
+- Cancel your RSVP: <a href="${eventURL}">${eventURL}</a><br>
+- More about ${event.chapter.name} or to unfollow this chapter: <a href="${chapterURL}">${chapterURL}</a><br>
+<br>
+----------------------------<br>
+You received this email because you follow this chapter.<br>
+<br>
+See the options above to change your notifications.`;
 
     await new MailerService(addresses, subject, body).sendEmail();
 

--- a/server/controllers/Events/resolver.ts
+++ b/server/controllers/Events/resolver.ts
@@ -213,4 +213,23 @@ To add this event to your calendar(s) you can use these links:
 
     return true;
   }
+
+  @Mutation(() => Boolean)
+  async sendEventInvite(@Arg('id', () => Int) id: number) {
+    const event = await Event.findOne(id, {
+      relations: ['chapter', 'chapter.users', 'chapter.users.user'],
+    });
+
+    if (!event) throw new Error("Can't find event");
+
+    // TODO: the default should probably be to bcc everyone.
+    const addresses = event.chapter.users.map(({ user }) => user.email);
+    const subject = `Invitation: new event, ${event.name}, with ${event.chapter.name}.`;
+    // TODO: this needs to include an ical file
+    const body = 'TBD';
+
+    await new MailerService(addresses, subject, body).sendEmail();
+
+    return true;
+  }
 }

--- a/server/controllers/Events/resolver.ts
+++ b/server/controllers/Events/resolver.ts
@@ -223,7 +223,9 @@ To add this event to your calendar(s) you can use these links:
     if (!event) throw new Error("Can't find event");
 
     // TODO: the default should probably be to bcc everyone.
-    const addresses = event.chapter.users.map(({ user }) => user.email);
+    const addresses = event.chapter.users
+      .filter((role) => role.interested)
+      .map(({ user }) => user.email);
     const subject = `Invitation to ${event.name}.`;
 
     const chapterURL = `${process.env.CLIENT_LOCATION}/chapters/${event.chapter.id}`;

--- a/server/models/UserChapterRole.ts
+++ b/server/models/UserChapterRole.ts
@@ -45,14 +45,14 @@ export class UserChapterRole extends BaseModel {
     userId: number;
     roleName: ChapterRoles;
     chapterId: number;
-    interested?: boolean;
+    interested: boolean;
   }) {
     super();
     if (params) {
       this.user_id = params.userId;
       this.role_name = params.roleName;
       this.chapter_id = params.chapterId;
-      this.interested = params.interested || true;
+      this.interested = params.interested;
     }
   }
 }


### PR DESCRIPTION
The UI is a bit horrible, but this PR adds another button to /dashboard/events/[id] which sends emails to everyone in that chapter.