### PR TITLE
fix: disable CodeSee on Gitpod

### DIFF
--- a/client/babel.config.js
+++ b/client/babel.config.js
@@ -3,7 +3,10 @@ var config = {
   plugins: [],
 };
 
-if (process.env.NODE_ENV === 'development') {
+if (
+  process.env.NODE_ENV === 'development' &&
+  !process.env.GITPOD_WORKSPACE_URL
+) {
   config.plugins.push(['@codesee/instrument', { hosted: true }]);
 }
 


### PR DESCRIPTION
CodeSee causes CORS errors in Gitpod, so needs to be disabled until those are resolved.
