### PR TITLE
fix: allow returning rsvp with null confirmed_at

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -3108,13 +3108,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3215,13 +3211,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -345,7 +345,7 @@ export type RegisterInput = {
 export type Rsvp = {
   __typename?: 'Rsvp';
   canceled: Scalars['Boolean'];
-  confirmed_at: Scalars['DateTime'];
+  confirmed_at?: Maybe<Scalars['DateTime']>;
   date: Scalars['DateTime'];
   event_id: Scalars['Int'];
   on_waitlist: Scalars['Boolean'];
@@ -355,7 +355,7 @@ export type Rsvp = {
 export type RsvpWithUser = {
   __typename?: 'RsvpWithUser';
   canceled: Scalars['Boolean'];
-  confirmed_at: Scalars['DateTime'];
+  confirmed_at?: Maybe<Scalars['DateTime']>;
   date: Scalars['DateTime'];
   event_id: Scalars['Int'];
   on_waitlist: Scalars['Boolean'];
@@ -799,7 +799,11 @@ export type ConfirmRsvpMutationVariables = Exact<{
 
 export type ConfirmRsvpMutation = {
   __typename?: 'Mutation';
-  confirmRsvp: { __typename?: 'Rsvp'; confirmed_at: any; on_waitlist: boolean };
+  confirmRsvp: {
+    __typename?: 'Rsvp';
+    confirmed_at?: any | null | undefined;
+    on_waitlist: boolean;
+  };
 };
 
 export type DeleteRsvpMutationVariables = Exact<{
@@ -983,7 +987,10 @@ export type RsvpToEventMutationVariables = Exact<{
 
 export type RsvpToEventMutation = {
   __typename?: 'Mutation';
-  rsvpEvent?: { __typename?: 'Rsvp'; confirmed_at: any } | null | undefined;
+  rsvpEvent?:
+    | { __typename?: 'Rsvp'; confirmed_at?: any | null | undefined }
+    | null
+    | undefined;
 };
 
 export type MinEventsQueryVariables = Exact<{ [key: string]: never }>;

--- a/server/src/graphql-types/Rsvp.ts
+++ b/server/src/graphql-types/Rsvp.ts
@@ -14,7 +14,7 @@ export class Rsvp {
   @Field(() => Boolean)
   on_waitlist: boolean;
 
-  @Field(() => Date)
+  @Field(() => Date, { nullable: true })
   confirmed_at: Date | null;
 
   @Field(() => Boolean)


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Changes `confirmed_at` field in `Rsvp` object type to allow being nullable. Rsvping in client expects rsvp object with `confirmed_at`. For invite only events, new rsvp object has `null` for `confirmed_at`, this results in complaints and error.