### PR TITLE
changes to event/[id] and dashoard/event/[id] pages to show RSVP count of Event

### DIFF
--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -86,7 +86,12 @@ export const EventPage: NextPage = () => {
 
       <Box p="2" borderWidth="1px" borderRadius="lg" mt="2">
         <DataTable
-          title="RSVPs:"
+          title={
+            'RSVPs: ' +
+            (data.event.rsvps
+              ? data.event.rsvps.filter((r) => !r.on_waitlist).length
+              : '0')
+          }
           data={data.event.rsvps.filter((r) => !r.on_waitlist)}
           keys={['id', 'user', 'ops'] as const}
           emptyText="No users"
@@ -102,7 +107,12 @@ export const EventPage: NextPage = () => {
         />
 
         <DataTable
-          title="Waitlist:"
+          title={
+            'Waitlist: ' +
+            (data.event.rsvps
+              ? data.event.rsvps.filter((r) => r.on_waitlist).length
+              : 0)
+          }
           data={data.event.rsvps.filter((r) => r.on_waitlist)}
           keys={['id', 'user', 'ops'] as const}
           emptyText="No users"

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -116,8 +116,10 @@ export const EventPage: NextPage = () => {
         </Link>
       </Heading>
       <Text>{data.event.description}</Text>
-
-      <Heading>RSVPs:</Heading>
+      <VStack align="start">
+        {rsvps && <Heading>RSVPs:{rsvps.length}</Heading>}
+        {waitlist && <Heading>Waitlist:{waitlist.length}</Heading>}
+      </VStack>
       {userRsvped === 'rsvp' ? (
         <HStack>
           <Heading>You&lsquo;ve RSVPed to this event</Heading>


### PR DESCRIPTION
1. Updated the eventPage.tsx to show the count of rsvp
2. updated EventPage.tsx to show the rsvp count

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #101 

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

1. eventPage.tsx Added VStack and then added count for RSVP heading and Waitlist heading
2. EventPage.tsx if rsvp data exists then show the count of the rsvp data beside the heading .
