### PR TITLE
Docs: Remove closed Chakra to-do from README. Add Cypress to Where to Find The Code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,15 +415,12 @@ The Chapter client uses the React framework [Next.js](https://nextjs.org/) with 
 
 ## Where to Find the Code
 
-The database and GraphQL schema are defined by files in _server/src/models_
-
-The resolvers for the GraphQL queries are defined in _server/src/controllers_
-
-The client accesses the data via hooks defined in _client/src/generated/generated.tsx_
-
-To create new hooks, modify _queries.ts_ and _mutations.ts_ files in _client/src/modules/**/graphql_
-
-Pages are defined according to [Next.js's routing](https://nextjs.org/docs/routing/dynamic-routes) e.g. _client/src/pages/dashboard/events/\[id\]/edit.tsx_ handles pages like _/dashboard/events/1/edit_
+* Database and GraphQL schema are defined by files in _server/src/models_
+* Resolvers for the GraphQL queries are defined in _server/src/controllers_
+* The client accesses the data via hooks defined in _client/src/generated/generated.tsx_
+* To create new hooks, modify _queries.ts_ and _mutations.ts_ files in _client/src/modules/**/graphql_
+* Client pages are defined according to [Next.js's routing](https://nextjs.org/docs/routing/dynamic-routes) e.g. _client/src/pages/dashboard/events/\[id\]/edit.tsx_ handles pages like _/dashboard/events/1/edit_
+* Cypress test coverage spec files should go in _/cypress/integration_, roughly mirroring the client pages pattern
 
 ## Where to Find the Issues
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We are using the following tools:
 * [Next.js](https://nextjs.org/) - for both client and server-side rendering of the frontend (NextJS is based on [React](https://reactjs.org))
   * [Apollo Client 3](https://www.apollographql.com/docs/react/)
   * [TypeScript](https://www.typescriptlang.org/index.html#download-links)
-  * [Chakra-UI](https://chakra-ui.com/) - for styling  + super easy DSL for custom css (we still have some legacy MUI stuff that's being removed [#608](https://github.com/freeCodeCamp/chapter/issues/608))
+  * [Chakra UI](https://chakra-ui.com/) - simple, modular & accessible UI components for React
   * Functional Components with [Hooks](https://reactjs.org/docs/hooks-intro.html)
 * [chai](https://www.chaijs.com/) - for writing unit tests.
   * [sinon](https://sinonjs.org/)


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes nothing.

Fran had a link to a to-do to convert pages to Chakra, but that's been done.

Added [Oliver's Cypress directory](https://github.com/freeCodeCamp/chapter/issues/786) note to the "Where to Find the Code" section of CONTRIBUTING.md and convert the list to bullets.