### PR TITLE
chore: remove ttypescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,6 +2680,7 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
       "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 12"
@@ -2690,6 +2691,7 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
       "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@cspotcode/source-map-consumer": "0.8.0"
@@ -5559,6 +5561,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
       "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@tsconfig/node12": {
@@ -5566,6 +5569,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
       "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@tsconfig/node14": {
@@ -5573,6 +5577,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
       "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@tsconfig/node16": {
@@ -5580,6 +5585,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/accepts": {
@@ -6248,30 +6254,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-    },
-    "node_modules/@zerollup/ts-helpers": {
-      "version": "1.7.18",
-      "resolved": "https://registry.npmjs.org/@zerollup/ts-helpers/-/ts-helpers-1.7.18.tgz",
-      "integrity": "sha512-S9zN+y+i5yN/evfWquzSO3lubqPXIsPQf6p9OiPMpRxDx/0totPLF39XoRw48Dav5dSvbIE8D2eAPpXXJxvKwg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.12.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=3.7.2"
-      }
-    },
-    "node_modules/@zerollup/ts-transform-paths": {
-      "version": "1.7.18",
-      "resolved": "https://registry.npmjs.org/@zerollup/ts-transform-paths/-/ts-transform-paths-1.7.18.tgz",
-      "integrity": "sha512-YPVUxvWQVzRx1OBN0Pmkd58+R9FcfUJuwTaPUSoi5rKxuXMtxevTXdfi0w5mEaIH8b0DfL+wg0wFDHiJE+S2zA==",
-      "dev": true,
-      "dependencies": {
-        "@zerollup/ts-helpers": "^1.7.18"
-      },
-      "peerDependencies": {
-        "typescript": ">=3.7.2"
-      }
     },
     "node_modules/abab": {
       "version": "2.0.5",
@@ -19645,6 +19627,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
       "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.7.0",
@@ -19687,6 +19670,7 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
@@ -19697,6 +19681,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.3.1"
@@ -19759,23 +19744,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
-    },
-    "node_modules/ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
-      "dev": true,
-      "dependencies": {
-        "resolve": ">=1.9.0"
-      },
-      "bin": {
-        "ttsc": "bin/tsc",
-        "ttsserver": "bin/tsserver"
-      },
-      "peerDependencies": {
-        "ts-node": ">=8.0.2",
-        "typescript": ">=3.2.2"
-      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -20658,7 +20626,6 @@
         "type-graphql": "1.1.1"
       },
       "devDependencies": {
-        "@zerollup/ts-transform-paths": "1.7.18",
         "chai": "4.3.6",
         "concurrently": "7.0.0",
         "date-fns": "2.28.0",
@@ -20670,7 +20637,6 @@
         "sinon": "13.0.0",
         "sinon-chai": "3.7.0",
         "supertest": "6.2.2",
-        "ttypescript": "1.5.13",
         "typescript": "4.4.4"
       }
     }
@@ -22770,6 +22736,7 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
       "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "@cspotcode/source-map-support": {
@@ -22777,6 +22744,7 @@
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
       "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "requires": {
         "@cspotcode/source-map-consumer": "0.8.0"
@@ -25036,6 +25004,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
       "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "@tsconfig/node12": {
@@ -25043,6 +25012,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
       "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "@tsconfig/node14": {
@@ -25050,6 +25020,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
       "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "@tsconfig/node16": {
