### PR TITLE
fix: prevent duplicating sponsors in ui

### DIFF
--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -197,14 +197,24 @@ const EventForm: React.FC<EventFormProps> = (props) => {
                         defaultValue={getValues(`sponsors.${index}.id`)}
                         {...register(`sponsors.${index}.id` as const, {
                           required: true,
+                          valueAsNumber: true,
                         })}
                       >
                         {sponsorData.sponsors
-                          ?.filter(
-                            //Filtering out the options of only selected type
-                            (item) =>
-                              item.type === watchSponsorsArray[index]?.type,
-                          )
+                          ?.filter((sponsor) => {
+                            const isRightSponsorType =
+                              sponsor.type === watchSponsorsArray[index]?.type;
+                            if (!isRightSponsorType) {
+                              return false;
+                            }
+                            const selectionIndex = watchSponsorsArray.findIndex(
+                              (selectedSponsor) =>
+                                selectedSponsor.id === sponsor.id,
+                            );
+                            const sponsorNotSelectedElsewhere =
+                              selectionIndex === -1 || selectionIndex === index;
+                            return sponsorNotSelectedElsewhere;
+                          })
                           .map((s) => (
                             <option key={s.id} value={s.id}>
                               {s.name}


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #781

---
- I tried to be more explicit about what is happening.
- I added `valueAsNumber: true` to registering `sponsors.${index}.id`, at some point `id`s of the sponsors in the `watchSponsorsArray` were starting to be as strings, what was messing up strict comparisons. I don't know why or how strings were making there.
- Default values for type/sponsor weren't touched (yet?), but sooner or later probably should.