### PR TITLE
Added functionality to send Email to selected Group of People

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -4,12 +4,14 @@ export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];
 };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
+  {
+    [SubKey in K]?: Maybe<T[SubKey]>;
+  };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
+  {
+    [SubKey in K]: Maybe<T[SubKey]>;
+  };
 const defaultOptions = {};
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -729,6 +731,7 @@ export type DeleteRsvpMutation = {
 
 export type SendEventInviteMutationVariables = Exact<{
   id: Scalars['Int'];
+  emailGroups?: Maybe<Array<string>>;
 }>;
 
 export type SendEventInviteMutation = {
@@ -1892,8 +1895,8 @@ export type DeleteRsvpMutationOptions = Apollo.BaseMutationOptions<
   DeleteRsvpMutationVariables
 >;
 export const SendEventInviteDocument = gql`
-  mutation sendEventInvite($id: Int!) {
-    sendEventInvite(id: $id)
+  mutation sendEventInvite($id: Int!, $emailGroups: [String!]) {
+    sendEventInvite(id: $id, emailGroups: $emailGroups)
   }
 `;
 export type SendEventInviteMutationFn = Apollo.MutationFunction<

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -4,14 +4,12 @@ export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K];
 };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
-  {
-    [SubKey in K]?: Maybe<T[SubKey]>;
-  };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
-  {
-    [SubKey in K]: Maybe<T[SubKey]>;
-  };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
 const defaultOptions = {};
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -2,6 +2,7 @@ import { Button, HStack } from '@chakra-ui/react';
 import { useConfirm, useConfirmDelete } from 'chakra-confirm';
 import { LinkButton } from 'chakra-next-link';
 import React, { useMemo } from 'react';
+import { useDisclosure } from '@chakra-ui/hooks';
 
 import { EVENT, EVENTS } from '../graphql/queries';
 import {
@@ -9,6 +10,7 @@ import {
   useCancelEventMutation,
   useDeleteEventMutation,
 } from 'generated/graphql';
+import SendEmailModal from './SendEmailModal';
 
 interface ActionsProps {
   event: Pick<Event, 'id' | 'canceled'>;
@@ -17,6 +19,7 @@ interface ActionsProps {
 }
 
 const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const [cancel] = useCancelEventMutation();
   const [remove] = useDeleteEventMutation();
 
@@ -53,6 +56,9 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
     }
   };
 
+  const clickEmailAttendees = () => {
+    onOpen();
+  };
   return (
     <HStack spacing="1">
       <Button size="sm" colorScheme="red" onClick={clickDelete}>
@@ -70,6 +76,10 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
           Cancel
         </Button>
       )}
+      <Button size="sm" colorScheme="blue" onClick={clickEmailAttendees}>
+        Email Attendees
+      </Button>
+      <SendEmailModal onClose={onClose} isOpen={isOpen} eventId={event.id} />
     </HStack>
   );
 };

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -1,16 +1,15 @@
+import { useDisclosure } from '@chakra-ui/hooks';
 import { Button, HStack } from '@chakra-ui/react';
 import { useConfirm, useConfirmDelete } from 'chakra-confirm';
 import { LinkButton } from 'chakra-next-link';
 import React, { useMemo } from 'react';
-import { useDisclosure } from '@chakra-ui/hooks';
-
 import { EVENT, EVENTS } from '../graphql/queries';
+import SendEmailModal from './SendEmailModal';
 import {
   Event,
   useCancelEventMutation,
   useDeleteEventMutation,
 } from 'generated/graphql';
