### PR TITLE
feat: email users on venue change

### DIFF
--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -37,6 +37,7 @@ export const EditEventPage: NextPage = () => {
       const eventData = {
         ...data,
         capacity: parseInt(String(data.capacity)),
+        venueId: parseInt(String(data.venueId)),
         start_at: new Date(data.start_at).toISOString(),
         ends_at: new Date(data.ends_at).toISOString(),
         tags: undefined,

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "projectId": "re65q6",
   "baseUrl": "http://localhost:3000",
-  "mailHogUrl": "http://localhost:8025"
+  "mailHogUrl": "http://localhost:8025",
+  "retries": { "runMode": 3, "openMode": 3 }
 }

--- a/cypress/integration/dashboard/events.js
+++ b/cypress/integration/dashboard/events.js
@@ -59,10 +59,14 @@ describe('events dashboard', () => {
     cy.location('pathname').should('match', /^\/dashboard\/events\/\d/);
     // confirm that the test data appears in the new event
     cy.wrap(Object.entries(fix)).each(([key, value]) => {
-      // TODO: remove this conditional when tags and dates are handled properly.
-      if (!['tags', 'startAt', 'endAt'].includes(key)) {
+      // TODO: simplify this conditional when tags and dates are handled
+      // properly.
+      if (!['tags', 'startAt', 'endAt', 'venueId'].includes(key)) {
         cy.contains(value);
       }
+    });
+    cy.get('@venueTitle').then((venueTitle) => {
+      cy.contains(venueTitle);
     });
   });
 });

--- a/cypress/integration/dashboard/events.js
+++ b/cypress/integration/dashboard/events.js
@@ -98,7 +98,15 @@ describe('events dashboard', () => {
     });
     cy.findByRole('form', { name: 'Update event' }).submit();
 
-    cy.mhGetAllMails().mhFirst().as('venueMail');
+    // Make sure that an email has been recieved.
+    cy.waitUntil(() =>
+      cy
+        .mhGetAllMails()
+        .as('allMail')
+        .then((mails) => mails?.length > 0),
+    );
+
+    cy.get('@allMail').mhFirst().as('venueMail');
 
     cy.get('@newVenueTitle').then((venueTitle) => {
       cy.get('@eventTitle').then((eventTitle) => {

--- a/cypress/integration/dashboard/events.js
+++ b/cypress/integration/dashboard/events.js
@@ -98,13 +98,7 @@ describe('events dashboard', () => {
     });
     cy.findByRole('form', { name: 'Update event' }).submit();
 
-    // Make sure that an email has been recieved.
-    cy.waitUntil(() =>
-      cy
-        .mhGetAllMails()
-        .as('allMail')
-        .then((mails) => mails?.length > 0),
-    );
+    cy.waitUntilMail('allMail');
 
     cy.get('@allMail').mhFirst().as('venueMail');
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -93,3 +93,12 @@ Cypress.Commands.add('interceptGQL', (operationName) => {
     }
   });
 });
+
+Cypress.Commands.add('waitUntilMail', (alias) => {
+  cy.waitUntil(() =>
+    cy
+      .mhGetAllMails()
+      .as(alias)
+      .then((mails) => mails?.length > 0),
+  );
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,6 +24,7 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
+import 'cypress-wait-until';
 import 'cypress-mailhog';
 import '@testing-library/cypress/add-commands';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "cross-env": "7.0.3",
         "cypress": "8.3.0",
         "cypress-mailhog": "1.4.0",
+        "cypress-wait-until": "^1.7.1",
         "dotenv": "^10.0.0",
         "eslint": "7.32.0",
         "eslint-config-prettier": "8.3.0",
@@ -3802,6 +3803,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cypress-mailhog/-/cypress-mailhog-1.4.0.tgz",
       "integrity": "sha512-n9iCgBKHuh/A7jTQLPsAE2ec1bivbKEQcGc9tQo7rHf7sZegB+2ySUodljOzZNZXoBGu99myryRqlKldRRAveQ==",
+      "dev": true
+    },
+    "node_modules/cypress-wait-until": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz",
+      "integrity": "sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==",
       "dev": true
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -14760,6 +14767,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cypress-mailhog/-/cypress-mailhog-1.4.0.tgz",
       "integrity": "sha512-n9iCgBKHuh/A7jTQLPsAE2ec1bivbKEQcGc9tQo7rHf7sZegB+2ySUodljOzZNZXoBGu99myryRqlKldRRAveQ==",
+      "dev": true
+    },
+    "cypress-wait-until": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz",
+      "integrity": "sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==",
       "dev": true
     },
     "dashdash": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "cross-env": "7.0.3",
     "cypress": "8.3.0",
     "cypress-mailhog": "1.4.0",
+    "cypress-wait-until": "^1.7.1",
     "dotenv": "^10.0.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",


### PR DESCRIPTION
This emails the users that have RVSP'd whenever the venue is changed.

Currently the tests only check that the venue change happens and that emails about it are sent.  It does not, yet, confirm that only the RVSPs get emailed, but I plan to circle back to that test later.

Closes #663