### PR TITLE
fix: require npm 7 in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,8 @@ tasks:
       echo 'export IS_DOCKER=false' >> ~/.bashrc &&
       export IS_DOCKER=false &&
       echo NEXT_PUBLIC_APOLLO_SERVER=$(gp url 5000) > client/.env.development.local &&
-      nvm install lts/fermium && nvm alias default lts/fermium
+      nvm install lts/fermium && nvm alias default lts/fermium &&
+      npm i -g npm@7
     # the rest, environment variables, installation and db setup, get persisted,
     # so we can save time and use init:
     init: |


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

npm 6 does not handle the lockfile correctly any more, so we need to require version 7.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