@@ -25057,6 +25028,7 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "@types/accepts": {
@@ -25624,24 +25596,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
           "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
-      }
-    },
-    "@zerollup/ts-helpers": {
-      "version": "1.7.18",
-      "resolved": "https://registry.npmjs.org/@zerollup/ts-helpers/-/ts-helpers-1.7.18.tgz",
-      "integrity": "sha512-S9zN+y+i5yN/evfWquzSO3lubqPXIsPQf6p9OiPMpRxDx/0totPLF39XoRw48Dav5dSvbIE8D2eAPpXXJxvKwg==",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.12.0"
-      }
-    },
-    "@zerollup/ts-transform-paths": {
-      "version": "1.7.18",
-      "resolved": "https://registry.npmjs.org/@zerollup/ts-transform-paths/-/ts-transform-paths-1.7.18.tgz",
-      "integrity": "sha512-YPVUxvWQVzRx1OBN0Pmkd58+R9FcfUJuwTaPUSoi5rKxuXMtxevTXdfi0w5mEaIH8b0DfL+wg0wFDHiJE+S2zA==",
-      "dev": true,
-      "requires": {
-        "@zerollup/ts-helpers": "^1.7.18"
       }
     },
     "abab": {
@@ -26790,7 +26744,6 @@
       "version": "file:server",
       "requires": {
         "@prisma/client": "^3.4.2",
-        "@zerollup/ts-transform-paths": "1.7.18",
         "apollo-server-express": "3.6.2",
         "babel-plugin-transform-typescript-metadata": "0.3.2",
         "calendar-link": "2.1.1",
@@ -26818,7 +26771,6 @@
         "sinon": "13.0.0",
         "sinon-chai": "3.7.0",
         "supertest": "6.2.2",
-        "ttypescript": "1.5.13",
         "type-graphql": "1.1.1",
         "typescript": "4.4.4"
       }
@@ -35917,6 +35869,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
       "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
       "dev": true,
+      "optional": true,
       "peer": true,
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",
@@ -35938,6 +35891,7 @@
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
           "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
           "dev": true,
+          "optional": true,
           "peer": true
         },
         "diff": {
@@ -35945,6 +35899,7 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true,
+          "optional": true,
           "peer": true
         }
       }
@@ -35996,15 +35951,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
-    },
-    "ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
-      "dev": true,
-      "requires": {
-        "resolve": ">=1.9.0"
-      }
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "jsonwebtoken": "8.5.1",
         "lint-staged": "12.3.2",
         "prettier": "2.5.1",
+        "shx": "^0.3.4",
         "ts-jest": "27.1.3",
         "typescript": "4.4.4"
       },
@@ -11643,6 +11644,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -17837,6 +17847,18 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -18540,11 +18562,44 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
       "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
     },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -29825,6 +29880,12 @@
         "side-channel": "^1.0.4"
       }
     },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -34464,6 +34525,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -35018,11 +35088,32 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
       "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
     },
+    "shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
+    },
+    "shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      }
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "npm run build:client && npm run build:server",
     "build:client": "npm -w=client run build",
     "build:server": "npm -w=server run build",
+    "clean": "shx rm ./server/tsconfig.tsbuildinfo",
     "gen": "npm -w=client run gen",
     "start": "concurrently \"npm run start:server\" \"npm run start:client\"",
     "start:server": "npm -w=server start",
@@ -91,6 +92,7 @@
     "jsonwebtoken": "8.5.1",
     "lint-staged": "12.3.2",
     "prettier": "2.5.1",
+    "shx": "^0.3.4",
     "ts-jest": "27.1.3",
     "typescript": "4.4.4"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -4,8 +4,8 @@
   "description": "A self-hosted event management tool for nonprofits",
   "main": "index.js",
   "scripts": {
-    "build": "ttsc",
-    "dev": "ttsc && concurrently \"ttsc --watch --preserveWatchOutput\" \"node-dev --notify=false src/app.js\"",
+    "build": "tsc",
+    "dev": "tsc && concurrently \"tsc --watch --preserveWatchOutput\" \"node-dev --notify=false src/app.js\"",
     "prepare": "rimraf tsconfig.tsbuildinfo && prisma generate",
     "start": "node ./src/app.js"
   },
@@ -48,7 +48,6 @@
     "type-graphql": "1.1.1"
   },
   "devDependencies": {
-    "@zerollup/ts-transform-paths": "1.7.18",
     "chai": "4.3.6",
     "concurrently": "7.0.0",
     "date-fns": "2.28.0",
@@ -60,7 +59,6 @@
     "sinon": "13.0.0",
     "sinon-chai": "3.7.0",
     "supertest": "6.2.2",
-    "ttypescript": "1.5.13",
     "typescript": "4.4.4"
   }
 }

--- a/server/prisma/generator/factories/chapters.factory.ts
+++ b/server/prisma/generator/factories/chapters.factory.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { Prisma } from '@prisma/client';
-import { prisma } from 'src/prisma';
+
+import { prisma } from '../../../src/prisma';
 
 const { company, lorem, address, image } = faker;
 

