### PR TITLE
feat: throw by default on prisma findUnique and findFirst

### DIFF
--- a/server/src/controllers/Auth/middleware.ts
+++ b/server/src/controllers/Auth/middleware.ts
@@ -30,6 +30,7 @@ export const userMiddleware = (
     .findUnique({
       where: { id: value.id },
       include: { chapter_roles: true },
+      rejectOnNotFound: false,
     })
     .then((user) => {
       if (!user) {

--- a/server/src/controllers/Auth/resolver.ts
+++ b/server/src/controllers/Auth/resolver.ts
@@ -50,9 +50,6 @@ export class AuthResolver {
       where: { email: data.email },
       rejectOnNotFound: () => new Error('USER_NOT_FOUND'),
     });
-    if (!user) {
-      throw new Error('USER_NOT_FOUND');
-    }
 
     const { token, code } = authTokenService.generateToken(user.email);
     if (isDev()) {
@@ -87,10 +84,6 @@ export class AuthResolver {
     const user = await prisma.users.findUnique({
       where: { email: data.email },
     });
-
-    if (!user) {
-      throw new Error('User not found');
-    }
 
     const authToken = sign({ id: user.id }, getConfig('JWT_SECRET'), {
       expiresIn: '31d',

--- a/server/src/controllers/Auth/resolver.ts
+++ b/server/src/controllers/Auth/resolver.ts
@@ -33,6 +33,7 @@ export class AuthResolver {
   async register(@Arg('data') data: RegisterInput): Promise<User> {
     const existingUser = await prisma.users.findUnique({
       where: { email: data.email },
+      rejectOnNotFound: false,
     });
     if (existingUser) {
       throw new Error('EMAIL_IN_USE');
@@ -47,6 +48,7 @@ export class AuthResolver {
   async login(@Arg('data') data: LoginInput): Promise<LoginType> {
     const user = await prisma.users.findUnique({
       where: { email: data.email },
+      rejectOnNotFound: () => new Error('USER_NOT_FOUND'),
     });
     if (!user) {
       throw new Error('USER_NOT_FOUND');

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -201,11 +201,6 @@ ${unsubscribe}
       where: { user_id_event_id: { user_id: userId, event_id: eventId } },
     });
 
-    // TODO: tell TS that rsvp exists more directly
-    if (!rsvp) {
-      throw new Error('RSVP not found');
-    }
-
     const rsvpData: Prisma.rsvpsUpdateInput = {
       confirmed_at: new Date(),
       on_waitlist: false,
@@ -243,13 +238,11 @@ ${unsubscribe}
     let venue;
     if (data.venue_id) {
       venue = await prisma.venues.findUnique({ where: { id: data.venue_id } });
-      if (!venue) throw new Error('Venue missing');
     }
 
     const chapter = await prisma.chapters.findUnique({
       where: { id: data.chapter_id },
     });
-    if (!chapter) throw new Error('Chapter missing');
 
     // TODO: add admin and owner once you've figured out how to handle instance
     // roles
@@ -316,7 +309,6 @@ ${unsubscribe}
         rsvps: { include: { user: true } },
       },
     });
-    if (!event) throw new Error('Cant find event');
 
     const eventSponsorInput: Prisma.event_sponsorsCreateManyInput[] =
       data.sponsor_ids.map((sId) => ({
@@ -349,7 +341,6 @@ ${unsubscribe}
       const venue = await prisma.venues.findUnique({
         where: { id: data.venue_id },
       });
-      if (!venue) throw new Error('Cant find venue');
       // TODO: include a link back to the venue page
       if (event.venue_id !== venue.id) {
         const emailList = event.rsvps.map((rsvp) => rsvp.user.email);
@@ -433,11 +424,6 @@ ${unsubscribe}
         user_event_roles: true,
       },
     });
-
-    // TODO: if we've got here, the event exists, since findUnique throws if it
-    // fails to find something (find a better way to convince TypesScript of
-    // this)
-    if (!event) throw new Error("Can't find event");
 
     // TODO: the default should probably be to bcc everyone.
     const addresses: string[] = [];

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -111,6 +111,7 @@ export class EventResolver {
           event_id: eventId,
         },
       },
+      rejectOnNotFound: false,
     });
 
     if (rsvp) {

--- a/server/src/controllers/UserChapterRole/resolver.ts
+++ b/server/src/controllers/UserChapterRole/resolver.ts
@@ -16,9 +16,6 @@ export class UserChapterRoleResolver {
       where: { id: event_id },
       include: { chapter: true },
     });
-    if (!event) {
-      throw Error('Cannot find the event with id ' + event_id);
-    }
     if (!event.chapter) {
       throw Error('Cannot find the chapter of the event with id ' + event_id);
     }

--- a/server/src/controllers/UserChapterRole/resolver.ts
+++ b/server/src/controllers/UserChapterRole/resolver.ts
@@ -31,6 +31,7 @@ export class UserChapterRoleResolver {
         user_id: ctx.user.id,
         chapter_id: event.chapter.id,
       },
+      rejectOnNotFound: false,
     });
 
     if (!userChapterRole) {

--- a/server/src/prisma.ts
+++ b/server/src/prisma.ts
@@ -3,4 +3,4 @@ import { PrismaClient } from '@prisma/client';
 // importing config so the .env gets parsed
 import 'src/config';
 
-export const prisma = new PrismaClient();
+export const prisma = new PrismaClient({ rejectOnNotFound: true });


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Created as draft, as couple places relies a bit on the current behavior (returning `null` when record is not found). This might need some consideration, if this is indeed wanted change. More about this below.
- Sets Prisma to throw by default when `findUnique` or `findFrist` doesn't find record, instead of returning `null`. [(Reference)](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#rejectonnotfound). Typescript recognizes that, what makes half a dozen checks after the query obsolete.
- There's couple places where logic relies on the returned `null`. Currently if prisma would throw there when record is not found, then instead of simple check, we'd need `try/catch`. With ideally(?) making sure we are catching only not found errors. Because of that, I've added for these places optional `rejectOnNotFound` parameter to override default throwing, if needed this parameter also could be used for custom error message. Probably these could/should/would be refactored to rely more on the db constraints, but I haven't look at that too close in this PR. Couple examples: https://github.com/freeCodeCamp/chapter/blob/8287aca478355c39c0650a600cde217e9e751a53/server/src/controllers/Auth/resolver.ts#L33-L44
https://github.com/freeCodeCamp/chapter/blob/8287aca478355c39c0650a600cde217e9e751a53/server/src/controllers/Events/resolver.ts#L107-L142
