### PR TITLE
Docs: Define "role" in the README terminology table

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ To better communicate and more easily build an API and UI, the current contribut
 | _organization_ | a non-profit with multiple _chapters_ | Women Who Code at the sub-domain: `chapter.womenwhocode.org` |
 | _chapter_      | a container for _events_ and _users_  | Women Who Code - New York City |
 | _event_ | a meeting with a specific location and time to which _users_ can RSVP | Coffee And Code - BistroOne, New York City, NY - April 9, 2020 |
+| _role_ | a named definition of permissions to be attached to _users_ for the purpose of granting authorization | Owner, Adminstrator, Organizer, Member |
 | _user_ | an authenticated _user_ who is authorized based on their _role(s)_ | Sally Gold - SallyG@example.com |
 | _visitor_ | an non-authenticated web browser session with view-only access to public content | Anonymous Web Browser Client |
 | _owner_ | the _role_ of a _user_ who can configure the [**_Chapter_** application](https://github.com/freeCodeCamp/chapter/) _instance_ and manage _administrators_ for an entire _organization_ | Women Who Code - Global IT |


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Defining the term "_role_" to give more explicit purpose to tables like _user_chapter_role_ and _user_event_role_ and _user_instance_role_

This should help avoid mixing authorization and non-authorization fields within these tables.

For example, we want to avoid having _user_ defined details, like their _event_ or _chapter_ subscription preferences, mixed in with "_role_" tables because it could lead to a situation where CRUD grant on a table is intended to be limited to a specific field, but is then manipulated to escalate _roles_.

Closes nothing.