-import SendEmailModal from './SendEmailModal';
 
 interface ActionsProps {
   event: Pick<Event, 'id' | 'canceled'>;

--- a/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
+++ b/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
@@ -34,7 +34,7 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
   const checkAtLeastOne = () => {
     return getValues('confirmed') ||
       getValues('on_waitlist') ||
-      getValues('interested')
+      getValues('canceled')
       ? true
       : 'Please tell me if this is too hard.';
   };
@@ -67,6 +67,7 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
             <Stack spacing={10} direction="row">
               <Checkbox
                 {...register('confirmed', { validate: checkAtLeastOne })}
+                defaultChecked
               >
                 Confirmed
               </Checkbox>
@@ -76,10 +77,9 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
                 Waitlist
               </Checkbox>
               <Checkbox
-                {...register('interested', { validate: checkAtLeastOne })}
-                defaultChecked
+                {...register('canceled', { validate: checkAtLeastOne })}
               >
-                Interested
+                Cancelled
               </Checkbox>
             </Stack>
           </form>

--- a/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
+++ b/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
@@ -1,0 +1,109 @@
+import { Button } from '@chakra-ui/button';
+import { Checkbox } from '@chakra-ui/checkbox';
+import { Stack } from '@chakra-ui/layout';
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalFooter,
+  ModalOverlay,
+} from '@chakra-ui/modal';
+import { Alert, AlertIcon, AlertDescription } from '@chakra-ui/react';
+import { useSendEventInviteMutation } from 'generated/graphql';
+import { useForm } from 'react-hook-form';
+
+interface SendEmailModalProps {
+  onClose: () => any;
+  isOpen: boolean;
+  eventId: number;
+}
+const SendEmailModal: React.FC<SendEmailModalProps> = ({
+  onClose,
+  isOpen,
+  eventId,
+}) => {
+  const {
+    register,
+    getValues,
+    handleSubmit,
+    formState: { errors },
+  } = useForm();
+
+  const checkAtLeastOne = () => {
+    return getValues('confirmed') ||
+      getValues('on_waitlist') ||
+      getValues('interested')
+      ? true
+      : 'Please tell me if this is too hard.';
+  };
+
+  const [publish] = useSendEventInviteMutation();
+  const onSubmit = (data: any) => {
+    console.log(data);
+    const emailGroups = [];
+    for (let key of Object.keys(data)) {
+      if (data[key]) {
+        emailGroups.push(key);
+      }
+    }
+    console.log(emailGroups);
+
+    publish({ variables: { id: eventId, emailGroups: emailGroups } });
+    onClose();
+  };
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Send Email to Attendees</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <form id="sendemail" onSubmit={handleSubmit(onSubmit)}>
+            <label htmlFor="attendees">
+              Who do you want to send the email to?
+            </label>
+            <Stack spacing={10} direction="row">
+              <Checkbox
+                {...register('confirmed', { validate: checkAtLeastOne })}
+              >
+                Confirmed
+              </Checkbox>
+              <Checkbox
+                {...register('on_waitlist', { validate: checkAtLeastOne })}
+              >
+                Waitlist
+              </Checkbox>
+              <Checkbox
+                {...register('interested', { validate: checkAtLeastOne })}
+                defaultChecked
+              >
+                Interested
+              </Checkbox>
+            </Stack>
+          </form>
+          {Object.keys(errors).length == 3 && (
+            <Alert status="error">
+              <AlertIcon />
+              <AlertDescription>
+                Please select atleast one checkbox
+              </AlertDescription>
+            </Alert>
+          )}
+        </ModalBody>
+
+        <ModalFooter>
+          <Button colorScheme="teal" mr={3} onClick={onClose}>
+            Close
+          </Button>
+          <Button type="submit" variant="solid" form="sendemail">
+            Send Email
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default SendEmailModal;

--- a/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
+++ b/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
@@ -92,7 +92,7 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
             <Alert status="error">
               <AlertIcon />
               <AlertDescription>
-                Please select atleast one checkbox
+                Please select at least one checkbox
               </AlertDescription>
             </Alert>
           )}

--- a/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
+++ b/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
@@ -11,9 +11,9 @@ import {
   ModalOverlay,
 } from '@chakra-ui/modal';
 import { Alert, AlertIcon, AlertDescription } from '@chakra-ui/react';
+import React from 'react';
 import { useForm } from 'react-hook-form';
 import { useSendEventInviteMutation } from 'generated/graphql';
