### PR TITLE
feat: return event on deletion

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -2208,8 +2208,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
+                "kind": "OBJECT",
+                "name": "Event",
                 "ofType": null
               }
             },

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -190,7 +190,7 @@ export type Mutation = {
   createSponsor: Sponsor;
   createVenue: Venue;
   deleteChapter: Scalars['Boolean'];
-  deleteEvent: Scalars['Boolean'];
+  deleteEvent: Event;
   deleteRsvp: Scalars['Boolean'];
   deleteVenue: Scalars['Boolean'];
   initUserInterestForChapter: Scalars['Boolean'];
@@ -789,7 +789,7 @@ export type DeleteEventMutationVariables = Exact<{
 
 export type DeleteEventMutation = {
   __typename?: 'Mutation';
-  deleteEvent: boolean;
+  deleteEvent: { __typename?: 'Event'; id: number };
 };
 
 export type ConfirmRsvpMutationVariables = Exact<{
@@ -1952,7 +1952,9 @@ export type CancelEventMutationOptions = Apollo.BaseMutationOptions<
 >;
 export const DeleteEventDocument = gql`
   mutation deleteEvent($id: Int!) {
-    deleteEvent(id: $id)
+    deleteEvent(id: $id) {
+      id
+    }
   }
 `;
 export type DeleteEventMutationFn = Apollo.MutationFunction<

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -148,7 +148,9 @@ export const cancelEvent = gql`
 
 export const deleteEvent = gql`
   mutation deleteEvent($id: Int!) {
-    deleteEvent(id: $id)
+    deleteEvent(id: $id) {
+      id
+    }
   }
 `;
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -33,7 +33,7 @@ model event_sponsors {
   updated_at DateTime @default(now())
   sponsor_id Int
   event_id   Int
-  events     events   @relation(fields: [event_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  events     events   @relation(fields: [event_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   sponsor    sponsors @relation(fields: [sponsor_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   @@id([sponsor_id, event_id])
@@ -74,7 +74,7 @@ model rsvps {
   on_waitlist  Boolean
   confirmed_at DateTime?
   canceled     Boolean
-  events       events    @relation(fields: [event_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  events       events    @relation(fields: [event_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   user         users     @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   @@id([user_id, event_id])
@@ -131,7 +131,7 @@ model user_event_roles {
   event_id   Int
   role_name  String
   subscribed Boolean
-  events     events   @relation(fields: [event_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  events     events   @relation(fields: [event_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   users      users    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   @@id([user_id, event_id, role_name])

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -404,13 +404,7 @@ ${unsubscribe}
 
   @Mutation(() => Event)
   async deleteEvent(@Arg('id', () => Int) id: number): Promise<Event> {
-    const result = await prisma.$transaction([
-      prisma.event_sponsors.deleteMany({ where: { event_id: id } }),
-      prisma.rsvps.deleteMany({ where: { event_id: id } }),
-      prisma.user_event_roles.deleteMany({ where: { event_id: id } }),
-      prisma.events.delete({ where: { id } }),
-    ]);
-    return result[3];
+    return await prisma.events.delete({ where: { id } });
   }
 
   // TODO: This will need a real GraphQL return type (AFAIK you have to return

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -402,12 +402,15 @@ ${unsubscribe}
     return event;
   }
 
-  // TODO: This will need a real GraphQL return type (AFAIK you have to return
-  // an object type)
-  @Mutation(() => Boolean)
-  async deleteEvent(@Arg('id', () => Int) id: number): Promise<boolean> {
-    await prisma.events.delete({ where: { id } });
-    return true;
+  @Mutation(() => Event)
+  async deleteEvent(@Arg('id', () => Int) id: number): Promise<Event> {
+    const result = await prisma.$transaction([
+      prisma.event_sponsors.deleteMany({ where: { event_id: id } }),
+      prisma.rsvps.deleteMany({ where: { event_id: id } }),
+      prisma.user_event_roles.deleteMany({ where: { event_id: id } }),
+      prisma.events.delete({ where: { id } }),
+    ]);
+    return result[3];
   }
 
   // TODO: This will need a real GraphQL return type (AFAIK you have to return


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Fixes not deleting events due to data existing in other related tables.
- Batches deletion in transaction.
- Returns event (id) on event deletion - this will be useful in case of updating cache directly after deletion.