--- a/server/prisma/generator/factories/events.factory.ts
+++ b/server/prisma/generator/factories/events.factory.ts
@@ -2,8 +2,8 @@ import { faker } from '@faker-js/faker';
 import { Prisma, events_venue_type_enum } from '@prisma/client';
 import { addHours, add } from 'date-fns';
 
+import { prisma } from '../../../src/prisma';
 import { random, randomEnum, randomItem, randomItems } from '../lib/random';
-import { prisma } from 'src/prisma';
 
 const { company, internet, lorem, image } = faker;
 

--- a/server/prisma/generator/factories/rsvps.factory.ts
+++ b/server/prisma/generator/factories/rsvps.factory.ts
@@ -1,9 +1,9 @@
 import { faker } from '@faker-js/faker';
 import { Prisma } from '@prisma/client';
 
+import { prisma } from '../../../src/prisma';
 import { random, randomItems } from '../lib/random';
 import { makeBooleanIterator } from '../lib/util';
-import { prisma } from 'src/prisma';
 
 const { date } = faker;
 

--- a/server/prisma/generator/factories/sponsors.factory.ts
+++ b/server/prisma/generator/factories/sponsors.factory.ts
@@ -1,7 +1,8 @@
 import { faker } from '@faker-js/faker';
 import { Prisma } from '@prisma/client';
+
+import { prisma } from '../../../src/prisma';
 import { randomEnum } from '../lib/random';
-import { prisma } from 'src/prisma';
 
 const { company, internet, system } = faker;
 

--- a/server/prisma/generator/factories/user.factory.ts
+++ b/server/prisma/generator/factories/user.factory.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { Prisma } from '@prisma/client';
-import { prisma } from 'src/prisma';
+
+import { prisma } from '../../../src/prisma';
 
 const { name, internet } = faker;
 

--- a/server/prisma/generator/factories/venues.factory.ts
+++ b/server/prisma/generator/factories/venues.factory.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { Prisma } from '@prisma/client';
-import { prisma } from 'src/prisma';
+
+import { prisma } from '../../../src/prisma';
 
 const { company, address } = faker;
 

--- a/server/prisma/generator/seed.ts
+++ b/server/prisma/generator/seed.ts
@@ -1,3 +1,4 @@
+import { prisma } from '../../src/prisma';
 import createChapters from './factories/chapters.factory';
 import createEvents from './factories/events.factory';
 import createRsvps from './factories/rsvps.factory';
@@ -5,7 +6,6 @@ import createSponsors from './factories/sponsors.factory';
 import createUsers from './factories/user.factory';
 import createVenues from './factories/venues.factory';
 import setupRoles from './setupRoles';
