### PR TITLE
Docs: Add a note about the local Mailhog localhost URL to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -397,7 +397,9 @@ Once the app has started you should be able to pull up these URLs in your web br
 
 * Main Client Website - http://localhost:3000
 * GraphQL Playground - http://localhost:5000/graphql
-* Mailhog - http://localhost:8025/ - all dev environment emails are captured and viewable through this Mailhog interface 
+* MailHog - http://localhost:8025/ - all dev environment emails are captured and viewable through this Mailhog interface 
+
+Note, MailHog is not started automatically in manual mode.  The easiest way to do that is via Docker: `docker run --rm --network host mailhog/mailhog`, but if you prefer to install it manually, instructions are on their [repository](https://github.com/mailhog/MailHog) 
 </details>
 
 # Adding a New Feature

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@
   - [Docker Mode](#running-the-application)
   - [Manual Mode](#running-the-application)
 - [Adding a New Feature](#adding-a-new-feature)
-  - [Where to find the code](#where-to-find-the-code)
-  - [Where to find the issues](#where-to-find-the-issues)
+  - [Where to Find the Code](#where-to-find-the-code)
+  - [Where to Find the Issues](#where-to-find-the-issues)
 - [Frequently Asked Questions](#frequently-asked-questions)
 - [Server-side Technical Documentation](#server-side-technical-documentation)
   - [API Specification](#api-specification)
@@ -397,21 +397,21 @@ Once the app has started you should be able to pull up these URLs in your web br
 
 * Main Client Website - http://localhost:3000
 * GraphQL Playground - http://localhost:5000/graphql
-
+* Mailhog - http://localhost:8025/ - all dev environment emails are captured and viewable through this Mailhog interface 
 </details>
 
 # Adding a New Feature
 
 In order to understand where to start, it may help to familiarize yourself with our [tech stack](https://github.com/freeCodeCamp/chapter/blob/main/README.md#tech-stack). For more details:
 
-<details><summary>Tech stack overview</summary>
+<details><summary>Tech Stack Overview</summary>
 
 The database we use is [PostgreSQL](https://www.postgresql.org/), which we interact with via [TypeORM](https://typeorm.io/).  This ORM lets us define our database tables via classes whose properties map to columns in the database.  It makes use of decorators to specify the details of the db.  The [Express](https://expressjs.com/) server itself uses [Apollo GraphQL server](https://www.apollographql.com/docs/apollo-server/) to handle requests from the client. Apollo needs to know the GraphQL schema and we define that by using [TypeGraphQL](https://typegraphql.com/) since it lets us use decorators, much like TypeORM.  This means we can use both sets of decorators in the same Model class, keeping our database and GraphQL schema definitions together.
 
 The Chapter client uses the React framework [Next.js](https://nextjs.org/) with [Apollo Client](https://www.apollographql.com/docs/react/) for data fetching.  Since we are generating a GraphQL schema we can use [GraphQL Code Generator](https://www.graphql-code-generator.com/) to convert the schema into a set of TypeScript types and, more importantly, functions to get the data from the server.  As a result we know exactly what we're allowed to request from the server and the shape of the data it returns.
 </details>
 
-## Where to find the code
+## Where to Find the Code
 
 The database and GraphQL schema are defined by files in _server/src/models_
 
@@ -423,7 +423,7 @@ To create new hooks, modify _queries.ts_ and _mutations.ts_ files in _client/src
 
 Pages are defined according to [Next.js's routing](https://nextjs.org/docs/routing/dynamic-routes) e.g. _client/src/pages/dashboard/events/\[id\]/edit.tsx_ handles pages like _/dashboard/events/1/edit_
 
-## Where to find the issues
+## Where to Find the Issues
 
 [This](https://github.com/freeCodeCamp/chapter/contribute) is a good place to go if you are looking to get started.
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes nothing

Adding a note about the localhost URL where test emails can be viewed since it's not obvious what happens to emails in a dev environment.

This is important since magic links for logging in are captured by Mailhog and necessary to login to the client in dev mode.