### PR TITLE
test: DRY email attendees tests

### DIFF
--- a/cypress/integration/dashboard/events.js
+++ b/cypress/integration/dashboard/events.js
@@ -139,6 +139,7 @@ describe('events dashboard', () => {
     cy.waitUntilMail('allMail');
     cy.get('@allMail').mhFirst().as('emails');
 
+    // TODO: can we avoid getting this multiple times?
     cy.getRSVPs(1).then((rsvps) => {
       const expectedEmails = rsvps
         .filter(filterCallback)


### PR DESCRIPTION
This should make the event dashboard a little less messy and easier to read.