### PR TITLE
refactor: move interested flag to UserEventRole

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -2489,22 +2489,6 @@
             "deprecationReason": null
           },
           {
-            "name": "interested",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "on_waitlist",
             "description": null,
             "args": [],
@@ -3834,6 +3818,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subscribed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -284,7 +284,6 @@ export type Rsvp = {
   date: Scalars['DateTime'];
   event: Event;
   id: Scalars['Int'];
-  interested: Scalars['Boolean'];
   on_waitlist: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
   user: User;
@@ -399,6 +398,7 @@ export type UserEventRole = {
   event_id: Scalars['Int'];
   id: Scalars['Int'];
   role_name: Scalars['String'];
+  subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
   user: User;
   user_id: Scalars['Int'];

--- a/server/db/generator/factories/rsvps.factory.ts
+++ b/server/db/generator/factories/rsvps.factory.ts
@@ -1,14 +1,21 @@
 import { date } from 'faker';
 import { random, randomItems } from '../lib/random';
-import { Event, User, Rsvp } from 'src/models';
+import { makeBooleanIterator } from '../lib/util';
+import { Event, User, Rsvp, UserEventRole } from 'src/models';
 
 const createRsvps = async (events: Event[], users: User[]): Promise<Rsvp[]> => {
   const rsvps: Rsvp[] = [];
+  const userEventRoles: UserEventRole[] = [];
 
+  const eventIterator = makeBooleanIterator();
   for (const event of events) {
     const eventUsers = randomItems(users, users.length / 2);
     const numberWaiting = 1 + random(eventUsers.length - 2);
     const numberCanceled = 1 + random(eventUsers.length - numberWaiting - 1);
+
+    // makes sure half of each event's users are organisers, but
+    // alternates which half.
+    const organizerIterator = makeBooleanIterator(eventIterator.next().value);
 
     for (let i = 0; i < eventUsers.length; i++) {
       const on_waitlist = i < numberWaiting;
@@ -22,7 +29,25 @@ const createRsvps = async (events: Event[], users: User[]): Promise<Rsvp[]> => {
         confirmed_at: new Date(),
       });
 
+      const attendee = new UserEventRole({
+        userId: eventUsers[i].id,
+        eventId: event.id,
+        roleName: 'attendee',
+        subscribed: true, // TODO: have some unsubscribed users
+      });
+
+      if (organizerIterator.next().value) {
+        const organizer = new UserEventRole({
+          userId: eventUsers[i].id,
+          eventId: event.id,
+          roleName: 'organizer',
+          subscribed: true, // TODO: even organizers may wish to opt out of emails
+        });
+        userEventRoles.push(organizer);
+      }
+
       rsvps.push(rsvp);
+      userEventRoles.push(attendee);
     }
   }
 
@@ -31,6 +56,15 @@ const createRsvps = async (events: Event[], users: User[]): Promise<Rsvp[]> => {
   } catch (e) {
     console.error(e);
     throw new Error('Error seeding rsvps');
+  }
+
+  try {
+    await Promise.all(
+      userEventRoles.map((userEventRole) => userEventRole.save()),
+    );
+  } catch (e) {
+    console.error(e);
+    throw new Error('Error seeding user-event-roles');
   }
 
   return rsvps;

--- a/server/db/generator/index.ts
+++ b/server/db/generator/index.ts
@@ -21,7 +21,7 @@ import setupRoles from './setupRoles';
   const events = await createEvents(chapters, venues, sponsors);
 
   await createRsvps(events, users);
-  await setupRoles(user, users, chapters, events);
+  await setupRoles(user, users, chapters);
 
   await connection.close();
 })();

--- a/server/db/generator/setupRoles.ts
+++ b/server/db/generator/setupRoles.ts
@@ -1,21 +1,12 @@
 import { makeBooleanIterator } from './lib/util';
-import {
-  User,
-  Chapter,
-  UserChapterRole,
-  UserBan,
-  Event,
-  UserEventRole,
-} from 'src/models';
+import { User, Chapter, UserChapterRole, UserBan } from 'src/models';
 
 const setupRoles = async (
   admin: User,
   users: User[],
   chapters: Chapter[],
-  events: Event[],
 ): Promise<void> => {
   const ucr: (UserChapterRole | UserBan)[] = [];
-  const uer: UserEventRole[] = [];
 
   const chapterIterator = makeBooleanIterator();
   for (const chapter of chapters) {
@@ -47,34 +38,11 @@ const setupRoles = async (
     ucr.push(ban);
   }
 
-  const eventIterator = makeBooleanIterator();
-  for (const event of events) {
-    // makes sure half of each event's users are organisers, but
-    // alternates which half.
-    const organizerIterator = makeBooleanIterator(eventIterator.next().value);
-    for (const user of users) {
-      if (organizerIterator.next().value) {
-        const userEventRole = new UserEventRole({
-          eventId: event.id,
-          userId: user.id,
-          roleName: 'organizer',
-        });
-        uer.push(userEventRole);
-      }
-    }
-  }
-
   try {
     await Promise.all(ucr.map((user) => user.save()));
   } catch (e) {
     console.error(e);
     throw new Error('Error seeding user-chapter-roles');
-  }
-  try {
-    await Promise.all(uer.map((user) => user.save()));
-  } catch (e) {
-    console.error(e);
-    throw new Error('Error seeding user-event-roles');
   }
 };
 

--- a/server/src/models/Rsvp.ts
+++ b/server/src/models/Rsvp.ts
@@ -37,20 +37,11 @@ export class Rsvp extends BaseModel {
   @Column({ nullable: false })
   canceled: boolean;
 
-  /*
-    This indicates whether he use wants to receive notifications about the event they RSVP'd to.
-    Defaults to True when the RSVP is created
-   */
-  @Field(() => Boolean)
-  @Column({ nullable: false })
-  interested: boolean;
-
   constructor(params: {
     date: Date;
     on_waitlist: boolean;
     event: Event;
     user: User;
-    interested?: boolean;
     canceled?: boolean;
     confirmed_at: Date | null;
   }) {
@@ -61,7 +52,6 @@ export class Rsvp extends BaseModel {
         on_waitlist,
         event,
         user,
-        interested = true,
         confirmed_at,
         canceled = false,
       } = params;
@@ -70,7 +60,6 @@ export class Rsvp extends BaseModel {
       this.event = event;
       this.user = user;
       this.canceled = canceled;
-      this.interested = interested;
       this.confirmed_at = confirmed_at;
     }
   }

--- a/server/src/models/UserEventRole.ts
+++ b/server/src/models/UserEventRole.ts
@@ -1,12 +1,12 @@
 import { Field, Int, ObjectType } from 'type-graphql';
-import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { BaseModel } from './BaseModel';
 import { Event } from './Event';
 import { User } from './User';
 
 // TODO: Make this enum, similarly to UserChapterRole
 
-type EventRoles = 'organizer';
+type EventRoles = 'organizer' | 'attendee';
 
 @ObjectType()
 @Entity({ name: 'user_event_roles' })
@@ -33,16 +33,22 @@ export class UserEventRole extends BaseModel {
   @PrimaryColumn({ type: 'text' })
   role_name!: EventRoles;
 
+  @Field(() => Boolean)
+  @Column({ nullable: false })
+  subscribed!: boolean;
+
   constructor(params: {
     userId: number;
     eventId: number;
     roleName: EventRoles;
+    subscribed: boolean;
   }) {
     super();
     if (params) {
       this.user_id = params.userId;
       this.event_id = params.eventId;
       this.role_name = params.roleName;
+      this.subscribed = params.subscribed;
     }
   }
 }


### PR DESCRIPTION
Instead of RSVP.interest, this makes it the responsibility of
UserEventRole

This makes RSVP responsible for information about the event (is a user
going, canceled etc.), but leaves information about the app (roles and
settings) in UserEventRole