-
 interface SendEmailModalProps {
   onClose: () => any;
   isOpen: boolean;

--- a/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
+++ b/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
@@ -19,6 +19,11 @@ interface SendEmailModalProps {
   isOpen: boolean;
   eventId: number;
 }
+interface FormInputs {
+  confirmed: boolean;
+  on_waitlist: boolean;
+  canceled: boolean;
+}
 const SendEmailModal: React.FC<SendEmailModalProps> = ({
   onClose,
   isOpen,
@@ -29,27 +34,28 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
     getValues,
     handleSubmit,
     formState: { errors },
-  } = useForm();
+  } = useForm<FormInputs>({ defaultValues: { confirmed: true } });
 
-  const checkAtLeastOne = () => {
-    return getValues('confirmed') ||
+  const atLeastOneChecked = () => {
+    return (
+      getValues('confirmed') ||
       getValues('on_waitlist') ||
       getValues('canceled')
-      ? true
-      : 'Please tell me if this is too hard.';
+    );
   };
 
   const [publish] = useSendEventInviteMutation();
-  const onSubmit = (data: any) => {
-    console.log(data);
+  const onSubmit = (data: FormInputs) => {
     const emailGroups = [];
-    for (const key of Object.keys(data)) {
-      if (data[key]) {
-        emailGroups.push(key);
-      }
+    if (data.confirmed) {
+      emailGroups.push('confirmed');
     }
-    console.log(emailGroups);
-
+    if (data.canceled) {
+      emailGroups.push('canceled');
+    }
+    if (data.on_waitlist) {
+      emailGroups.push('on_waitlist');
+    }
     publish({ variables: { id: eventId, emailGroups: emailGroups } });
     onClose();
   };
@@ -66,18 +72,17 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
             </label>
             <Stack spacing={10} direction="row">
               <Checkbox
-                {...register('confirmed', { validate: checkAtLeastOne })}
-                defaultChecked
+                {...register('confirmed', { validate: atLeastOneChecked })}
               >
                 Confirmed
               </Checkbox>
               <Checkbox
-                {...register('on_waitlist', { validate: checkAtLeastOne })}
+                {...register('on_waitlist', { validate: atLeastOneChecked })}
               >
                 Waitlist
               </Checkbox>
               <Checkbox
-                {...register('canceled', { validate: checkAtLeastOne })}
+                {...register('canceled', { validate: atLeastOneChecked })}
               >
                 Cancelled
               </Checkbox>

--- a/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
+++ b/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
@@ -11,8 +11,8 @@ import {
   ModalOverlay,
 } from '@chakra-ui/modal';
 import { Alert, AlertIcon, AlertDescription } from '@chakra-ui/react';
-import { useSendEventInviteMutation } from 'generated/graphql';
 import { useForm } from 'react-hook-form';
+import { useSendEventInviteMutation } from 'generated/graphql';
 
 interface SendEmailModalProps {
   onClose: () => any;
@@ -43,7 +43,7 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
   const onSubmit = (data: any) => {
     console.log(data);
     const emailGroups = [];
-    for (let key of Object.keys(data)) {
+    for (const key of Object.keys(data)) {
       if (data[key]) {
         emailGroups.push(key);
       }

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -305,19 +305,30 @@ ${venue.postal_code} <br>
     }
     if (emailGroups.includes('on_waitlist')) {
       const waitlistUsers: string[] = event.rsvps
-        .filter((rsvp) => rsvp.on_waitlist)
+        .filter((rsvp) => rsvp.on_waitlist && rsvp.interested)
         .map(({ user }) => user.email);
       addresses.push(...waitlistUsers);
     }
     if (emailGroups.includes('confirmed')) {
       const confirmedUsers: string[] = event.rsvps
-        .filter((rsvp) => !rsvp.on_waitlist)
+        .filter(
+          (rsvp) => !rsvp.on_waitlist && !rsvp.canceled && rsvp.interested,
+        )
+        .map(({ user }) => user.email);
+      addresses.push(...confirmedUsers);
+    }
+    if (emailGroups.includes('canceled')) {
+      const confirmedUsers: string[] = event.rsvps
+        .filter((rsvp) => rsvp.canceled && rsvp.interested)
         .map(({ user }) => user.email);
       addresses.push(...confirmedUsers);
     }
 
     console.log(addresses);
 
+    if (!addresses.length) {
+      return true;
+    }
     const subject = `Invitation to ${event.name}.`;
 
     const chapterURL = `${process.env.CLIENT_LOCATION}/chapters/${event.chapter.id}`;

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -279,7 +279,7 @@ ${venue.postal_code} <br>
       nullable: true,
       defaultValue: ['interested'],
     })
-    emailGroups: Array<string>,
+    emailGroups: Array<'confirmed' | 'on_waitlist' | 'canceled' | 'interested'>,
   ) {
     const event = await Event.findOne(id, {
       relations: [
@@ -323,8 +323,6 @@ ${venue.postal_code} <br>
         .map(({ user }) => user.email);
       addresses.push(...confirmedUsers);
     }
-
-    console.log(addresses);
 
     if (!addresses.length) {
       return true;


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #99 

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

i. Server

	1. resolver.ts
		Modified the sendEventInvite Resolver to take an
		emailGroup as optional argument.
ii. Client
	1. Added New argument in method definitions in graphql.tsx
	2. Created a new Modal component to show the checkboxes for
	   selecting the group
	3. Added a button in Actions components to show the Modal
	   component
