### PR TITLE
chore: update renovate to group jest deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,10 @@
       "matchCurrentVersion": "!/^0/",
       "automerge": true,
       "automergeType": "branch"
+    },
+    {
+      "groupName": "Jest and ts-jest",
+      "matchPackageNames": ["jest", "ts-jest", "@types/jest"]
     }
   ],
   "rangeStrategy": "pin"


### PR DESCRIPTION
This should avoid conflicted PRs like: https://github.com/freeCodeCamp/chapter/pull/689 and https://github.com/freeCodeCamp/chapter/pull/686/
