### PR TITLE
fix: use prisma's updateAt to handle updates

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -138,6 +138,8 @@ model user_event_roles {
 }
 
 model user_instance_roles {
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
   user_id   Int
   role_name String
   users     users  @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -13,7 +13,7 @@ datasource db {
 
 model chapters {
   created_at  DateTime             @default(now())
-  updated_at  DateTime             @default(now())
+  updated_at  DateTime             @updatedAt
   id          Int                  @id @default(autoincrement())
   name        String
   description String
@@ -30,7 +30,7 @@ model chapters {
 
 model event_sponsors {
   created_at DateTime @default(now())
-  updated_at DateTime @default(now())
+  updated_at DateTime @updatedAt
   sponsor_id Int
   event_id   Int
   events     events   @relation(fields: [event_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
@@ -41,7 +41,7 @@ model event_sponsors {
 
 model events {
   created_at       DateTime               @default(now())
-  updated_at       DateTime               @default(now())
+  updated_at       DateTime               @updatedAt
   id               Int                    @id @default(autoincrement())
   name             String
   description      String
@@ -67,7 +67,7 @@ model events {
 
 model rsvps {
   created_at   DateTime  @default(now())
-  updated_at   DateTime  @default(now())
+  updated_at   DateTime  @updatedAt
   user_id      Int
   event_id     Int
   date         DateTime
@@ -82,7 +82,7 @@ model rsvps {
 
 model sponsors {
   created_at     DateTime         @default(now())
-  updated_at     DateTime         @default(now())
+  updated_at     DateTime         @updatedAt
   id             Int              @id @default(autoincrement())
   name           String
   website        String
@@ -93,7 +93,7 @@ model sponsors {
 
 model tags {
   created_at DateTime @default(now())
-  updated_at DateTime @default(now())
+  updated_at DateTime @updatedAt
   id         Int      @id @default(autoincrement())
   name       String
   event_id   Int?
@@ -102,7 +102,7 @@ model tags {
 
 model user_bans {
   created_at DateTime @default(now())
-  updated_at DateTime @default(now())
+  updated_at DateTime @updatedAt
   user_id    Int
   chapter_id Int
   chapters   chapters @relation(fields: [chapter_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
@@ -113,7 +113,7 @@ model user_bans {
 
 model user_chapter_roles {
   created_at DateTime @default(now())
-  updated_at DateTime @default(now())
+  updated_at DateTime @updatedAt
   user_id    Int
   chapter_id Int
   role_name  String
@@ -126,7 +126,7 @@ model user_chapter_roles {
 
 model user_event_roles {
   created_at DateTime @default(now())
-  updated_at DateTime @default(now())
+  updated_at DateTime @updatedAt
   user_id    Int
   event_id   Int
   role_name  String
@@ -147,7 +147,7 @@ model user_instance_roles {
 
 model users {
   created_at          DateTime              @default(now())
-  updated_at          DateTime              @default(now())
+  updated_at          DateTime              @updatedAt
   id                  Int                   @id @default(autoincrement())
   first_name          String
   last_name           String
@@ -161,7 +161,7 @@ model users {
 
 model venues {
   created_at     DateTime @default(now())
-  updated_at     DateTime @default(now())
+  updated_at     DateTime @updatedAt
   id             Int      @id @default(autoincrement())
   name           String
   street_address String?


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

I'm not 100% convinced we *need* `created_at` or `updated_at`, but this makes sure that `update_at` is automatically changed to the current time whenever a record is altered.

For future reference, it's not correct to use queries like `SELECT * FROM chapters WHERE created_at = updated_at;` to see if a record has been updated, since `created_at` and `updated_at` may differ by a few milliseconds even on a newly created record.  `SELECT * FROM chapters WHERE updated_at <= (created_at + '2 ms');` seems fine, though a wider interval might be wise.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
