### PR TITLE
fix: sponsor fields should not be empty

### DIFF
--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -148,6 +148,14 @@ const EventForm: React.FC<EventFormProps> = (props) => {
                   id: firstSponsorId,
                 });
               }}
+              isDisabled={
+                loadingSponsors ||
+                errorSponsor ||
+                !sponsorData ||
+                sponsorFields.length < sponsorData.sponsors.length
+                  ? false
+                  : true
+              }
             >
               Add
             </Button>

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -17,6 +17,26 @@ export type sponsorType = {
   id: number;
 };
 
+export interface EventSponsorTypeInput {
+  name: string;
+  type: string;
+}
+
+export const sponsorTypes: EventSponsorTypeInput[] = [
+  {
+    name: 'Food',
+    type: 'FOOD',
+  },
+  {
+    name: 'Venue',
+    type: 'VENUE',
+  },
+  {
+    name: 'Other',
+    type: 'OTHER',
+  },
+];
+
 export interface EventSponsorInput {
   id: number;
   type: string;

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -200,7 +200,6 @@ export const getAllowedSponsors = (
       !isSponsorSelectedElsewhere(sponsor, watchSponsorsArray, sponsorFieldId),
   );
 
-
 const getSelectedFieldIdForSponsor = (
   sponsor: EventSponsorInput,
   watchSponsorsArray: EventSponsorInput[],

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -1,4 +1,4 @@
-import { Event, Venue } from '../../../../generated/graphql';
+import { Event, Venue, SponsorsQuery } from '../../../../generated/graphql';
 
 export interface Field {
   key: keyof EventFormData;
@@ -160,4 +160,84 @@ export const formatValue = (field: Field, store?: IEventData): any => {
   }
 
   return store[key];
+};
+
+export const getAllowedSponsorTypes = (
+  sponsorData: SponsorsQuery,
+  sponsorTypes: EventSponsorTypeInput[],
+  watchSponsorsArray: EventSponsorInput[],
+  sponsorFieldId: number,
+) =>
+  sponsorTypes.filter(({ type }) =>
+    hasTypeAllowedSponsors(
+      sponsorData,
+      type,
+      watchSponsorsArray,
+      sponsorFieldId,
+    ),
+  ) ?? [];
+
+export const getAllowedSponsorsForType = (
+  sponsorData: SponsorsQuery,
+  sponsorType: string,
+  watchSponsorsArray: EventSponsorInput[],
+  sponsorFieldId?: number,
+) =>
+  sponsorData.sponsors.filter(
+    (sponsor) =>
+      hasMatchingSponsorType(sponsor, sponsorType) &&
+      !isSponsorSelectedElsewhere(sponsor, watchSponsorsArray, sponsorFieldId),
+  ) ?? [];
+
+export const getAllowedSponsors = (
+  sponsorData: SponsorsQuery,
+  watchSponsorsArray: EventSponsorInput[],
+  sponsorFieldId?: number,
+) =>
+  sponsorData.sponsors.filter(
+    (sponsor) =>
+      !isSponsorSelectedElsewhere(sponsor, watchSponsorsArray, sponsorFieldId),
+  );
+
+const hasTypeAllowedSponsors = (
+  sponsorData: SponsorsQuery,
+  sponsorType: string,
+  watchSponsorsArray: EventSponsorInput[],
+  sponsorFieldId: number,
+) =>
+  (
+    getAllowedSponsorsForType(
+      sponsorData,
+      sponsorType,
+      watchSponsorsArray,
+      sponsorFieldId,
+    ) ?? []
+  ).length > 0;
+
+const getSelectedFieldIdForSponsor = (
+  sponsor: EventSponsorInput,
+  watchSponsorsArray: EventSponsorInput[],
+) =>
+  watchSponsorsArray.findIndex(
+    (selectedSponsor) => selectedSponsor.id === sponsor.id,
+  );
+
+const hasMatchingSponsorType = (
+  sponsor: EventSponsorInput,
+  sponsorType: string,
+) => sponsor.type === sponsorType;
+
+const isSponsorSelectedElsewhere = (
+  sponsor: EventSponsorInput,
+  watchSponsorsArray: EventSponsorInput[],
+  sponsorFieldId?: number,
+) => {
+  const selectedFieldId = getSelectedFieldIdForSponsor(
+    sponsor,
+    watchSponsorsArray,
+  );
+  return (
+    selectedFieldId !== -1 &&
+    (sponsorFieldId === undefined || selectedFieldId !== sponsorFieldId)
+  );
 };

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -9,6 +9,14 @@ export interface Field {
   isRequired: boolean;
 }
 
+export type sponsorType = {
+  name: string;
+  logo_path: string;
+  website: string;
+  type: string;
+  id: number;
+};
+
 export interface EventSponsorInput {
   id: number;
   type: string;

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -168,14 +168,15 @@ export const getAllowedSponsorTypes = (
   watchSponsorsArray: EventSponsorInput[],
   sponsorFieldId: number,
 ) =>
-  sponsorTypes.filter(({ type }) =>
-    hasTypeAllowedSponsors(
-      sponsorData,
-      type,
-      watchSponsorsArray,
-      sponsorFieldId,
-    ),
-  ) ?? [];
+  sponsorTypes.filter(
+    ({ type }) =>
+      getAllowedSponsorsForType(
+        sponsorData,
+        type,
+        watchSponsorsArray,
+        sponsorFieldId,
+      ).length,
+  );
 
 export const getAllowedSponsorsForType = (
   sponsorData: SponsorsQuery,
@@ -185,9 +186,9 @@ export const getAllowedSponsorsForType = (
 ) =>
   sponsorData.sponsors.filter(
     (sponsor) =>
-      hasMatchingSponsorType(sponsor, sponsorType) &&
+      sponsor.type === sponsorType &&
       !isSponsorSelectedElsewhere(sponsor, watchSponsorsArray, sponsorFieldId),
-  ) ?? [];
+  );
 
 export const getAllowedSponsors = (
   sponsorData: SponsorsQuery,
@@ -199,20 +200,6 @@ export const getAllowedSponsors = (
       !isSponsorSelectedElsewhere(sponsor, watchSponsorsArray, sponsorFieldId),
   );
 
-const hasTypeAllowedSponsors = (
-  sponsorData: SponsorsQuery,
-  sponsorType: string,
-  watchSponsorsArray: EventSponsorInput[],
-  sponsorFieldId: number,
-) =>
-  (
-    getAllowedSponsorsForType(
-      sponsorData,
-      sponsorType,
-      watchSponsorsArray,
-      sponsorFieldId,
-    ) ?? []
-  ).length > 0;
 
 const getSelectedFieldIdForSponsor = (
   sponsor: EventSponsorInput,
@@ -221,11 +208,6 @@ const getSelectedFieldIdForSponsor = (
   watchSponsorsArray.findIndex(
     (selectedSponsor) => selectedSponsor.id === sponsor.id,
   );
-
-const hasMatchingSponsorType = (
-  sponsor: EventSponsorInput,
-  sponsorType: string,
-) => sponsor.type === sponsorType;
 
 const isSponsorSelectedElsewhere = (
   sponsor: EventSponsorInput,

--- a/client/src/modules/dashboard/Events/components/EventSponsorCard.tsx
+++ b/client/src/modules/dashboard/Events/components/EventSponsorCard.tsx
@@ -1,12 +1,6 @@
 import { Box, Heading, Flex, Spacer, Link, Badge } from '@chakra-ui/react';
 import React from 'react';
-type sponsorType = {
-  name: string;
-  logo_path: string;
-  website: string;
-  type: string;
-  id: number;
-};
+import { sponsorType } from './EventFormUtils';
 
 interface SponsorProps {
   sponsor: sponsorType;


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Still required:
- [x] Clean up

Closes #846

---

- Disables `Add` button, when all existing sponsors are added.
- When adding new sponsor, default sponsor type and sponsor are selected from still available sponsors.
- Available sponsor types and sponsors are limited based on selections in other fields.
- Moves default sponsor types to utils.
- Moves functions getting allowed sponsors, sponsor types to utils.
- Any notes are appreciated.
- Tested on local fork.