### PR TITLE
feat: add labels for dashboard tables

### DIFF
--- a/client/src/modules/dashboard/Chapters/pages/ChaptersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChaptersPage.tsx
@@ -14,7 +14,7 @@ export const ChaptersPage: NextPage = () => {
     <Layout>
       <VStack>
         <Flex w="full" justify="space-between">
-          <Heading>Chapters</Heading>
+          <Heading id="page-heading">Chapters</Heading>
           <LinkButton href="/dashboard/chapters/new">Add new</LinkButton>
         </Flex>
         {loading ? (
@@ -30,6 +30,7 @@ export const ChaptersPage: NextPage = () => {
           <DataTable
             data={data.chapters}
             keys={['name', 'actions'] as const}
+            tableProps={{ table: { 'aria-labelledby': 'page-heading' } }}
             mapper={{
               name: (chapter) => (
                 <LinkButton href={`/dashboard/chapters/${chapter.id}`}>

--- a/client/src/modules/dashboard/Events/pages/EventsPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventsPage.tsx
@@ -15,7 +15,7 @@ export const EventsPage: NextPage = () => {
     <Layout>
       <VStack>
         <Flex w="full" justify="space-between">
-          <Heading>Events</Heading>
+          <Heading id="page-heading">Events</Heading>
           <LinkButton href="/dashboard/events/new">Add new</LinkButton>
         </Flex>
 
@@ -30,6 +30,7 @@ export const EventsPage: NextPage = () => {
           </>
         ) : (
           <DataTable
+            tableProps={{ table: { 'aria-labelledby': 'page-heading' } }}
             data={data.events}
             keys={
               [

--- a/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
@@ -15,7 +15,7 @@ export const VenuesPage: NextPage = () => {
     <Layout>
       <VStack>
         <Flex w="full" justify="space-between">
-          <Heading>Venues</Heading>
+          <Heading id="page-heading">Venues</Heading>
           <LinkButton href="/dashboard/venues/new">Add new</LinkButton>
         </Flex>
         {loading ? (
@@ -29,6 +29,7 @@ export const VenuesPage: NextPage = () => {
           </>
         ) : (
           <DataTable
+            tableProps={{ table: { 'aria-labelledby': 'page-heading' } }}
             data={data.venues}
             keys={['name', 'location', 'actions'] as const}
             mapper={{

--- a/cypress/integration/dashboard/chapters.js
+++ b/cypress/integration/dashboard/chapters.js
@@ -6,8 +6,11 @@ describe('chapters dashboard', () => {
     cy.get('a[aria-current="page"]').should('have.text', 'Chapters');
   });
 
-  it('should have links to view, create and edit chapters', () => {
+  it('should have a table with links to view, create and edit chapters', () => {
     cy.visit('/dashboard/chapters');
+    cy.findByRole('table', { name: 'Chapters' }).should('be.visible');
+    cy.findByRole('columnheader', { name: 'name' }).should('be.visible');
+    cy.findByRole('columnheader', { name: 'actions' }).should('be.visible');
     cy.get('a[href="/dashboard/chapters/1"]').should('be.visible');
     cy.get('a[href="/dashboard/chapters/new"]').should('be.visible');
     cy.get('a[href="/dashboard/chapters/1/edit"]').should('be.visible');

--- a/cypress/integration/dashboard/events.js
+++ b/cypress/integration/dashboard/events.js
@@ -9,8 +9,11 @@ describe('events dashboard', () => {
     cy.get('a[aria-current="page"]').should('have.text', 'Events');
   });
 
-  it('should have links to view, create and edit events', () => {
+  it('should have a table with links to view, create and edit events', () => {
     cy.visit('/dashboard/events');
+    cy.findByRole('table', { name: 'Events' }).should('be.visible');
+    cy.findByRole('columnheader', { name: 'name' }).should('be.visible');
+    cy.findByRole('columnheader', { name: 'actions' }).should('be.visible');
     cy.get('a[href="/dashboard/events/1"]').should('be.visible');
     cy.get('a[href="/dashboard/events/new"]').should('be.visible');
     cy.get('a[href="/dashboard/events/1/edit"]').should('be.visible');

--- a/cypress/integration/dashboard/venues.js
+++ b/cypress/integration/dashboard/venues.js
@@ -6,8 +6,11 @@ describe('venues dashboard', () => {
     cy.get('a[aria-current="page"]').should('have.text', 'Venues');
   });
 
-  it('should have links to view, create and edit venues', () => {
+  it('should have a table with links to view, create and edit venues', () => {
     cy.visit('/dashboard/venues');
+    cy.findByRole('table', { name: 'Venues' }).should('be.visible');
+    cy.findByRole('columnheader', { name: 'name' }).should('be.visible');
+    cy.findByRole('columnheader', { name: 'actions' }).should('be.visible');
     cy.get('a[href="/dashboard/venues/1"]').should('be.visible');
     cy.get('a[href="/dashboard/venues/new"]').should('be.visible');
     cy.get('a[href="/dashboard/venues/1/edit"]').should('be.visible');


### PR DESCRIPTION
Looking at the likes of https://www.w3.org/TR/wai-aria-practices/examples/grid/dataGrids.html it seems to be a standard a11y practice to add aria-labelledby to tables, so this adds them for all the existing dashboard tables.

Thanks to @Zeko369 for the neat library.  It's great that you can pass in the table props and it just works.