### PR TITLE
feat: make dashboard for users

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -502,6 +502,21 @@ export type ChapterQuery = {
   }>;
 };
 
+export type ChapterUsersQueryVariables = Exact<{
+  id: Scalars['Int'];
+}>;
+
+export type ChapterUsersQuery = {
+  __typename?: 'Query';
+  chapter?: Maybe<{
+    __typename?: 'Chapter';
+    users: Array<{
+      __typename?: 'UserChapterRole';
+      user: { __typename?: 'User'; name: string; email: string };
+    }>;
+  }>;
+};
+
 export type ChaptersQueryVariables = Exact<{ [key: string]: never }>;
 
 export type ChaptersQuery = {
@@ -1106,6 +1121,69 @@ export type ChapterLazyQueryHookResult = ReturnType<typeof useChapterLazyQuery>;
 export type ChapterQueryResult = Apollo.QueryResult<
   ChapterQuery,
   ChapterQueryVariables
+>;
+export const ChapterUsersDocument = gql`
+  query chapterUsers($id: Int!) {
+    chapter(id: $id) {
+      users {
+        user {
+          name
+          email
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * __useChapterUsersQuery__
+ *
+ * To run a query within a React component, call `useChapterUsersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useChapterUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useChapterUsersQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useChapterUsersQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    ChapterUsersQuery,
+    ChapterUsersQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<ChapterUsersQuery, ChapterUsersQueryVariables>(
+    ChapterUsersDocument,
+    options,
+  );
+}
+export function useChapterUsersLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ChapterUsersQuery,
+    ChapterUsersQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<ChapterUsersQuery, ChapterUsersQueryVariables>(
+    ChapterUsersDocument,
+    options,
+  );
+}
+export type ChapterUsersQueryHookResult = ReturnType<
+  typeof useChapterUsersQuery
+>;
+export type ChapterUsersLazyQueryHookResult = ReturnType<
+  typeof useChapterUsersLazyQuery
+>;
+export type ChapterUsersQueryResult = Apollo.QueryResult<
+  ChapterUsersQuery,
+  ChapterUsersQueryVariables
 >;
 export const ChaptersDocument = gql`
   query chapters {

--- a/client/src/modules/chapters/graphql/queries.ts
+++ b/client/src/modules/chapters/graphql/queries.ts
@@ -27,6 +27,19 @@ export const CHAPTER = gql`
   }
 `;
 
+export const CHAPTER_USERS = gql`
+  query chapterUsers($id: Int!) {
+    chapter(id: $id) {
+      users {
+        user {
+          name
+          email
+        }
+      }
+    }
+  }
+`;
+
 export const CHAPTERS = gql`
   query chapters {
     chapters {

--- a/client/src/modules/dashboard/Chapters/Users/index.ts
+++ b/client/src/modules/dashboard/Chapters/Users/index.ts
@@ -1,0 +1,1 @@
+export { ChapterUsersPage } from './pages/ChapterUsersPage';

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { NextPage } from 'next';
+
+import { useChapterUsersQuery } from '../../../../../generated/graphql';
+import { Layout } from '../../../shared/components/Layout';
+import { VStack, Flex, Text, Heading } from '@chakra-ui/react';
+import { DataTable } from 'chakra-data-table';
+import { LinkButton } from 'chakra-next-link';
+import { getId } from 'helpers/getId';
+import { useRouter } from 'next/router';
+
+export const ChapterUsersPage: NextPage = () => {
+  const router = useRouter();
+
+  const id = getId(router.query) || -1;
+
+  const { loading, error, data } = useChapterUsersQuery({
+    variables: { id },
+  });
+
+  return (
+    <Layout>
+      <VStack>
+        <Flex w="full" justify="space-between">
+          <Heading id="pageTitle">Chapter Users</Heading>
+          <LinkButton href={`/dashboard/chapters/${id}/users/new`}>
+            Invite user
+          </LinkButton>
+        </Flex>
+        {loading ? (
+          <Heading>Loading...</Heading>
+        ) : error || !data?.chapter?.users ? (
+          <>
+            <Heading>Error</Heading>
+            <Text>
+              {error?.name}: {error?.message}
+            </Text>
+          </>
+        ) : (
+          <DataTable
+            data={data.chapter.users}
+            tableProps={{ table: { 'aria-labelledby': 'pageTitle' } }}
+            keys={['name', 'email'] as const}
+            mapper={{
+              name: ({ user }) => user.name,
+              email: ({ user }) => user.email,
+            }}
+          />
+        )}
+      </VStack>
+    </Layout>
+  );
+};

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -22,7 +22,7 @@ export const ChapterUsersPage: NextPage = () => {
     <Layout>
       <VStack>
         <Flex w="full" justify="space-between">
-          <Heading id="pageTitle">Chapter Users</Heading>
+          <Heading id="page-heading">Chapter Users</Heading>
           <LinkButton href={`/dashboard/chapters/${id}/users/new`}>
             Invite user
           </LinkButton>
@@ -39,7 +39,7 @@ export const ChapterUsersPage: NextPage = () => {
         ) : (
           <DataTable
             data={data.chapter.users}
-            tableProps={{ table: { 'aria-labelledby': 'pageTitle' } }}
+            tableProps={{ table: { 'aria-labelledby': 'page-heading' } }}
             keys={['name', 'email'] as const}
             mapper={{
               name: ({ user }) => user.name,

--- a/client/src/pages/dashboard/chapters/[id]/users/index.tsx
+++ b/client/src/pages/dashboard/chapters/[id]/users/index.tsx
@@ -1,0 +1,2 @@
+import { ChapterUsersPage } from '../../../../../modules/dashboard/Chapters/Users';
+export default ChapterUsersPage;

--- a/cypress/integration/dashboard/chapters/users.js
+++ b/cypress/integration/dashboard/chapters/users.js
@@ -1,0 +1,11 @@
+describe('Chapter Users dashboard', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+  it('should have a table of users', () => {
+    cy.visit('/dashboard/chapters/1/users');
+    cy.findByRole('table', { name: 'Chapter Users' }).should('be.visible');
+    cy.findByRole('columnheader', { name: 'name' }).should('be.visible');
+    cy.findByRole('columnheader', { name: 'email' }).should('be.visible');
+  });
+});


### PR DESCRIPTION
- feat: add a basic chapter users dashboard
- test: add spec for chapter users dashboard

Related to https://github.com/freeCodeCamp/chapter/issues/98 in that it creates a page where a given chapter's organizers can see the users.

Banning functionality to follow!