### PR TITLE
feat: add cancel event button to event edit page

### DIFF
--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -1,15 +1,12 @@
 import { useDisclosure } from '@chakra-ui/hooks';
 import { Button, HStack } from '@chakra-ui/react';
-import { useConfirm, useConfirmDelete } from 'chakra-confirm';
+import { useConfirmDelete } from 'chakra-confirm';
 import { LinkButton } from 'chakra-next-link';
 import React, { useMemo } from 'react';
 import { EVENT, EVENTS } from '../graphql/queries';
+import EventCancelButton from './EventCancelButton';
 import SendEmailModal from './SendEmailModal';
-import {
-  Event,
-  useCancelEventMutation,
-  useDeleteEventMutation,
-} from 'generated/graphql';
+import { Event, useDeleteEventMutation } from 'generated/graphql';
 
 interface ActionsProps {
   event: Pick<Event, 'id' | 'canceled'>;
@@ -19,7 +16,6 @@ interface ActionsProps {
 
 const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [cancel] = useCancelEventMutation();
   const [remove] = useDeleteEventMutation();
 
   const data = useMemo(
@@ -33,19 +29,7 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
     [event],
   );
 
-  const confirmCancel = useConfirm({
-    title: 'Are you sure you want to cancel this',
-    body: 'Canceling this will send emails to everyone who RSVPd',
-    buttonColor: 'orange',
-  });
   const confirmDelete = useConfirmDelete();
-
-  const clickCancel = async () => {
-    const ok = await confirmCancel();
-    if (ok) {
-      await cancel(data);
-    }
-  };
 
   const clickDelete = async () => {
     const ok = await confirmDelete();
@@ -71,9 +55,7 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
         Edit
       </LinkButton>
       {!hideCancel && !event.canceled && (
-        <Button size="sm" colorScheme="orange" onClick={clickCancel}>
-          Cancel
-        </Button>
+        <EventCancelButton size="sm" event={event} buttonText="Cancel" />
       )}
       <Button size="sm" colorScheme="blue" onClick={clickEmailAttendees}>
         Email Attendees

--- a/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
+++ b/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
@@ -21,16 +21,13 @@ const EventCancelButton: React.FC<EventCancelButtonProps> = (props) => {
     buttonColor: 'orange',
   });
 
-  const data = useMemo(
-    () => ({
-      variables: { id: event.id },
-      refetchQueries: [
-        { query: EVENT, variables: { id: event.id } },
-        { query: EVENTS },
-      ],
-    }),
-    [event],
-  );
+  const data = {
+    variables: { id: event.id },
+    refetchQueries: [
+      { query: EVENT, variables: { id: event.id } },
+      { query: EVENTS },
+    ],
+  };
 
   const clickCancel = async () => {
     const ok = await confirmCancel();

--- a/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
+++ b/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonProps } from '@chakra-ui/react';
 import { useConfirm } from 'chakra-confirm';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Event, useCancelEventMutation } from '../../../../generated/graphql';
 import { EVENT, EVENTS } from '../graphql/queries';
 

--- a/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
+++ b/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
@@ -1,0 +1,53 @@
+import { Button, ButtonProps } from '@chakra-ui/react';
+import { useConfirm } from 'chakra-confirm';
+import React, { useMemo } from 'react';
+import { Event, useCancelEventMutation } from '../../../../generated/graphql';
+import { EVENT, EVENTS } from '../graphql/queries';
+
+interface EventCancelButtonProps extends ButtonProps {
+  isFullWidth?: boolean;
+  buttonText: string;
+  event: Pick<Event, 'id' | 'canceled'>;
+}
+
+const EventCancelButton: React.FC<EventCancelButtonProps> = (props) => {
+  const { isFullWidth, buttonText, event, ...rest } = props;
+
+  const [cancel] = useCancelEventMutation();
+
+  const confirmCancel = useConfirm({
+    title: 'Are you sure you want to cancel this',
+    body: 'Canceling this will send emails to everyone who RSVPd',
+    buttonColor: 'orange',
+  });
+
+  const data = useMemo(
+    () => ({
+      variables: { id: event.id },
+      refetchQueries: [
+        { query: EVENT, variables: { id: event.id } },
+        { query: EVENTS },
+      ],
+    }),
+    [event],
+  );
+
+  const clickCancel = async () => {
+    const ok = await confirmCancel();
+    if (ok) {
+      await cancel(data);
+    }
+  };
+  return (
+    <Button
+      {...rest}
+      isFullWidth={isFullWidth}
+      colorScheme="orange"
+      onClick={clickCancel}
+    >
+      {buttonText}
+    </Button>
+  );
+};
+
+export default EventCancelButton;

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -239,7 +239,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
             );
           })}
         </FormControl>
-        {data && data.canceled && <Text color="red.500">Event canceled</Text>}
+        {data?.canceled && <Text color="red.500">Event canceled</Text>}
         <HStack width="100%">
           <Button
             isFullWidth={true}

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -1,5 +1,6 @@
 import {
   VStack,
+  HStack,
   Checkbox,
   Button,
   FormLabel,
@@ -9,6 +10,7 @@ import {
   Spacer,
   CloseButton,
   Flex,
+  Text,
 } from '@chakra-ui/react';
 import React, { useMemo } from 'react';
 import { useForm, useFieldArray } from 'react-hook-form';
@@ -18,6 +20,7 @@ import {
   useSponsorsQuery,
   useVenuesQuery,
 } from '../../../../generated/graphql';
+import EventCancelButton from './EventCancelButton';
 import {
   EventFormProps,
   fields,
@@ -236,14 +239,24 @@ const EventForm: React.FC<EventFormProps> = (props) => {
             );
           })}
         </FormControl>
-        <Button
-          width="100%"
-          colorScheme="blue"
-          type="submit"
-          isDisabled={loading}
-        >
-          {submitText}
-        </Button>
+        {data && data.canceled && <Text color="red.500">Event canceled</Text>}
+        <HStack width="100%">
+          <Button
+            isFullWidth={true}
+            colorScheme="blue"
+            type="submit"
+            isDisabled={loading}
+          >
+            {submitText}
+          </Button>
+          {data && !data.canceled && (
+            <EventCancelButton
+              isFullWidth={true}
+              event={data}
+              buttonText="Cancel this Event"
+            />
+          )}
+        </HStack>
       </VStack>
     </form>
   );

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -94,6 +94,7 @@ export interface EventFormData {
   venue_id?: number | null;
   invite_only?: boolean;
   sponsors: Array<EventSponsorInput>;
+  canceled: boolean;
 }
 
 export type IEventData = Pick<


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #268

---
- Moves cancelling button to separate component.
- Adds cancelling button to event edit page: [image](https://user-images.githubusercontent.com/60067306/148791341-45cab5e9-1d1e-442a-86be-f2f44dd9a61b.png)
- Any notes are appreciated.
- Tested on local fork.