### PR TITLE
feat: send emails to rsvps on event cancel

### DIFF
--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -362,7 +362,7 @@ ${unsubscribe}
         const subject = `Venue changed for event ${event.name}`;
         const body = `We have had to change the location of ${event.name}.
 The event is now being held at <br>
-${venue.name} <br> 
+${venue.name} <br>
 ${venue.street_address ? venue.street_address + '<br>' : ''}
 ${venue.city} <br>
 ${venue.region} <br>
@@ -382,6 +382,22 @@ ${unsubscribe}
       where: { id },
       data: { canceled: true },
     });
+
+    const notCancelledRsvps = await prisma.rsvps.findMany({
+      where: {
+        event_id: id,
+        canceled: false,
+      },
+      include: { user: true },
+    });
+
+    if (notCancelledRsvps) {
+      const emailList = notCancelledRsvps.map((rsvp) => rsvp.user.email);
+      const subject = `Event ${event.name} cancelled`;
+      const body = `placeholder body`;
+
+      new MailerService(emailList, subject, body).sendEmail();
+    }
 
     return event;
   }


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Still required:
- [ ] Email text.
- [x] Tests?
- [ ] Anything else?

Related to #100

---
Draft adding sending emails to rsvps when event is cancelled.
- Email is send to rsvps that are not cancelled. That means those confirmed or in waitlist. Note in generated data there might be generated rsvps with `cancelled: true`, but this doesn't seem to be displayed in the client right now.
- I've initially added permission check, similar to one in other resolver, based on `user.user_event_roles`, but as that's going to be handled by authorization I've removed it.
- Tested on local fork.