### PR TITLE
fix(gitpod): make port 5000 visible

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,6 +6,7 @@ ports:
     onOpen: ignore
   - port: 5000
     onOpen: ignore
+    visibility: public
 tasks:
   # both .bashrc and nvm settings get wiped when a workspace is restarted, so
   # they need setting here

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -39,6 +39,7 @@
         "@types/node": "14.17.5",
         "@types/react": "17.0.14",
         "@types/react-dom": "17.0.9",
+        "prettier": "^2.3.2",
         "typescript": "4.3.5"
       }
     },
@@ -8181,6 +8182,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/process": {
@@ -16695,6 +16708,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true
     },
     "process": {

--- a/client/package.json
+++ b/client/package.json
@@ -40,6 +40,7 @@
     "@types/node": "14.17.5",
     "@types/react": "17.0.14",
     "@types/react-dom": "17.0.9",
+    "prettier": "^2.3.2",
     "typescript": "4.3.5"
   },
   "license": "MIT"


### PR DESCRIPTION
Otherwise the client will be denied access to the server.

Prettier is used by `npm run both` from the client, but npm doesn't look in parent directories for executables, so I added it to /client