### PR TITLE
test: check interested users get invited

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -520,6 +520,7 @@ export type ChapterUsersQuery = {
         __typename?: 'Chapter';
         users: Array<{
           __typename?: 'UserChapterRole';
+          interested: boolean;
           user: { __typename?: 'User'; name: string; email: string };
         }>;
       }
@@ -1174,6 +1175,7 @@ export const ChapterUsersDocument = gql`
           name
           email
         }
+        interested
       }
     }
   }

--- a/client/src/modules/chapters/graphql/queries.ts
+++ b/client/src/modules/chapters/graphql/queries.ts
@@ -35,6 +35,7 @@ export const CHAPTER_USERS = gql`
           name
           email
         }
+        interested
       }
     }
   }

--- a/cypress/integration/dashboard/events.js
+++ b/cypress/integration/dashboard/events.js
@@ -33,7 +33,7 @@ describe('events dashboard', () => {
     cy.get('a[href="/dashboard/events/1/edit"]').should('be.visible');
   });
 
-  it('lets a user create an event', () => {
+  it('emails interested users when an event is created', () => {
     createEvent();
     cy.location('pathname').should('match', /^\/dashboard\/events\/\d/);
     // confirm that the test data appears in the new event
@@ -47,6 +47,21 @@ describe('events dashboard', () => {
     // check that the title we selected is in the event we created.
     cy.get('@venueTitle').then((venueTitle) => {
       cy.contains(venueTitle);
+    });
+
+    // check that the interested users have been emailed
+    cy.waitUntilMail('allMail');
+
+    cy.get('@allMail').mhFirst().as('invitation');
+    // TODO: select chapter during event creation and use that here (much like @venueTitle
+    // ) i.e. remove the hardcoding.
+    cy.getChapterMembers(1).then((members) => {
+      const subscriberEmails = members
+        .filter(({ interested }) => interested)
+        .map(({ user: { email } }) => email);
+      cy.get('@invitation')
+        .mhGetRecipients()
+        .should('have.members', subscriberEmails);
     });
   });
 

--- a/cypress/integration/dashboard/events.js
+++ b/cypress/integration/dashboard/events.js
@@ -12,6 +12,7 @@ const testEvent = {
 
 describe('events dashboard', () => {
   beforeEach(() => {
+    cy.exec('npm run db:reset');
     cy.login();
     cy.mhDeleteAll();
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -94,6 +94,29 @@ Cypress.Commands.add('interceptGQL', (operationName) => {
   });
 });
 
+Cypress.Commands.add('getChapterMembers', (chapterId) => {
+  const chapterQuery = {
+    operationName: 'chapterUsers',
+    variables: {
+      id: chapterId,
+    },
+    query: `query chapterUsers($id: Int!) {
+      chapter(id: $id) {
+        users {
+          user {
+            name
+            email
+          }
+          interested
+        }
+      }
+    }`,
+  };
+  return cy
+    .request('POST', 'http://localhost:5000/graphql', chapterQuery)
+    .then((response) => response.body.data.chapter.users);
+});
+
 Cypress.Commands.add('waitUntilMail', (alias) => {
   cy.waitUntil(() =>
     cy


### PR DESCRIPTION
I had to change the `chapterUsers` query so that it returned _user_chapter_role.interested_ as the tests needed to confirm that only those users gets emailed.  Changing a query for testing purposes doesn't feel great, but we'll need to revisit the GraphQL server when we audit for security and make sure only users with appropriate permissions can make queries.

That is to say, we might need to change things, but not yet.