### PR TITLE
fix: make root dir available in docker dev

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,12 +4,12 @@ services:
   app:
     command: sh -c './wait-for db:5432 -- npm run dev'
     volumes:
-      - ./server:/usr/chapter/server
+      - ./:/usr/chapter/
 
   client:
     command: npm run dev
     volumes:
-      - ./client:/usr/chapter/client
+      - ./:/usr/chapter/
 
   mailhog:
     depends_on:


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes https://github.com/freeCodeCamp/chapter/issues/891

@gikf you were right that this was a workspace issue.  Since a lot of dependencies were pulled up to `/` they weren't available to the containers (which had access to `/client` and `/server`). I'd like to keep using workspaces, but we can always revert (or switch to yarn) if the cons outweigh the pros.

Let me know if this sorts it out on your machine (it shouldn't be necessary to rebuild, just `docker-compose up`).
 
<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
