### PR TITLE
Fix/video_url to streaming_ url label for New Event

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -606,7 +606,7 @@
             "deprecationReason": null
           },
           {
-            "name": "video_url",
+            "name": "streaming_url",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -1188,7 +1188,7 @@
             "deprecationReason": null
           },
           {
-            "name": "video_url",
+            "name": "streaming_url",
             "description": null,
             "args": [],
             "type": {
@@ -3079,7 +3079,7 @@
             "deprecationReason": null
           },
           {
-            "name": "video_url",
+            "name": "streaming_url",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -570,6 +570,18 @@
             "deprecationReason": null
           },
           {
+            "name": "streaming_url",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "url",
             "description": null,
             "type": {
@@ -599,18 +611,6 @@
             "type": {
               "kind": "ENUM",
               "name": "VenueType",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "streaming_url",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -1088,6 +1088,18 @@
             "deprecationReason": null
           },
           {
+            "name": "streaming_url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "tags",
             "description": null,
             "args": [],
@@ -1183,18 +1195,6 @@
                 "name": "VenueType",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "streaming_url",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3043,6 +3043,18 @@
             "deprecationReason": null
           },
           {
+            "name": "streaming_url",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "url",
             "description": null,
             "type": {
@@ -3072,18 +3084,6 @@
             "type": {
               "kind": "ENUM",
               "name": "VenueType",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "streaming_url",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
               "ofType": null
             },
             "defaultValue": null,

--- a/client/src/components/Form/Input.tsx
+++ b/client/src/components/Form/Input.tsx
@@ -66,7 +66,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   return (
     <FormControl
       isInvalid={isInvalid || !!props.error}
-      isRequired={false} //TODO: determine which inputs are required
+      isRequired={isRequired} //TODO: determine which inputs are required
       {...outerProps}
     >
       {!noLabel && (

--- a/client/src/components/Form/Input.tsx
+++ b/client/src/components/Form/Input.tsx
@@ -66,7 +66,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   return (
     <FormControl
       isInvalid={isInvalid || !!props.error}
-      isRequired={isRequired}
+      isRequired={false} //TODO: determine which inputs are required
       {...outerProps}
     >
       {!noLabel && (

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -68,7 +68,7 @@ export type CreateEventInputs = {
   url?: Maybe<Scalars['String']>;
   venueId?: Maybe<Scalars['Int']>;
   venue_type?: Maybe<VenueType>;
-  video_url?: Maybe<Scalars['String']>;
+  streaming_url?: Maybe<Scalars['String']>;
 };
 
 export type CreateVenueInputs = {
@@ -112,7 +112,7 @@ export type Event = {
   user_roles: Array<UserEventRole>;
   venue?: Maybe<Venue>;
   venue_type: VenueType;
-  video_url?: Maybe<Scalars['String']>;
+  streaming_url?: Maybe<Scalars['String']>;
 };
 
 export type EventSponsor = {
@@ -337,7 +337,7 @@ export type UpdateEventInputs = {
   url?: Maybe<Scalars['String']>;
   venueId?: Maybe<Scalars['Int']>;
   venue_type?: Maybe<VenueType>;
-  video_url?: Maybe<Scalars['String']>;
+  streaming_url?: Maybe<Scalars['String']>;
 };
 
 export type UpdateVenueInputs = {
@@ -595,7 +595,7 @@ export type EventsQuery = {
     description: string;
     url?: string | null | undefined;
     invite_only: boolean;
-    video_url?: string | null | undefined;
+    streaming_url?: string | null | undefined;
     start_at: any;
     capacity: number;
     venue?:
@@ -623,7 +623,7 @@ export type EventQuery = {
         description: string;
         url?: string | null | undefined;
         invite_only: boolean;
-        video_url?: string | null | undefined;
+        streaming_url?: string | null | undefined;
         canceled: boolean;
         capacity: number;
         start_at: any;
@@ -671,7 +671,7 @@ export type EventVenuesQuery = {
         name: string;
         description: string;
         url?: string | null | undefined;
-        video_url?: string | null | undefined;
+        streaming_url?: string | null | undefined;
         capacity: number;
         start_at: any;
         ends_at: any;
@@ -699,7 +699,7 @@ export type CreateEventMutation = {
     canceled: boolean;
     description: string;
     url?: string | null | undefined;
-    video_url?: string | null | undefined;
+    streaming_url?: string | null | undefined;
     capacity: number;
     tags?:
       | Array<{ __typename?: 'Tag'; id: number; name: string }>
@@ -722,7 +722,7 @@ export type UpdateEventMutation = {
     canceled: boolean;
     description: string;
     url?: string | null | undefined;
-    video_url?: string | null | undefined;
+    streaming_url?: string | null | undefined;
     capacity: number;
     tags?:
       | Array<{ __typename?: 'Tag'; id: number; name: string }>
@@ -1423,7 +1423,7 @@ export const EventsDocument = gql`
       description
       url
       invite_only
-      video_url
+      streaming_url
       start_at
       capacity
       venue {
@@ -1485,7 +1485,7 @@ export const EventDocument = gql`
       description
       url
       invite_only
-      video_url
+      streaming_url
       canceled
       capacity
       start_at
@@ -1567,7 +1567,7 @@ export const EventVenuesDocument = gql`
       name
       description
       url
-      video_url
+      streaming_url
       capacity
       start_at
       ends_at
@@ -1642,7 +1642,7 @@ export const CreateEventDocument = gql`
       canceled
       description
       url
-      video_url
+      streaming_url
       capacity
       tags {
         id
@@ -1702,7 +1702,7 @@ export const UpdateEventDocument = gql`
       canceled
       description
       url
-      video_url
+      streaming_url
       capacity
       tags {
         id

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -65,10 +65,10 @@ export type CreateEventInputs = {
   invite_only?: Maybe<Scalars['Boolean']>;
   name: Scalars['String'];
   start_at: Scalars['DateTime'];
+  streaming_url?: Maybe<Scalars['String']>;
   url?: Maybe<Scalars['String']>;
   venueId?: Maybe<Scalars['Int']>;
   venue_type?: Maybe<VenueType>;
-  streaming_url?: Maybe<Scalars['String']>;
 };
 
 export type CreateVenueInputs = {
@@ -106,13 +106,13 @@ export type Event = {
   rsvps: Array<Rsvp>;
   sponsors: Array<EventSponsor>;
   start_at: Scalars['DateTime'];
+  streaming_url?: Maybe<Scalars['String']>;
   tags?: Maybe<Array<Tag>>;
   updated_at: Scalars['DateTime'];
   url?: Maybe<Scalars['String']>;
   user_roles: Array<UserEventRole>;
   venue?: Maybe<Venue>;
   venue_type: VenueType;
-  streaming_url?: Maybe<Scalars['String']>;
 };
 
 export type EventSponsor = {
@@ -334,10 +334,10 @@ export type UpdateEventInputs = {
   invite_only?: Maybe<Scalars['Boolean']>;
   name?: Maybe<Scalars['String']>;
   start_at?: Maybe<Scalars['DateTime']>;
+  streaming_url?: Maybe<Scalars['String']>;
   url?: Maybe<Scalars['String']>;
   venueId?: Maybe<Scalars['Int']>;
   venue_type?: Maybe<VenueType>;
-  streaming_url?: Maybe<Scalars['String']>;
 };
 
 export type UpdateVenueInputs = {

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -38,7 +38,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
       name: data.name,
       description: data.description,
       url: data.url,
-      video_url: data.video_url,
+      streaming_url: data.streaming_url,
       capacity: data.capacity,
       start_at: new Date(data.start_at).toISOString().slice(0, 16),
       ends_at: new Date(data.ends_at).toISOString().slice(0, 16),

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -34,7 +34,7 @@ export const fields: Field[] = [
     placeholder: '',
   },
   {
-    key: 'video_url',
+    key: 'streaming_url',
     type: 'url',
     label: 'Video Url',
     placeholder: '',
@@ -72,7 +72,7 @@ export interface EventFormData {
   description: string;
   url?: string | null;
   image_url: string;
-  video_url?: string | null;
+  streaming_url?: string | null;
   capacity: number;
   tags: string;
   start_at: string;

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -36,7 +36,7 @@ export const fields: Field[] = [
   {
     key: 'streaming_url',
     type: 'url',
-    label: 'Video Url',
+    label: 'Streaming Url',
     placeholder: '',
   },
   {

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -9,7 +9,7 @@ export const EVENTS = gql`
       description
       url
       invite_only
-      video_url
+      streaming_url
       start_at
       capacity
       venue {
@@ -32,7 +32,7 @@ export const EVENT = gql`
       description
       url
       invite_only
-      video_url
+      streaming_url
       canceled
       capacity
       start_at
@@ -74,7 +74,7 @@ export const EVENT_WITH_VENU = gql`
       name
       description
       url
-      video_url
+      streaming_url
       capacity
       start_at
       ends_at
@@ -101,7 +101,7 @@ export const createEvent = gql`
       canceled
       description
       url
-      video_url
+      streaming_url
       capacity
       tags {
         id
@@ -119,7 +119,7 @@ export const updateEvent = gql`
       canceled
       description
       url
-      video_url
+      streaming_url
       capacity
       tags {
         id

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -67,9 +67,10 @@ export const EventPage: NextPage = () => {
             Event Url: <a href={data.event.url}>{data.event.url}</a>
           </Text>
         )}
-        {data.event.video_url && (
+        {data.event.streaming_url && (
           <Text>
-            Video Url: <a href={data.event.video_url}>{data.event.video_url}</a>
+            Video Url:{' '}
+            <a href={data.event.streaming_url}>{data.event.streaming_url}</a>
           </Text>
         )}
         <Text>Capacity: {data.event.capacity}</Text>

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -69,7 +69,7 @@ export const EventPage: NextPage = () => {
         )}
         {data.event.streaming_url && (
           <Text>
-            Video Url:{' '}
+            Streaming Url:{' '}
             <a href={data.event.streaming_url}>{data.event.streaming_url}</a>
           </Text>
         )}

--- a/client/src/modules/dashboard/Events/pages/EventsPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventsPage.tsx
@@ -39,7 +39,7 @@ export const EventsPage: NextPage = () => {
                 'invite only',
                 'venue',
                 'capacity',
-                'video_url',
+                'streaming_url',
                 'date',
                 'actions',
               ] as const
@@ -71,7 +71,7 @@ export const EventsPage: NextPage = () => {
               'invite only': (event) => (event.invite_only ? 'Yes' : 'No'),
               venue: (event) => event.venue?.name || '',
               capacity: true,
-              video_url: true,
+              streaming_url: true,
               date: (event) => formatDate(event.start_at),
               actions: (event) => (
                 <LinkButton

--- a/cypress/integration/dashboard/events.js
+++ b/cypress/integration/dashboard/events.js
@@ -2,7 +2,7 @@ const testEvent = {
   title: 'Test Event',
   description: 'Test Description',
   url: 'https://test.event.org',
-  videoUrl: 'https://test.event.org/video',
+  streamingUrl: 'https://test.event.org/video',
   capacity: '10',
   tags: 'Test, Event, Tag',
   startAt: '2022-01-01T00:01',
@@ -77,7 +77,9 @@ describe('events dashboard', () => {
       testEvent.imageUrl,
     );
     cy.findByRole('textbox', { name: 'Url' }).type(testEvent.url);
-    cy.findByRole('textbox', { name: 'Video Url' }).type(testEvent.videoUrl);
+    cy.findByRole('textbox', { name: 'Streaming Url' }).type(
+      testEvent.streamingUrl,
+    );
     cy.findByRole('spinbutton', { name: 'Capacity' }).type(testEvent.capacity);
     cy.findByRole('textbox', { name: 'Tags (separated by a comma)' }).type(
       'Test, Event, Tag',

--- a/schema.graphql
+++ b/schema.graphql
@@ -52,7 +52,7 @@ type Event {
     url: String
     venue: Venue
     venue_type: VenueType!
-    video_url: String
+    streaming_url: String
 }
 
 type EventSponsor {
@@ -216,7 +216,7 @@ input CreateEventInputs {
     url: String
     venueId: Int
     venue_type: VenueType
-    video_url: String
+    streaming_url: String
 }
 
 input CreateVenueInputs {
@@ -265,7 +265,7 @@ input UpdateEventInputs {
     url: String
     venueId: Int
     venue_type: VenueType
-    video_url: String
+    streaming_url: String
 }
 
 input UpdateVenueInputs {

--- a/server/db/generator/factories/events.factory.ts
+++ b/server/db/generator/factories/events.factory.ts
@@ -37,7 +37,7 @@ const createEvents = async (
       chapter: randomItem(chapters),
       description: lorem.words(),
       url: internet.url(),
-      video_url: internet.url(),
+      streaming_url: internet.url(),
       venue_type: randomEnum(VenueType),
       capacity: random(1000),
       venue: randomItem(venues),

--- a/server/src/controllers/Events/inputs.ts
+++ b/server/src/controllers/Events/inputs.ts
@@ -16,7 +16,7 @@ export class CreateEventInputs {
 
   @Field(() => String, { nullable: true })
   @IsUrl()
-  video_url?: string;
+  streaming_url?: string;
 
   @Field(() => VenueType, { nullable: true })
   venue_type: VenueType;
@@ -57,7 +57,7 @@ export class UpdateEventInputs {
 
   @Field(() => String, { nullable: true })
   @IsUrl()
-  video_url?: string;
+  streaming_url?: string;
 
   @Field(() => VenueType, { nullable: true })
   venue_type: VenueType;

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -228,7 +228,7 @@ ${unsubscribe}
     event.name = data.name ?? event.name;
     event.description = data.description ?? event.description;
     event.url = data.url ?? event.url;
-    event.video_url = data.video_url ?? event.video_url;
+    event.streaming_url = data.streaming_url ?? event.streaming_url;
     event.venue_type = data.venue_type ?? event.venue_type;
     event.start_at = new Date(data.start_at) ?? event.start_at;
     event.ends_at = new Date(data.ends_at) ?? event.ends_at;

--- a/server/src/models/Event.ts
+++ b/server/src/models/Event.ts
@@ -36,7 +36,7 @@ export class Event extends BaseModel {
 
   @Field(() => String, { nullable: true })
   @Column({ nullable: true })
-  video_url?: string;
+  streaming_url?: string;
 
   @Field(() => VenueType)
   @Column({ type: 'enum', enum: VenueType, default: VenueType.Physical })
@@ -98,7 +98,7 @@ export class Event extends BaseModel {
     name: string;
     description: string;
     url?: string;
-    video_url?: string;
+    streaming_url?: string;
     venue_type: VenueType;
     start_at: Date;
     ends_at: Date;
@@ -116,7 +116,7 @@ export class Event extends BaseModel {
         name,
         description,
         url,
-        video_url,
+        streaming_url,
         venue_type,
         start_at,
         ends_at,
@@ -132,7 +132,7 @@ export class Event extends BaseModel {
       this.name = name;
       this.description = description;
       this.url = url;
-      this.video_url = video_url;
+      this.streaming_url = streaming_url;
       this.venue_type = venue_type;
       this.start_at = start_at;
       this.ends_at = ends_at;


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

This changes the label for input `video_url` to `streaming_url` as per [chat](https://chat.freecodecamp.org/channel/chapter?msg=zXtACaS3Tch7Xuxu2) and mentoned in #270.

The only outstanding issue, #767, is that [_all_ inputs](https://github.com/paulywill/chapter/commit/7219ba46a96d4b6f5224644158c438f1a10f5962) were set to `isRequired` for the Input component.

Thus, the prop for each input on whether it should be `isRequired` should be passed.

@ojeytonwilliams mentioned to reference [graphql.tsx](https://github.com/freeCodeCamp/chapter/blob/bf8f4f1da83560d055d67f9f85b41ace16e647dc/client/src/generated/graphql.tsx#L59) and check which inputs are _without_ `?` as required and visa versa for optional.




