### PR TITLE
docs: Update CONTRIBUTING.md to require npm 7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,7 +322,7 @@ You have successfully created a PR. Congratulations! :tada:
 Ensure the Node.js tools are installed:
 
 * Node.js 14 or greater - `node --version` and the output should be like **v14**.16.0
-* npm 6 or greater - `npm --version` and the output should be like **6**.14.11
+* npm 7 or greater - `npm --version` and the output should be like **7**.23.0
 
 Run `npm i` to install all of the necessary dependencies.
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Update a line in the docs that says npm 6 is required.

We now require npm 7 to work around a lockVersion 1 bug mentioned in https://github.com/freeCodeCamp/chapter/issues/705

Closes #705 

@ojeytonwilliams I know you updated another spot in the docs, but this was a different spot.  Also, I believe you made changes to encourage / force npm 7, so I think that will workaround #705.
