### PR TITLE
test: Cypress test for event page

### DIFF
--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -105,7 +105,7 @@ export const EventPage: NextPage = () => {
         modalProps={modalProps}
       />
 
-      <Heading>
+      <Heading as="h1">
         {data.event.invite_only && <LockIcon />} {data.event.name}
         {data.event.name}
       </Heading>
@@ -137,12 +137,18 @@ export const EventPage: NextPage = () => {
           </Button>
         </HStack>
       ) : (
-        <Button colorScheme="blue" onClick={() => checkOnRsvp(true)}>
+        <Button
+          data-cy="rsvp button"
+          colorScheme="blue"
+          onClick={() => checkOnRsvp(true)}
+        >
           {data.event.invite_only ? 'Request' : 'RSVP'}
         </Button>
       )}
 
-      <Heading size="md">RSVPs:</Heading>
+      <Heading data-cy="rsvps heading" size="md">
+        RSVPs:
+      </Heading>
       <List>
         {rsvps.map((rsvp) => (
           <ListItem key={rsvp.id} mb="2">
@@ -156,7 +162,9 @@ export const EventPage: NextPage = () => {
 
       {!data.event.invite_only && (
         <>
-          <Heading size="md">Waitlist:</Heading>
+          <Heading data-cy="waitlist heading" size="md">
+            Waitlist:
+          </Heading>
           <List>
             {waitlist.map((rsvp) => (
               <ListItem key={rsvp.id} mb="2">

--- a/cypress/integration/event/[eventId].js
+++ b/cypress/integration/event/[eventId].js
@@ -1,0 +1,17 @@
+describe('event page', () => {
+  it('should render correctly', () => {
+    cy.visit('/events/1');
+    cy.get('h1').should('not.have.text', 'Loading...');
+    cy.get('[data-cy="rsvp button"]').should('be.visible');
+    cy.get('[data-cy="rsvps heading"]')
+      .should('be.visible')
+      .next()
+      .should('be.visible')
+      .should('match', 'ul');
+    cy.get('[data-cy="waitlist heading"]')
+      .should('be.visible')
+      .next()
+      .should('be.visible')
+      .should('match', 'ul');
+  });
+});

--- a/db/generator/factories/rsvps.factory.ts
+++ b/db/generator/factories/rsvps.factory.ts
@@ -1,17 +1,19 @@
 import { Event, User, Rsvp } from '../../../server/models';
-import { randomItems } from '../lib/random';
+import { random, randomItems } from '../lib/random';
 import { date } from 'faker';
 
 const createRsvps = async (events: Event[], users: User[]): Promise<Rsvp[]> => {
   const rsvps: Rsvp[] = [];
 
   for (const event of events) {
-    for (const user of randomItems(users, users.length / 2)) {
+    const eventUsers = randomItems(users, users.length / 2);
+    const numberWaiting = 1 + random(eventUsers.length - 1);
+    for (let i = 0; i < eventUsers.length; i++) {
       const rsvp = new Rsvp({
         event,
-        user,
+        user: eventUsers[i],
         date: date.future(),
-        on_waitlist: Math.random() > 0.5,
+        on_waitlist: i < numberWaiting,
         confirmed_at: new Date(),
       });
       rsvps.push(rsvp);


### PR DESCRIPTION
- fix(seed): guarantee a mixture of waiting and not
- test: add basic cy test for an event page

Also bumps up the first heading to `h1` since it's standard a11y practice.