### PR TITLE
fix: standardizes installation to just use npm i

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Update npm
         run: npm i -g npm@7
       - name: Install dependencies
-        run: npx recursive-install
+        run: npm i
       - name: Run linter
         run: npm run lint
       - name: Type check client

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -50,7 +50,7 @@ jobs:
           echo IS_DOCKER= >> .env
 
       - name: Install Dependencies
-        run: npx recursive-install
+        run: npm i
 
       - name: Seed Database
         run: npm run db:reset

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,7 +21,7 @@ tasks:
       cp .env.example .env &&
       createuser -d postgres &&
       createdb chapter &&
-      npx recursive-install &&
+      npm i &&
       npm run db:reset
     command: npm run both
 github:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,7 +325,7 @@ Ensure the Node.js tools are installed:
 * Node.js 14 or greater - `node --version` and the output should be like **v14**.16.0
 * npm 6 or greater - `npm --version` and the output should be like **6**.14.11
 
-Run `npx recursive-install` to install all of the necessary dependencies.
+Run `npx i` to install all of the necessary dependencies.
 
 This step will **automatically** read and process the _package.json_ file. Most notably it:
 * Downloads all Node package dependencies to the _node_modules_ sub-directory

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "gen": "graphql-codegen --config codegen.yml",
-    "gen:dev": "yarn gen --watch"
+    "gen:dev": "npm run gen --watch"
   },
   "dependencies": {
     "@apollo/client": "3.3.21",

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "gen": "graphql-codegen --config codegen.yml",
-    "gen:dev": "npm run gen --watch"
+    "gen:dev": "npm run gen -- --watch"
   },
   "dependencies": {
     "@apollo/client": "3.3.21",

--- a/scripts/postInstall.js
+++ b/scripts/postInstall.js
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { existsSync, copyFileSync } = require('fs');
-const { execSync } = require('child_process');
+const { execSync, spawn } = require('child_process');
 const isDocker = require('is-docker');
 
 console.log('--------------------------');
@@ -11,7 +11,21 @@ const CHAPTER_REMOTE = 'freeCodeCamp/chapter.git';
 let IS_ERROR = false;
 
 if (!isDocker()) {
-  setup();
+  const child = spawn('npm', ['i'], { cwd: 'client' });
+  child.on('error', (err) => {
+    console.error(err);
+  });
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', function (data) {
+    console.log(data);
+  });
+  child.on('close', function (code) {
+    if (code === 0) {
+      setup();
+    } else {
+      console.log('Installing client returned error code', code);
+    }
+  });
 }
 
 function setup() {
@@ -54,7 +68,7 @@ function setup() {
 
   if (!IS_ERROR) {
     console.log(
-      '\nCongratulations, its almost done 🙌🏼. Run `npm run dev` to start the development server.',
+      '\nCongratulations, its almost done 🙌🏼. Run `npm run both` to start the development server.',
     );
   }
 }


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Rather than using `npx recursive-install` I changed the postInstall script to install the client.  That way we get a friendlier output (Welcome to Chapter, etc) and sufficient to use `npm i` to get up and running.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
