### PR TITLE
docs: add a basic guide to the tech stack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -414,7 +414,7 @@ The Chapter client uses the React framework [Next.js](https://nextjs.org/) with 
 
 The database and GraphQL schema are defined by files in _server/models_
 
-The resolvers for the GraphQL queries are defined in _server/controllers_
+The resolvers for the GraphQL queries are defined in _server/src/controllers_
 
 The client accesses the data via hooks defined in _client/src/generated/generated.tsx_
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@
 - [Running the Application](#running-the-application)
   - [Docker Mode](#running-the-application)
   - [Manual Mode](#running-the-application)
+- [Adding a New Feature](#adding-a-new-feature)
+  - [Where to find the code](#where-to-find-the-code)
 - [Frequently Asked Questions](#frequently-asked-questions)
 - [Server-side Technical Documentation](#server-side-technical-documentation)
   - [API Specification](#api-specification)
@@ -397,6 +399,28 @@ Once the app has started you should be able to pull up these URLs in your web br
 
 </details>
 
+# Adding a New Feature
+
+In order to understand where to start, it may help to familiarise yourself with our tech stack.  The key technologies we use are: PostgreSQL, TypeORM, Apollo, Express, React and Next.js.  For more details:
+
+<details><summary>Tech stack overview</summary>
+
+The database we use is [PostgreSQL](https://www.postgresql.org/), which we interact with via [TypeORM](https://typeorm.io/).  This ORM lets us define our database tables via classes whose properties map to columns in the database.  It makes use of decorators to specify the details of the db.  The [Express](https://expressjs.com/) server itself uses [Apollo GraphQL server](https://www.apollographql.com/docs/apollo-server/) to handle requests from the client. Apollo needs to know the GraphQL schema and we define that by using [TypeGraphQL](https://typegraphql.com/) since it lets us use decorators, much like TypeORM.  This means we can use both sets of decorators in the same Model class, keeping our database and GraphQL schema definitions together.
+
+The Chapter client uses the React framework [Next.js](https://nextjs.org/) with [Apollo Client](https://www.apollographql.com/docs/react/) for data fetching.  Since we are generating a GraphQL schema we can use [GraphQL Code Generator](https://www.graphql-code-generator.com/) to convert the schema into a set of TypeScript types and, more importantly, functions to get the data from the server.  As a result we know exactly what we're allowed to request from the server and the shape of the data it returns.
+</details>
+
+## Where to find the code
+
+The database and GraphQL schema are defined by files in _server/models_
+
+The resolvers for the GraphQL queries are defined in _server/controllers_
+
+The client accesses the data via hooks defined in _client/src/generated/generated.tsx_
+
+To create new hooks, modify _queries.ts_ and _mutations.ts_ files in _client/src/modules/**/graphql_
+
+Pages are defined according to [Next.js's routing](https://nextjs.org/docs/routing/dynamic-routes) e.g. _client/src/pages/dashboard/events/\[id\]/edit.tsx_ handles pages like _/dashboard/events/1/edit_
 # Frequently Asked Questions
 
 <details><summary>What do we need help with right now?</summary>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -401,7 +401,7 @@ Once the app has started you should be able to pull up these URLs in your web br
 
 # Adding a New Feature
 
-In order to understand where to start, it may help to familiarise yourself with our tech stack.  The key technologies we use are: PostgreSQL, TypeORM, Apollo, Express, React and Next.js.  For more details:
+In order to understand where to start, it may help to familiarize yourself with our [tech stack](https://github.com/freeCodeCamp/chapter/blob/main/README.md#tech-stack). For more details:
 
 <details><summary>Tech stack overview</summary>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -413,7 +413,7 @@ The Chapter client uses the React framework [Next.js](https://nextjs.org/) with 
 
 ## Where to find the code
 
-The database and GraphQL schema are defined by files in _server/models_
+The database and GraphQL schema are defined by files in _server/src/models_
 
 The resolvers for the GraphQL queries are defined in _server/src/controllers_
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@
   - [Manual Mode](#running-the-application)
 - [Adding a New Feature](#adding-a-new-feature)
   - [Where to find the code](#where-to-find-the-code)
+  - [Where to find the issues](#where-to-find-the-issues)
 - [Frequently Asked Questions](#frequently-asked-questions)
 - [Server-side Technical Documentation](#server-side-technical-documentation)
   - [API Specification](#api-specification)
@@ -421,6 +422,11 @@ The client accesses the data via hooks defined in _client/src/generated/generate
 To create new hooks, modify _queries.ts_ and _mutations.ts_ files in _client/src/modules/**/graphql_
 
 Pages are defined according to [Next.js's routing](https://nextjs.org/docs/routing/dynamic-routes) e.g. _client/src/pages/dashboard/events/\[id\]/edit.tsx_ handles pages like _/dashboard/events/1/edit_
+
+## Where to find the issues
+
+[This](https://github.com/freeCodeCamp/chapter/contribute) is a good place to go if you are looking to get started.
+
 # Frequently Asked Questions
 
 <details><summary>What do we need help with right now?</summary>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ We are using the following tools:
   * [sinon](https://sinonjs.org/)
   * [sinon-chai](https://github.com/domenic/sinon-chai)
 
+For more information and a guide to working on features, go to the [contributing docs](/CONTRIBUTING.md#adding-a-new-feature).
 ## User Stories
 
 ### MVP


### PR DESCRIPTION
The hope is that this should help with onboarding new contributors as well as reminding longer standing ones.  One of the biggest barriers I had to contributing was figuring out what the various parts of the tech stack were responsible for and how they interacted.

This should help people get up to speed quickly so they can actually make stuff.

If https://github.com/freeCodeCamp/chapter/pull/685 goes in, the directories will need updating to reflect those changes.