### PR TITLE
chore: untrack cypress artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ typings/
 # Jetbrains project settings
 .idea/
 
+# Cypress.io
+cypress/videos
+cypress/screenshots
+
 # tsc output
 
 /server/src/**/*.js


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Adds to `.gitignore` folders with artifacts created by cypress when running tests.