### PR TITLE
fix: handle expired and invalid session JWTs

### DIFF
--- a/cypress/integration/auth/login.js
+++ b/cypress/integration/auth/login.js
@@ -33,4 +33,35 @@ describe('login', () => {
         cy.get('[data-cy="logout-button"]').should('not.exist');
       });
   });
+
+  it('should redirect to /auth/login after the token expires', () => {
+    cy.window().then((win) => {
+      win.localStorage.setItem('token', Cypress.env('JWT_EXPIRED'));
+    });
+    cy.visit('/');
+    cy.location('pathname').should('eq', '/auth/login');
+    cy.window().should((win) => {
+      expect(win.localStorage.getItem('token')).to.be.null;
+    });
+  });
+
+  it('should clear the JWT if it has no signature', () => {
+    cy.window().then((win) => {
+      win.localStorage.setItem('token', Cypress.env('JWT_UNSIGNED'));
+    });
+    cy.visit('/');
+    cy.window().should((win) => {
+      expect(win.localStorage.getItem('token')).to.be.null;
+    });
+  });
+
+  it('should clear the JWT if it is malformed', () => {
+    cy.window().then((win) => {
+      win.localStorage.setItem('token', Cypress.env('JWT_MALFORMED'));
+    });
+    cy.visit('/');
+    cy.window().should((win) => {
+      expect(win.localStorage.getItem('token')).to.be.null;
+    });
+  });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -39,6 +39,20 @@ module.exports = (on, config) => {
     },
   );
 
+  config.env.JWT_EXPIRED = jwt.sign(
+    { email: 'foo@bar.com' },
+    process.env.JWT_SECRET,
+    {
+      expiresIn: '1',
+    },
+  );
+
+  // Standard JWT (with id, exp etc.), but with the signature removed:
+  config.env.JWT_UNSIGNED =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjM1ODYzNjQ2LCJleHAiOjE2Mzg1NDIwNDZ9.';
+
+  config.env.JWT_MALFORMED = 'not-a-valid-format';
+
   // This makes sure the db is populated before running any tests. Without this,
   // it's difficult (when running docker-compose up) to guarantee that both the
   // docker container is running and that the db has been seeded.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,7 +8,10 @@ import { buildSchema } from 'type-graphql';
 import { initDB } from './db';
 import { GQLCtx, Request } from 'src/common-types/gql';
 import { resolvers } from 'src/controllers';
-import { userMiddleware } from 'src/controllers/Auth/middleware';
+import {
+  userMiddleware,
+  handleAuthenticationError,
+} from 'src/controllers/Auth/middleware';
 
 // Make sure to kill the app if using non docker-compose setup and docker-compose
 if (isDocker() && process.env.IS_DOCKER !== 'true') {
@@ -25,6 +28,7 @@ export const main = async (app: Express) => {
   await initDB();
   app.use(cors({ credentials: true, origin: true }));
   app.use(userMiddleware);
+  app.use(handleAuthenticationError);
 
   const schema = await buildSchema({ resolvers });
   const server = new ApolloServer({

--- a/server/src/controllers/Auth/middleware.ts
+++ b/server/src/controllers/Auth/middleware.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Response } from 'express';
-import { verify } from 'jsonwebtoken';
+import { TokenExpiredError, JsonWebTokenError, verify } from 'jsonwebtoken';
 import { Request } from 'src/common-types/gql';
 import { getConfig } from 'src/config';
 import { User } from 'src/models';
@@ -14,15 +14,16 @@ export const userMiddleware = (
     return next();
   }
 
+  // We don't, currently, handle different JsonWebTokenError messages
+  // differently but we do need to add messages to the error object.
   const raw = authorization.split(' ');
   if (raw.length != 2 || raw[0] != 'Bearer') {
-    // TODO: Handle this better
-    return next('Auth header wrong');
+    return next(new JsonWebTokenError('Invalid auth header'));
   }
 
   const value = verify(raw[1], getConfig('JWT_SECRET')) as { id: number };
   if (!value.id) {
-    return next('Token malformed');
+    return next(new JsonWebTokenError('Missing contents'));
   }
 
   User.findOne(value.id, { relations: ['chapter_roles'] })
@@ -38,3 +39,24 @@ export const userMiddleware = (
       next(err);
     });
 };
+
+export function handleAuthenticationError(
+  err: any,
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  if (err instanceof TokenExpiredError) {
+    return res.status(401).send({
+      message: 'Token expired',
+    });
+  } else if (err instanceof JsonWebTokenError) {
+    return res.status(401).send({
+      message: 'Token invalid',
+    });
+  }
+}


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Instead of just reporting there's an error, this clears the JWT (since it was rejected by the server).  If the JWT has expired, the user is redirected to the login page.  This isn't the best UX, so we should investigate refresh tokens or some other way of silently authenticating.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
