### PR TITLE
feat: update cache directly

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -2603,7 +2603,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "Event",
+                "name": "EventWithEverything",
                 "ofType": null
               }
             },
@@ -3630,6 +3630,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Float",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "chapter_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null,

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -200,7 +200,7 @@ export type Mutation = {
   sendEmail: Email;
   sendEventInvite: Scalars['Boolean'];
   updateChapter: Chapter;
-  updateEvent: Event;
+  updateEvent: EventWithEverything;
   updateSponsor: Sponsor;
   updateVenue: Venue;
 };
@@ -396,6 +396,7 @@ export type UpdateChapterInputs = {
 
 export type UpdateEventInputs = {
   capacity?: InputMaybe<Scalars['Float']>;
+  chapter_id?: InputMaybe<Scalars['Int']>;
   description?: InputMaybe<Scalars['String']>;
   ends_at?: InputMaybe<Scalars['DateTime']>;
   image_url?: InputMaybe<Scalars['String']>;
@@ -759,7 +760,7 @@ export type UpdateEventMutationVariables = Exact<{
 export type UpdateEventMutation = {
   __typename?: 'Mutation';
   updateEvent: {
-    __typename?: 'Event';
+    __typename?: 'EventWithEverything';
     id: number;
     name: string;
     canceled: boolean;
@@ -775,11 +776,36 @@ export type UpdateEventMutation = {
       | Array<{ __typename?: 'Tag'; id: number; name: string }>
       | null
       | undefined;
+    sponsors: Array<{
+      __typename?: 'EventSponsor';
+      sponsor: {
+        __typename?: 'Sponsor';
+        name: string;
+        website: string;
+        logo_path: string;
+        type: string;
+        id: number;
+      };
+    }>;
+    venue?:
+      | {
+          __typename?: 'Venue';
+          id: number;
+          name: string;
+          street_address?: string | null | undefined;
+          city: string;
+          postal_code: string;
+          region: string;
+          country: string;
+        }
+      | null
+      | undefined;
+    chapter: { __typename?: 'Chapter'; id: number; name: string };
   };
 };
 
-export type UpdateEventFragmentFragment = {
-  __typename?: 'Event';
+export type UpdateFragmentEventWithChapterFragment = {
+  __typename?: 'EventWithChapter';
   id: number;
   name: string;
   description: string;
@@ -790,6 +816,54 @@ export type UpdateEventFragmentFragment = {
   ends_at: any;
   image_url: string;
   invite_only: boolean;
+  chapter: { __typename?: 'Chapter'; id: number; name: string };
+  tags?:
+    | Array<{ __typename?: 'Tag'; id: number; name: string }>
+    | null
+    | undefined;
+};
+
+export type UpdateFragmengEventWithEverythingFragment = {
+  __typename?: 'EventWithEverything';
+  id: number;
+  name: string;
+  description: string;
+  url?: string | null | undefined;
+  streaming_url?: string | null | undefined;
+  capacity: number;
+  start_at: any;
+  ends_at: any;
+  image_url: string;
+  invite_only: boolean;
+  chapter: { __typename?: 'Chapter'; id: number; name: string };
+  tags?:
+    | Array<{ __typename?: 'Tag'; id: number; name: string }>
+    | null
+    | undefined;
+  sponsors: Array<{
+    __typename?: 'EventSponsor';
+    sponsor: {
+      __typename?: 'Sponsor';
+      name: string;
+      website: string;
+      logo_path: string;
+      type: string;
+      id: number;
+    };
+  }>;
+  venue?:
+    | {
+        __typename?: 'Venue';
+        id: number;
+        name: string;
+        street_address?: string | null | undefined;
+        city: string;
+        postal_code: string;
+        region: string;
+        country: string;
+      }
+    | null
+    | undefined;
 };
 
 export type CancelEventMutationVariables = Exact<{
@@ -1067,8 +1141,8 @@ export type HomeQuery = {
   }>;
 };
 
-export const UpdateEventFragmentFragmentDoc = gql`
-  fragment updateEventFragment on Event {
+export const UpdateFragmentEventWithChapterFragmentDoc = gql`
+  fragment updateFragmentEventWithChapter on EventWithChapter {
     id
     name
     description
@@ -1080,6 +1154,55 @@ export const UpdateEventFragmentFragmentDoc = gql`
     capacity
     image_url
     invite_only
+    chapter {
+      id
+      name
+    }
+    tags {
+      id
+      name
+    }
+  }
+`;
+export const UpdateFragmengEventWithEverythingFragmentDoc = gql`
+  fragment updateFragmengEventWithEverything on EventWithEverything {
+    id
+    name
+    description
+    url
+    streaming_url
+    capacity
+    start_at
+    ends_at
+    capacity
+    image_url
+    invite_only
+    chapter {
+      id
+      name
+    }
+    tags {
+      id
+      name
+    }
+    sponsors {
+      sponsor {
+        name
+        website
+        logo_path
+        type
+        id
+      }
+    }
+    venue {
+      id
+      name
+      street_address
+      city
+      postal_code
+      region
+      country
+    }
   }
 `;
 export const LoginDocument = gql`
@@ -1886,6 +2009,28 @@ export const UpdateEventDocument = gql`
       image_url
       invite_only
       tags {
+        id
+        name
+      }
+      sponsors {
+        sponsor {
+          name
+          website
+          logo_path
+          type
+          id
+        }
+      }
+      venue {
+        id
+        name
+        street_address
+        city
+        postal_code
+        region
+        country
+      }
+      chapter {
         id
         name
       }

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -866,6 +866,8 @@ export type UpdateFragmengEventWithEverythingFragment = {
     | undefined;
 };
 
+export type CancelEventFragment = { __typename?: 'Event'; canceled: boolean };
+
 export type CancelEventMutationVariables = Exact<{
   id: Scalars['Int'];
 }>;
@@ -1203,6 +1205,11 @@ export const UpdateFragmengEventWithEverythingFragmentDoc = gql`
       region
       country
     }
+  }
+`;
+export const CancelEventFragmentDoc = gql`
+  fragment cancelEvent on Event {
+    canceled
   }
 `;
 export const LoginDocument = gql`

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -767,11 +767,29 @@ export type UpdateEventMutation = {
     url?: string | null | undefined;
     streaming_url?: string | null | undefined;
     capacity: number;
+    start_at: any;
+    ends_at: any;
+    image_url: string;
+    invite_only: boolean;
     tags?:
       | Array<{ __typename?: 'Tag'; id: number; name: string }>
       | null
       | undefined;
   };
+};
+
+export type UpdateEventFragmentFragment = {
+  __typename?: 'Event';
+  id: number;
+  name: string;
+  description: string;
+  url?: string | null | undefined;
+  streaming_url?: string | null | undefined;
+  capacity: number;
+  start_at: any;
+  ends_at: any;
+  image_url: string;
+  invite_only: boolean;
 };
 
 export type CancelEventMutationVariables = Exact<{
@@ -1049,6 +1067,21 @@ export type HomeQuery = {
   }>;
 };
 
+export const UpdateEventFragmentFragmentDoc = gql`
+  fragment updateEventFragment on Event {
+    id
+    name
+    description
+    url
+    streaming_url
+    capacity
+    start_at
+    ends_at
+    capacity
+    image_url
+    invite_only
+  }
+`;
 export const LoginDocument = gql`
   mutation login($email: String!) {
     login(data: { email: $email }) {
@@ -1848,6 +1881,10 @@ export const UpdateEventDocument = gql`
       url
       streaming_url
       capacity
+      start_at
+      ends_at
+      image_url
+      invite_only
       tags {
         id
         name

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -129,11 +129,31 @@ export const updateEvent = gql`
       url
       streaming_url
       capacity
+      start_at
+      ends_at
+      image_url
+      invite_only
       tags {
         id
         name
       }
     }
+  }
+`;
+
+export const EVENT_FRAGMENT_UPDATE = gql`
+  fragment updateEventFragment on Event {
+    id
+    name
+    description
+    url
+    streaming_url
+    capacity
+    start_at
+    ends_at
+    capacity
+    image_url
+    invite_only
   }
 `;
 

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -137,12 +137,34 @@ export const updateEvent = gql`
         id
         name
       }
+      sponsors {
+        sponsor {
+          name
+          website
+          logo_path
+          type
+          id
+        }
+      }
+      venue {
+        id
+        name
+        street_address
+        city
+        postal_code
+        region
+        country
+      }
+      chapter {
+        id
+        name
+      }
     }
   }
 `;
 
-export const EVENT_FRAGMENT_UPDATE = gql`
-  fragment updateEventFragment on Event {
+export const EVENT_WITH_CHAPTER_FRAGMENT_UPDATE = gql`
+  fragment updateFragmentEventWithChapter on EventWithChapter {
     id
     name
     description
@@ -154,6 +176,56 @@ export const EVENT_FRAGMENT_UPDATE = gql`
     capacity
     image_url
     invite_only
+    chapter {
+      id
+      name
+    }
+    tags {
+      id
+      name
+    }
+  }
+`;
+
+export const EVENT_WITH_EVERYTHING_FRAGMENT_UPDATE = gql`
+  fragment updateFragmengEventWithEverything on EventWithEverything {
+    id
+    name
+    description
+    url
+    streaming_url
+    capacity
+    start_at
+    ends_at
+    capacity
+    image_url
+    invite_only
+    chapter {
+      id
+      name
+    }
+    tags {
+      id
+      name
+    }
+    sponsors {
+      sponsor {
+        name
+        website
+        logo_path
+        type
+        id
+      }
+    }
+    venue {
+      id
+      name
+      street_address
+      city
+      postal_code
+      region
+      country
+    }
   }
 `;
 

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -229,6 +229,12 @@ export const EVENT_WITH_EVERYTHING_FRAGMENT_UPDATE = gql`
   }
 `;
 
+export const EVENT_CANCEL_FRAGMENT = gql`
+  fragment cancelEvent on Event {
+    canceled
+  }
+`;
+
 export const cancelEvent = gql`
   mutation cancelEvent($id: Int!) {
     cancelEvent(id: $id) {

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -43,7 +43,7 @@ export const EditEventPage: NextPage = () => {
           paginatedEvents(existingData) {
             cache.writeFragment({
               id: `EventWithChapter:${event?.updateEvent.id}`,
-              data: event?.updateEvent,
+              data: { ...event?.updateEvent, __typename: 'EventWithChapter' },
               fragment: EVENT_WITH_CHAPTER_FRAGMENT_UPDATE,
             });
             return existingData;

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -30,7 +30,6 @@ export const EditEventPage: NextPage = () => {
 
   const [updateEvent] = useUpdateEventMutation({
     update(cache, { data: event }) {
-      console.log(event);
       cache.modify({
         fields: {
           events(existingData) {

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -10,7 +10,10 @@ import { getId } from '../../../../helpers/getId';
 import { Layout } from '../../shared/components/Layout';
 import EventForm from '../components/EventForm';
 import { EventFormData } from '../components/EventFormUtils';
-import { EVENT_FRAGMENT_UPDATE } from '../graphql/queries';
+import {
+  EVENT_WITH_CHAPTER_FRAGMENT_UPDATE,
+  EVENT_WITH_EVERYTHING_FRAGMENT_UPDATE,
+} from '../graphql/queries';
 
 export const EditEventPage: NextPage = () => {
   const router = useRouter();
@@ -27,13 +30,14 @@ export const EditEventPage: NextPage = () => {
 
   const [updateEvent] = useUpdateEventMutation({
     update(cache, { data: event }) {
+      console.log(event);
       cache.modify({
         fields: {
           events(existingData) {
             cache.writeFragment({
               id: `EventWithEverything:${event?.updateEvent.id}`,
               data: event?.updateEvent,
-              fragment: EVENT_FRAGMENT_UPDATE,
+              fragment: EVENT_WITH_EVERYTHING_FRAGMENT_UPDATE,
             });
             return existingData;
           },
@@ -41,7 +45,7 @@ export const EditEventPage: NextPage = () => {
             cache.writeFragment({
               id: `EventWithChapter:${event?.updateEvent.id}`,
               data: event?.updateEvent,
-              fragment: EVENT_FRAGMENT_UPDATE,
+              fragment: EVENT_WITH_CHAPTER_FRAGMENT_UPDATE,
             });
             return existingData;
           },

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -10,7 +10,7 @@ import { getId } from '../../../../helpers/getId';
 import { Layout } from '../../shared/components/Layout';
 import EventForm from '../components/EventForm';
 import { EventFormData } from '../components/EventFormUtils';
-import { EVENTS, EVENT } from '../graphql/queries';
+import { EVENT_FRAGMENT_UPDATE } from '../graphql/queries';
 
 export const EditEventPage: NextPage = () => {
   const router = useRouter();
@@ -25,10 +25,29 @@ export const EditEventPage: NextPage = () => {
     variables: { id },
   });
 
-  // TODO: update the cache directly:
-  // https://www.apollographql.com/docs/react/data/mutations/#updating-the-cache-directly
   const [updateEvent] = useUpdateEventMutation({
-    refetchQueries: [{ query: EVENTS }, { query: EVENT, variables: { id } }],
+    update(cache, { data: event }) {
+      cache.modify({
+        fields: {
+          events(existingData) {
+            cache.writeFragment({
+              id: `EventWithEverything:${event?.updateEvent.id}`,
+              data: event?.updateEvent,
+              fragment: EVENT_FRAGMENT_UPDATE,
+            });
+            return existingData;
+          },
+          paginatedEvents(existingData) {
+            cache.writeFragment({
+              id: `EventWithChapter:${event?.updateEvent.id}`,
+              data: event?.updateEvent,
+              fragment: EVENT_FRAGMENT_UPDATE,
+            });
+            return existingData;
+          },
+        },
+      });
+    },
   });
 
   const onSubmit = async (data: EventFormData) => {

--- a/server/src/controllers/Events/inputs.ts
+++ b/server/src/controllers/Events/inputs.ts
@@ -81,6 +81,10 @@ export class UpdateEventInputs {
 
   @Field(() => String, { nullable: true })
   image_url: string;
+
   @Field(() => [Int])
   sponsor_ids: number[];
+
+  @Field(() => Int, { nullable: true })
+  chapter_id: number;
 }

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -330,12 +330,12 @@ ${unsubscribe}
         event_id: id,
         sponsor_id: sId,
       }));
-    // TODO: if possible, replace (i.e. delete and create replacements in a
-    // batch)
-    await prisma.event_sponsors.deleteMany({ where: { event_id: id } });
-    await prisma.event_sponsors.createMany({
-      data: eventSponsorInput,
-    });
+    await prisma.$transaction([
+      prisma.event_sponsors.deleteMany({ where: { event_id: id } }),
+      prisma.event_sponsors.createMany({
+        data: eventSponsorInput,
+      }),
+    ]);
 
     // TODO: Handle tags
     const update: Prisma.eventsUpdateInput = {
@@ -351,14 +351,6 @@ ${unsubscribe}
       image_url: data.image_url ?? event.image_url,
       venue: { connect: { id: data?.venue_id } },
       chapter: { connect: { id: data.chapter_id ?? event.chapter.id } },
-      sponsors: {
-        connect: data.sponsor_ids.map((sId) => ({
-          sponsor_id_event_id: {
-            event_id: id,
-            sponsor_id: sId,
-          },
-        })),
-      },
     };
 
     if (data.venue_id) {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

To do:
- [x] Add updating for fields referencing other objects - at least `sponsors` and `venue`.
- [ ] Add direct cache updating in other places?
- [ ] Clean up.
- [ ] Anything else?

---

- Updated values are written to two cache ids - `EventWithChapter:${eventId}` and `EventWithEverything:${eventId}` (if they exist already). First one is from events query on home page.
- Updates cache directly on event edit and event cancel.
- Any notes and nitpicks are appreciated.