### PR TITLE
fix: don't auto add rsvps from waitlist if event is invite only

### DIFF
--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -124,7 +124,7 @@ export class EventResolver {
         },
       });
 
-      if (!oldRsvp.on_waitlist) {
+      if (!event.invite_only && !oldRsvp.on_waitlist) {
         const waitingList = event.rsvps.filter((r) => r.on_waitlist);
 
         if (waitingList.length > 0) {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Fixes, for invite only events, bug moving rsvp from waitlist, when confirmed rsvps cancels. As that behavior seems to be fine for non-invite-only events, there's just added check if event is not invite only.

To reproduce issue:
1. Rsvp for invite only event. Rsvp is placed on waitlist.
2. Confirm rsvp in dashboard.
3. Cancel rsvp on event page.
4. See one of the remaining waitlisted rsvp be moved out of the waitlist.