### PR TITLE
Update the .env.example with 32 character example for JWT_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,6 @@ EMAIL_USERNAME=project.1
 EMAIL_PASSWORD=secret.1
 EMAIL_SERVICE=emailServicePlaceholder
 
-JWT_SECRET=foobar123
+# change this variable to at least 32 random characters
+# to enforce 256-bit cryto security on Auth0's JsonWebToken 
+JWT_SECRET=SetThisTo32orMoreRandomCharacters


### PR DESCRIPTION
This is a simple documentation change.

The JWT_SECRET environment variable needs to be 32 random characters, or more, to function as a [proper secret for the default 256-bit crypto algorithm used with Auth0 and JsonWebToken per the earlier conversation](https://github.com/freeCodeCamp/chapter/issues/604#issuecomment-828792850).

The current example is too short and _administrators_ might set a short secret that reduces the security.

The [default HS256 algorithm is 256-bit](https://github.com/auth0/node-jsonwebtoken#usage) so we need at least 32 characters, but having more than 32 doesn't make things more secure unless we were to change the algorithm to something using 512-bit.

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

Closes: nothing