-import { prisma } from 'src/prisma';
 
 (async () => {
   const tablenames = await prisma.$queryRaw<

--- a/server/prisma/generator/setupRoles.ts
+++ b/server/prisma/generator/setupRoles.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client';
 
+import { prisma } from '../../src/prisma';
 import { makeBooleanIterator } from './lib/util';
-import { prisma } from 'src/prisma';
 
 const setupRoles = async (
   adminId: number,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,12 +4,13 @@ import cors from 'cors';
 import express, { Express, Response } from 'express';
 // import isDocker from 'is-docker';
 import { buildSchema } from 'type-graphql';
-import { GQLCtx, Request } from 'src/common-types/gql';
-import { resolvers } from 'src/controllers';
+
+import { GQLCtx, Request } from './common-types/gql';
+import { resolvers } from './controllers';
 import {
   userMiddleware,
   handleAuthenticationError,
-} from 'src/controllers/Auth/middleware';
+} from './controllers/Auth/middleware';
 
 // TODO: reinstate these checks (possibly using an IS_DOCKER env var)
 // // Make sure to kill the app if using non docker-compose setup and docker-compose

--- a/server/src/common-types/gql.ts
+++ b/server/src/common-types/gql.ts
@@ -1,5 +1,6 @@
 import { Request as ExpressRequest, Response } from 'express';
-import { User } from 'src/graphql-types';
+
+import { User } from '../graphql-types';
 
 // TODO: import from the TypeGraphQL user chapter role object, once that's fixed
 // rather than defining it here

--- a/server/src/common-types/index.d.ts
+++ b/server/src/common-types/index.d.ts
@@ -1,4 +1,4 @@
-import { User } from 'src/graphql-types';
+import { User } from '../graphql-types';
 
 declare global {
   namespace Express {

--- a/server/src/controllers/Auth/inputs.ts
+++ b/server/src/controllers/Auth/inputs.ts
@@ -1,5 +1,6 @@
 import { InputType, Field, ObjectType } from 'type-graphql';
-import { User } from 'src/graphql-types';
+
+import { User } from '../../graphql-types';
 
 @InputType()
 export class RegisterInput {

--- a/server/src/controllers/Auth/middleware.ts
+++ b/server/src/controllers/Auth/middleware.ts
@@ -1,8 +1,9 @@
 import { NextFunction, Response } from 'express';
 import { TokenExpiredError, JsonWebTokenError, verify } from 'jsonwebtoken';
-import { Request } from 'src/common-types/gql';
-import { getConfig } from 'src/config';
-import { prisma } from 'src/prisma';
+
+import { Request } from '../../common-types/gql';
+import { getConfig } from '../../config';
+import { prisma } from '../../prisma';
 
 export const userMiddleware = (
   req: Request,

--- a/server/src/controllers/Auth/resolver.ts
+++ b/server/src/controllers/Auth/resolver.ts
@@ -2,18 +2,18 @@ import { Prisma } from '@prisma/client';
 import { verify, sign } from 'jsonwebtoken';
 import { Resolver, Arg, Mutation, Query, Ctx } from 'type-graphql';
 
+import { GQLCtx } from '../../common-types/gql';
+import { getConfig, isDev } from '../../config';
+import { User } from '../../graphql-types';
+import { prisma } from '../../prisma';
+import { authTokenService } from '../../services/AuthToken';
+import MailerService from '../../services/MailerService';
 import {
   AuthenticateType,
   LoginInput,
   LoginType,
   RegisterInput,
 } from './inputs';
-import { GQLCtx } from 'src/common-types/gql';
-import { getConfig, isDev } from 'src/config';
-import { User } from 'src/graphql-types';
-import { prisma } from 'src/prisma';
-import { authTokenService } from 'src/services/AuthToken';
-import MailerService from 'src/services/MailerService';
 
 type TokenResponseType = {
   email: string;

--- a/server/src/controllers/Chapter/inputs.ts
+++ b/server/src/controllers/Chapter/inputs.ts
@@ -1,5 +1,6 @@
 import { InputType, Field } from 'type-graphql';
-import { Chapter } from 'src/graphql-types';
+
+import { Chapter } from '../../graphql-types';
 
 @InputType()
 export class CreateChapterInputs implements Omit<Chapter, 'id' | 'creator_id'> {

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -1,9 +1,10 @@
 import { Prisma } from '@prisma/client';
 import { Resolver, Query, Arg, Int, Mutation, Ctx } from 'type-graphql';
+
+import { GQLCtx } from '../../common-types/gql';
+import { Chapter, ChapterWithRelations } from '../../graphql-types';
+import { prisma } from '../../prisma';
 import { CreateChapterInputs, UpdateChapterInputs } from './inputs';
-import { GQLCtx } from 'src/common-types/gql';
-import { Chapter, ChapterWithRelations } from 'src/graphql-types';
-import { prisma } from 'src/prisma';
 
 @Resolver()
 export class ChapterResolver {

--- a/server/src/controllers/Events/inputs.ts
+++ b/server/src/controllers/Events/inputs.ts
@@ -1,6 +1,7 @@
 import { IsUrl } from 'class-validator';
 import { InputType, Field, Int } from 'type-graphql';
-import { events_venue_type_enum } from 'src/graphql-types';
+
+import { events_venue_type_enum } from '../../graphql-types';
 
 @InputType()
 export class CreateEventInputs {

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -1,16 +1,17 @@
 import { Prisma } from '@prisma/client';
 import { CalendarEvent, google, outlook } from 'calendar-link';
 import { Resolver, Query, Arg, Int, Mutation, Ctx } from 'type-graphql';
-import { CreateEventInputs, UpdateEventInputs } from './inputs';
-import { GQLCtx } from 'src/common-types/gql';
+
+import { GQLCtx } from '../../common-types/gql';
 import {
   Event,
   Rsvp,
   EventWithEverything,
   EventWithChapter,
-} from 'src/graphql-types';
-import { prisma } from 'src/prisma';
-import MailerService from 'src/services/MailerService';
+} from '../../graphql-types';
+import { prisma } from '../../prisma';
+import MailerService from '../../services/MailerService';
+import { CreateEventInputs, UpdateEventInputs } from './inputs';
 
 //Place holder for unsubscribe
 //TODO: Replace placeholder with actual unsubscribe link

--- a/server/src/controllers/Messages/resolver.ts
+++ b/server/src/controllers/Messages/resolver.ts
@@ -1,7 +1,8 @@
 import { Resolver, Mutation, Arg } from 'type-graphql';
+
+import MailerService from '../../services/MailerService';
 import { Email } from './Email';
 import { SendEmailInputs } from './inputs';
-import MailerService from 'src/services/MailerService';
 
 @Resolver()
 export class EmailResolver {

--- a/server/src/controllers/Sponsors/resolver.ts
+++ b/server/src/controllers/Sponsors/resolver.ts
@@ -1,9 +1,9 @@
 import { Prisma } from '@prisma/client';
 import { Resolver, Query, Arg, Int, Mutation } from 'type-graphql';
 
+import { Sponsor } from '../../graphql-types/Sponsor';
+import { prisma } from '../../prisma';
 import { CreateSponsorInputs, UpdateSponsorInputs } from './inputs';
-import { Sponsor } from 'src/graphql-types/Sponsor';
-import { prisma } from 'src/prisma';
 
 @Resolver()
 export class SponsorResolver {

--- a/server/src/controllers/UserChapterRole/resolver.ts
+++ b/server/src/controllers/UserChapterRole/resolver.ts
@@ -1,6 +1,7 @@
 import { Arg, Ctx, Int, Mutation, Resolver } from 'type-graphql';
-import { GQLCtx } from 'src/common-types/gql';
-import { prisma } from 'src/prisma';
+
+import { GQLCtx } from '../../common-types/gql';
+import { prisma } from '../../prisma';
 
 @Resolver()
 export class UserChapterRoleResolver {

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -1,8 +1,9 @@
 import { Prisma } from '@prisma/client';
 import { Resolver, Query, Arg, Int, Mutation } from 'type-graphql';
+
+import { Venue } from '../../graphql-types';
+import { prisma } from '../../prisma';
 import { CreateVenueInputs, UpdateVenueInputs } from './inputs';
-import { Venue } from 'src/graphql-types';
-import { prisma } from 'src/prisma';
 
 @Resolver()
 export class VenueResolver {

--- a/server/src/controllers/index.ts
+++ b/server/src/controllers/index.ts
@@ -1,11 +1,12 @@
+import { UserResolver } from '../graphql-types';
+import { AuthResolver } from './Auth/resolver';
 import { ChapterResolver } from './Chapter/resolver';
 import { EventResolver } from './Events/resolver';
 import { EmailResolver } from './Messages/resolver';
 import { SponsorResolver } from './Sponsors/resolver';
 import { UserChapterRoleResolver } from './UserChapterRole/resolver';
 import { VenueResolver } from './Venue/resolver';
-import { AuthResolver } from 'src/controllers/Auth/resolver';
-import { UserResolver } from 'src/graphql-types';
+
 const resolvers = [
   ChapterResolver,
   VenueResolver,

--- a/server/src/prisma.ts
+++ b/server/src/prisma.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 
 // importing config so the .env gets parsed
-import 'src/config';
+import './config';
 
 export const prisma = new PrismaClient();

--- a/server/src/production.ts
+++ b/server/src/production.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import express from 'express';
 import next from 'next';
 
-import { main } from 'src/app';
+import { main } from './app';
 
 const PORT = parseInt(process.env.PORT || '', 10) || 5000;
 const app = next({ dev: false, dir: join(__dirname, '../../client') });

--- a/server/src/services/AuthToken.ts
+++ b/server/src/services/AuthToken.ts
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
-import { getConfig } from 'src/config';
+
+import { getConfig } from '../config';
 
 class AuthToken {
   private readonly secret: string;

--- a/server/src/services/MailerService.ts
+++ b/server/src/services/MailerService.ts
@@ -1,5 +1,6 @@
 import nodemailer, { Transporter, SentMessageInfo } from 'nodemailer';
-import Utilities from 'src/util/Utilities';
+
+import Utilities from '../util/Utilities';
 
 // @todo add ourEmail, emailUsername, emailPassword, and emailService as
 // environment variables when they become available. Temporary placeholders

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -1,8 +1,9 @@
 import { assert, expect } from 'chai';
 import jwt from 'jsonwebtoken';
 import { stub, restore } from 'sinon';
-import { getConfig } from 'src/config';
-import { authTokenService } from 'src/services/AuthToken';
+
+import { getConfig } from '../src/config';
+import { authTokenService } from '../src/services/AuthToken';
 
 beforeEach(() => {
   stub(console, 'warn');

--- a/server/tests/Mailer.test.ts
+++ b/server/tests/Mailer.test.ts
@@ -2,8 +2,9 @@ import assert from 'assert';
 import chai, { expect } from 'chai';
 import { stub, restore } from 'sinon';
 import sinonChai from 'sinon-chai';
-import MailerService from 'src/services/MailerService';
-import Utilities from 'src/util/Utilities';
+
+import MailerService from '../src/services/MailerService';
+import Utilities from '../src/util/Utilities';
 
 chai.use(sinonChai);
 

--- a/server/tests/Resolver.test.ts
+++ b/server/tests/Resolver.test.ts
@@ -2,8 +2,8 @@ import { faker } from '@faker-js/faker';
 import { expect } from 'chai';
 import { GraphQLError } from 'graphql';
 import { ArgumentValidationError } from 'type-graphql/dist/errors/ArgumentValidationError';
+import longString from '../src/controllers/Messages/longString';
 import { callSchema } from './testUtils/callSchema';
-import longString from 'src/controllers/Messages/longString';
 
 interface WithValidationError extends GraphQLError {
   originalError: ArgumentValidationError;

--- a/server/tests/Utilities.test.ts
+++ b/server/tests/Utilities.test.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
-import Utilities from 'src/util/Utilities';
+
+import Utilities from '../src/util/Utilities';
 
 describe('Utilities Class', () => {
   it('allValuesAreDefined should correctly catch undefined, null, and empty string values', () => {

--- a/server/tests/testUtils/App.ts
+++ b/server/tests/testUtils/App.ts
@@ -3,8 +3,9 @@ import express from 'express';
 import { responseErrorHandler } from 'express-response-errors';
 import getPort, { portNumbers } from 'get-port';
 import request from 'supertest';
-import { Request, ChapterRoles } from 'src/common-types/gql';
-import { User } from 'src/graphql-types';
+
+import { Request, ChapterRoles } from '../../src/common-types/gql';
+import { User } from '../../src/graphql-types';
 
 type InitProps = {
   withRouter?: express.Router;

--- a/server/tests/testUtils/createSchema.ts
+++ b/server/tests/testUtils/createSchema.ts
@@ -1,5 +1,6 @@
 import { buildSchema } from 'type-graphql';
-import { resolvers } from 'src/controllers';
+
+import { resolvers } from '../../src/controllers';
 
 export const createSchema = () =>
   buildSchema({

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -24,12 +24,6 @@
     "types": ["jest", "node"],
     "typeRoots": ["src/common-types/index.d.ts", "../node_modules/@types"],
     "incremental": true,
-    "plugins": [
-      {
-        "transform": "@zerollup/ts-transform-paths",
-        "exclude": ["*"]
-      }
-    ]
   },
   "include": ["src/**/*", "prisma/**/*", "tests/**/*"],
   "exclude": ["node_modules"]

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -3,7 +3,6 @@
     "allowSyntheticDefaultImports": true,
     "jsx": "preserve",
     "lib": ["dom", "es2017"],
-    "baseUrl": "./",
     "module": "commonjs",
     "moduleResolution": "node",
     "noUnusedLocals": true,


### PR DESCRIPTION
- chore: convert to relative links
- chore: remove ts-transform-paths and ttypescript

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Absolute paths were quite nice, but they make it less obvious what's a node_module and what's source.  Also, supporting them requires both ttypescript and the plugin ts-transform-paths.  Finally, due to an incompatibility between ttypescript and recent versions of typescript, we've been stuck to version 4.4.4 of typescript.  Removing ttypescript unblocks updates.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
