### PR TITLE
fix: relax renovate to stop it pinning engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "doc": "docs"
   },
   "engines": {
-    "node": "14.18.0",
-    "npm": "7.24.2"
+    "node": "^14.18.0",
+    "npm": "^7.24.2"
   },
   "scripts": {
     "typeorm": "cd server && node_modules/.bin/typeorm",

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,5 @@
       "groupName": "Jest and ts-jest",
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"]
     }
-  ],
-  "rangeStrategy": "pin"
+  ]
 }


### PR DESCRIPTION
Right now renovate pins everything, but pinning `engines` to specific node versions is annoying since node updates often. It should not matter if a dev uses a different minor version locally.

This might not pin exactly as we want, but we could be lucky and the defaults could Just Work.