### PR TITLE
fix: use logged in user as chapter creator

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -115,6 +115,22 @@
             "deprecationReason": null
           },
           {
+            "name": "creator_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "description",
             "description": null,
             "args": [],
@@ -247,6 +263,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "creator_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -34,6 +34,7 @@ export type Chapter = {
   category: Scalars['String'];
   city: Scalars['String'];
   country: Scalars['String'];
+  creator_id: Scalars['Int'];
   description: Scalars['String'];
   id: Scalars['Int'];
   imageUrl: Scalars['String'];
@@ -46,6 +47,7 @@ export type ChapterWithRelations = {
   category: Scalars['String'];
   city: Scalars['String'];
   country: Scalars['String'];
+  creator_id: Scalars['Int'];
   description: Scalars['String'];
   events: Array<Event>;
   id: Scalars['Int'];

--- a/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
+++ b/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
@@ -7,7 +7,7 @@ import type { Chapter, ChapterQuery } from '../../../../generated/graphql';
 
 export type ChapterFormData = Omit<
   Chapter,
-  'id' | 'events' | 'creator' | 'users' | 'banned_users'
+  'id' | 'events' | 'creator_id' | 'users' | 'banned_users'
 >;
 
 interface ChapterFormProps {

--- a/cypress/integration/dashboard/chapters.js
+++ b/cypress/integration/dashboard/chapters.js
@@ -26,6 +26,7 @@ describe('chapters dashboard', () => {
       category: 'Type of chapter',
       imageUrl: 'https://example.com/image.jpg',
     };
+    cy.login();
     cy.visit('/dashboard/chapters');
     cy.get('a[href="/dashboard/chapters/new"]').click();
     cy.findByRole('textbox', { name: 'Chapter name' }).type(fix.name);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -22,7 +22,7 @@ model chapters {
   region      String
   country     String
   imageUrl    String
-  creator_id  Int?
+  creator_id  Int
   events      events[]
   user_bans   user_bans[]
   users       user_chapter_roles[]

--- a/server/src/controllers/Chapter/inputs.ts
+++ b/server/src/controllers/Chapter/inputs.ts
@@ -1,7 +1,8 @@
 import { InputType, Field } from 'type-graphql';
+import { Chapter } from 'src/graphql-types';
 
 @InputType()
-export class CreateChapterInputs {
+export class CreateChapterInputs implements Partial<Chapter> {
   @Field(() => String)
   name: string;
 
@@ -25,7 +26,7 @@ export class CreateChapterInputs {
 }
 
 @InputType()
-export class UpdateChapterInputs {
+export class UpdateChapterInputs implements Partial<Chapter> {
   @Field(() => String, { nullable: true })
   name: string;
 

--- a/server/src/controllers/Chapter/inputs.ts
+++ b/server/src/controllers/Chapter/inputs.ts
@@ -2,7 +2,7 @@ import { InputType, Field } from 'type-graphql';
 import { Chapter } from 'src/graphql-types';
 
 @InputType()
-export class CreateChapterInputs implements Partial<Chapter> {
+export class CreateChapterInputs implements Omit<Chapter, 'id' | 'creator_id'> {
   @Field(() => String)
   name: string;
 
@@ -26,7 +26,7 @@ export class CreateChapterInputs implements Partial<Chapter> {
 }
 
 @InputType()
-export class UpdateChapterInputs implements Partial<Chapter> {
+export class UpdateChapterInputs implements Omit<Chapter, 'id' | 'creator_id'> {
   @Field(() => String, { nullable: true })
   name: string;
 

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -31,7 +31,7 @@ export class ChapterResolver {
     @Ctx() ctx: GQLCtx,
   ): Promise<Chapter> {
     if (!ctx.user) {
-      throw Error('User must be logged in to create events');
+      throw Error('User must be logged in to create chapters');
     }
     const chapterData: Prisma.chaptersCreateInput = {
       ...data,

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
-import { Resolver, Query, Arg, Int, Mutation } from 'type-graphql';
+import { Resolver, Query, Arg, Int, Mutation, Ctx } from 'type-graphql';
 import { CreateChapterInputs, UpdateChapterInputs } from './inputs';
+import { GQLCtx } from 'src/common-types/gql';
 import { Chapter, ChapterWithRelations } from 'src/graphql-types';
 import { prisma } from 'src/prisma';
 
@@ -27,16 +28,14 @@ export class ChapterResolver {
   @Mutation(() => Chapter)
   async createChapter(
     @Arg('data') data: CreateChapterInputs,
+    @Ctx() ctx: GQLCtx,
   ): Promise<Chapter> {
-    // TODO: Use logged in user
-    const user = await prisma.users.findFirst();
-    // TODO: fix the TypeGraphQL type, CreateChapterInputs (it should include
-    // details or the db should not require it)
-    // TODO: creator_id should not be optional and we shouldn't need Unchecked
-    // here
-    const chapterData: Prisma.chaptersUncheckedCreateInput = {
+    if (!ctx.user) {
+      throw Error('User must be logged in to create events');
+    }
+    const chapterData: Prisma.chaptersCreateInput = {
       ...data,
-      creator_id: user?.id,
+      creator_id: ctx.user.id,
     };
 
     return prisma.chapters.create({ data: chapterData });

--- a/server/src/graphql-types/Chapter.ts
+++ b/server/src/graphql-types/Chapter.ts
@@ -1,4 +1,4 @@
-import { ObjectType, Field } from 'type-graphql';
+import { ObjectType, Field, Int } from 'type-graphql';
 import { BaseObject } from './BaseObject';
 
 @ObjectType()
@@ -23,4 +23,7 @@ export class Chapter extends BaseObject {
 
   @Field(() => String)
   imageUrl!: string;
+
+  @Field(() => Int)
+  creator_id: number;
 }


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Creating new chapter adds logged in user as creator.
- `ctx.user` is checked, so there's no complains that `creator_id` might be not set.
- `creator_id` is required in `chapters` model and `ObjectType`. 
- Making `creator_id` required in the `CreateChapterInputs` currently would be erroring, as data passed from client doesn't have currently `creator_id`. I couldn't figure a way, to add `creator_id` from the `ctx`, before type of `data` is checked in the mutation resolver. Some middleware or other `type-graphql` feature?