### PR TITLE
fix: add mailhog to docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ CHAPTER_EMAIL=ourEmail@placeholder.place
 EMAIL_USERNAME=project.1
 EMAIL_PASSWORD=secret.1
 EMAIL_SERVICE=emailServicePlaceholder
+EMAIL_HOST=localhost
 
 # change this variable to at least 32 random characters
 # to enforce 256-bit cryto security on Auth0's JsonWebToken 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     working_dir: /usr/chapter
     environment:
       - DB_URL=db
+      - EMAIL_HOST=mailhog
     volumes:
       - .:/usr/chapter
     ports:
@@ -34,3 +35,10 @@ services:
       NEXT_PUBLIC_APOLLO_SERVER:
     volumes:
       - ./client:/usr/chapter/client
+  mailhog:
+    depends_on:
+      - app
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"

--- a/server/services/MailerService.ts
+++ b/server/services/MailerService.ts
@@ -14,6 +14,7 @@ export default class MailerService {
   emailUsername: string;
   emailPassword: string;
   emailService: string;
+  emailHost: string;
 
   constructor(
     emailList: Array<string>,
@@ -32,6 +33,7 @@ export default class MailerService {
     this.emailUsername = (process.env.EMAIL_USERNAME as string) || 'project.1';
     this.emailPassword = (process.env.EMAIL_PASSWORD as string) || 'secret.1';
     this.emailService = process.env.EMAIL_SERVICE as string;
+    this.emailHost = process.env.EMAIL_HOST || 'localhost';
 
     this.createTransporter();
   }
@@ -52,7 +54,7 @@ export default class MailerService {
 
     this.transporter = nodemailer.createTransport({
       service: this.emailService,
-      host: 'localhost',
+      host: this.emailHost,
       port: 1025,
       auth: {
         user: this.emailUsername,


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [X] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #XXXXX

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
Paired with @ojeytonwilliams to accomplish this. 

- Adds the mailhog image to the docker-compose file
- Changes the `host` option to be an environment variable
  - Added the `EMAIL_HOST` to the `.env.example` with a default of `localhost` for manual setups
  - Added the `EMAIL_HOST` to the docker-compose with a value of `mailhog` to match the Mailhog image name.
- Rebuilt and started docker images with new configuration, confirmed that email flow appears to work as intended.
- Confirmed that behaviour remains as intended with manual setup.