### PR TITLE
test/AuthToken  

### DIFF
--- a/server/src/services/AuthToken.ts
+++ b/server/src/services/AuthToken.ts
@@ -11,7 +11,7 @@ class AuthToken {
   public generateToken(email: string) {
     const code = AuthToken.generateCode();
     const token = jwt.sign({ email, code }, this.secret, {
-      expiresIn: '120min',
+      expiresIn: '2h',
     });
 
     return { token, code };

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -1,10 +1,10 @@
 import assert from 'assert';
 import chai, { expect } from 'chai';
+import jwt from 'jsonwebtoken';
 import { stub, restore } from 'sinon';
 import sinonChai from 'sinon-chai';
 import { getConfig } from 'src/config';
 import { authTokenService } from 'src/services/AuthToken';
-import jwt from 'jsonwebtoken';
 
 chai.use(sinonChai);
 

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -1,12 +1,8 @@
-import assert from 'assert';
-import chai, { expect } from 'chai';
+import { assert, expect } from 'chai';
 import jwt from 'jsonwebtoken';
 import { stub, restore } from 'sinon';
-import sinonChai from 'sinon-chai';
 import { getConfig } from 'src/config';
 import { authTokenService } from 'src/services/AuthToken';
-
-chai.use(sinonChai);
 
 beforeEach(() => {
   stub(console, 'warn');

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -21,6 +21,7 @@ afterEach(() => {
 const secret = getConfig('JWT_SECRET');
 const email = 'joe.smith@example.com';
 const { token, code } = authTokenService.generateToken(email);
+
 const isTokenExpired = (token: string): number => {
   const { exp } = jwt.decode(token) as {
     exp: number;
@@ -28,7 +29,9 @@ const isTokenExpired = (token: string): number => {
   return exp;
 };
 
-const now = Date.now() / 1000;
+const nowInSeconds = Date.now() / 1000;
+const expTimeInSeconds = isTokenExpired(token);
+const ninetyMinsInSeconds = 90 * 60;
 
 // Tests
 describe('AuthToken Setup', () => {
@@ -48,6 +51,7 @@ describe('Generation of Code and Token', () => {
   });
 
   it('The token should not have expired yet', () => {
-    expect(now).to.be.below(isTokenExpired(token));
+    expect(nowInSeconds).to.be.below(expTimeInSeconds);
+    expect(expTimeInSeconds).to.be.above(nowInSeconds + ninetyMinsInSeconds);
   });
 });

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -1,9 +1,12 @@
 import assert from 'assert';
-//import chai, { expect } from 'chai';
-import chai from 'chai';
+import chai, { expect } from 'chai';
+//import chai from 'chai';
 import { stub, restore } from 'sinon';
 import sinonChai from 'sinon-chai';
-//import { authTokenService } from 'src/services/AuthToken';
+import { authTokenService } from 'src/services/AuthToken';
+import { getConfig } from 'src/config';
+//import { User } from 'src/models';
+import jwt from 'jsonwebtoken';
 
 chai.use(sinonChai);
 
@@ -17,10 +20,37 @@ afterEach(() => {
 });
 
 // Setup
+//const mock_secret = 'SetThisTo32orMoreRandomCharacters';
+const secret = getConfig('JWT_SECRET');
+const email = 'joe.smith@example.com';
+const { token, code } = authTokenService.generateToken(email);
+const isTokenExpired = (token: string): number => {
+  const { exp } = jwt.decode(token) as {
+    exp: number;
+  };
+  return exp;
+};
 
-describe('First test', () => {
-  it('Should fail test', () => {
-    const tokenNum = '123456789';
-    assert.equal(tokenNum, 'abc');
+const now = Date.now() / 1000;
+
+// Tests
+describe('AuthToken Setup', () => {
+  it('Secret should be 32 or more characters.', () => {
+    expect(secret).to.have.lengthOf.above(31);
+  });
+});
+
+describe('Generation of Token', () => {
+  it('The token and code should not be null', () => {
+    assert.notEqual(token, null);
+    assert.notEqual(code, null);
+  });
+
+  it('The code should have a length of 8 numbers', () => {
+    expect(code).to.have.lengthOf(8);
+  });
+
+  it('The token had not expired yet', () => {
+    expect(now).to.be.below(isTokenExpired(token));
   });
 });

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -1,11 +1,9 @@
 import assert from 'assert';
 import chai, { expect } from 'chai';
-//import chai from 'chai';
 import { stub, restore } from 'sinon';
 import sinonChai from 'sinon-chai';
 import { authTokenService } from 'src/services/AuthToken';
 import { getConfig } from 'src/config';
-//import { User } from 'src/models';
 import jwt from 'jsonwebtoken';
 
 chai.use(sinonChai);
@@ -39,7 +37,7 @@ describe('AuthToken Setup', () => {
   });
 });
 
-describe('Generation of Token', () => {
+describe('Generation of Code and Token', () => {
   it('The token and code should not be null', () => {
     assert.notEqual(token, null);
     assert.notEqual(code, null);

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -1,5 +1,26 @@
 import assert from 'assert';
-import chai, { expect } from 'chai';
+//import chai, { expect } from 'chai';
+import chai from 'chai';
 import { stub, restore } from 'sinon';
 import sinonChai from 'sinon-chai';
-import { authTokenService } from 'src/services/AuthToken';
+//import { authTokenService } from 'src/services/AuthToken';
+
+chai.use(sinonChai);
+
+beforeEach(() => {
+  stub(console, 'warn');
+});
+
+afterEach(() => {
+  // Restore the default sandbox here
+  restore();
+});
+
+// Setup
+
+describe('First test', () => {
+  it('Should fail test', () => {
+    const tokenNum = '123456789';
+    assert.equal(tokenNum, 'abc');
+  });
+});

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -22,7 +22,7 @@ const secret = getConfig('JWT_SECRET');
 const email = 'joe.smith@example.com';
 const { token, code } = authTokenService.generateToken(email);
 
-const isTokenExpired = (token: string): number => {
+const getExpTime = (token: string): number => {
   const { exp } = jwt.decode(token) as {
     exp: number;
   };

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -2,8 +2,8 @@ import assert from 'assert';
 import chai, { expect } from 'chai';
 import { stub, restore } from 'sinon';
 import sinonChai from 'sinon-chai';
-import { authTokenService } from 'src/services/AuthToken';
 import { getConfig } from 'src/config';
+import { authTokenService } from 'src/services/AuthToken';
 import jwt from 'jsonwebtoken';
 
 chai.use(sinonChai);

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -20,7 +20,6 @@ afterEach(() => {
 });
 
 // Setup
-//const mock_secret = 'SetThisTo32orMoreRandomCharacters';
 const secret = getConfig('JWT_SECRET');
 const email = 'joe.smith@example.com';
 const { token, code } = authTokenService.generateToken(email);
@@ -35,7 +34,7 @@ const now = Date.now() / 1000;
 
 // Tests
 describe('AuthToken Setup', () => {
-  it('Secret should be 32 or more characters.', () => {
+  it('Secret should be 32 or more characters', () => {
     expect(secret).to.have.lengthOf.above(31);
   });
 });
@@ -50,7 +49,7 @@ describe('Generation of Token', () => {
     expect(code).to.have.lengthOf(8);
   });
 
-  it('The token had not expired yet', () => {
+  it('The token should not have expired yet', () => {
     expect(now).to.be.below(isTokenExpired(token));
   });
 });

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -30,7 +30,7 @@ const getExpTime = (token: string): number => {
 };
 
 const nowInSeconds = Date.now() / 1000;
-const expTimeInSeconds = isTokenExpired(token);
+const expTimeInSeconds = getExpTime(token);
 const ninetyMinsInSeconds = 90 * 60;
 
 // Tests

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -1,0 +1,5 @@
+import assert from 'assert';
+import chai, { expect } from 'chai';
+import { stub, restore } from 'sinon';
+import sinonChai from 'sinon-chai';
+import { authTokenService } from 'src/services/AuthToken';


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Created a test for the `AuthToken.ts`.
- Secret should be 32 or more characters
- The token and code should not be null
- The code should have a length of 8 numbers
- The token should not have expired yet

Discovered by making the test that `expiresIn: '120min',` was not working as intended, `2h` appears to be valid.

The only or caveat I foresee is invoking the `jwt.decode(token)` without any error handling I've seen in examples.