### PR TITLE
Docs: Update nvm, node, and npm notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Follow these steps to fork the repository:
     * _Git Bash_ - this terminal shell emulates Linux and is included in _Git for Windows_. It works, but is more likely to have permission errors or minor inconsistencies.
     * _PowerShell_ and _cmd_ may run the **_Chapter_** app in _Docker Mode_, but these Windows native shells are not supported for this project.
 
-**Prerequisites**: [Git](https://git-scm.com/downloads) must exist (run ``git --version`` to check) within your development terminal / shell.  You will also need to have [Node.js](https://nodejs.org/en/) 16 and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) 8.  We recommend using [nvm](https://github.com/nvm-sh/nvm) to simplify the process of installing Node.js - `nvm install` will automatically install the correct version. Then `npm i -g npm@8` will update npm to a compatible version.
+**Prerequisites**: [Git](https://git-scm.com/downloads) must exist (run ``git --version`` to check) within your development terminal / shell.
 
 1. Decide if you will [authenticate to GitHub using SSH or HTTPS](https://docs.github.com/en/github/authenticating-to-github/about-authentication-to-github#authenticating-with-the-command-line).
     * SSH - uses SSH key authentication instead of a username and password.
@@ -318,17 +318,22 @@ You have successfully created a PR. Congratulations! :tada:
 # Running the Application
 **Prerequisite**: Follow steps 1 and 2 of the [**Contributing Code**](#contributing-code) section, above, before continuing to the next step in this section.
 
-<details><summary><b>Step 1</b> - Install Node.js and dependencies</summary>
+<details><summary><b>Step 1</b> - Install Node.js and Dependencies</summary>
  
-**Prerequisite**: [Node.js](https://nodejs.org/en/download/) must exist on your system.
+**Prerequisite**: Node.js must exist on your system
+
 > Note: Close and re-open your terminal after the installation finishes.
 
-Ensure the Node.js tools are installed:
+Check that compatible versions of _node_ and _npm_ are installed:
+* Node.js 16 or greater - run `node --version` and the output should be like **v16**.0.0
+* npm 8 or greater - run `npm --version` and the output should be like **8**.0.0
 
-* Node.js 16 or greater - `node --version` and the output should be like **v16**.0.0
-* npm 8 or greater - `npm --version` and the output should be like **8**.0.0
+> Note: If your version of _node_ or _npm_ are not sufficient, then: 
+> * (Recommended) Use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to manage multiple version of Node.js, then running `nvm install` within the root code directory.
+ > * Or, install or update the [latest version of Node.js](https://nodejs.org/en/download/)
 
-Run `npm i` to install all of the necessary dependencies.
+
+Now, run `npm i` to install all of the necessary dependencies.
 
 This step will **automatically** read and process the _package.json_ file. Most notably it:
 * Downloads all Node package dependencies to the _node_modules_ sub-directory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Follow these steps to fork the repository:
 ![an image illustrating the fork button](docs/assets/how-to-fork.png)
 </details>
 
-<details><summary><b>Step 2</b> - Prepare the Development Environment</summary>
+<details><summary><b>Step 2</b> - Prepare the Terminal and Git Environment</summary>
 
 **Prerequisite**:  All `commands` will be run within a terminal's command line / shell on your development device. Options vary by operating system.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,17 +320,17 @@ You have successfully created a PR. Congratulations! :tada:
 
 <details><summary><b>Step 1</b> - Install Node.js and Dependencies</summary>
  
-**Prerequisite**: Node.js must exist on your system
+**Prerequisite**: _Node.js_ 16+ and _npm_ 8+ must be installed
 
-Check that compatible versions of _node_ and _npm_ are installed:
-* Node.js 16 or greater - run `node --version` and the output should be like **v16**.0.0
-* npm 8 or greater - run `npm --version` and the output should be like **8**.0.0
+> Note
+> * To check Node.js, run `node --version` and the output should be like **v16**.#.#
+> * If _Node.js_ is not installed, or using an older version, then:  
+>   * (Recommended) Use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to manage multiple version of Node.js and run `nvm install` within the root code directory.
+ >   * Or, install or update the [latest version of Node.js](https://nodejs.org/en/download/). Be sure to close and re-open your terminal for the changes to take effect.
+> * To check npm, run `npm --version` and the output should be like **8**.#.#
+> * Update npm to the latest version by running `npm i -g npm@8` in the root code directory.
 
-> Note: If your version of _node_ or _npm_ are not sufficient, then: 
-> * (Recommended) Use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to manage multiple version of Node.js and run `nvm install` within the root code directory.
- > * Or, install or update the [latest version of Node.js](https://nodejs.org/en/download/). Be sure to close and re-open your terminal for the changes to take effect.
-
-Now, run `npm i` to install all of the necessary dependencies.
+Run `npm i` to install all of the necessary dependencies.
 
 This step will **automatically** read and process the _package.json_ file. Most notably it:
 * Downloads all Node package dependencies to the _node_modules_ sub-directory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,16 +322,13 @@ You have successfully created a PR. Congratulations! :tada:
  
 **Prerequisite**: Node.js must exist on your system
 
-> Note: Close and re-open your terminal after the installation finishes.
-
 Check that compatible versions of _node_ and _npm_ are installed:
 * Node.js 16 or greater - run `node --version` and the output should be like **v16**.0.0
 * npm 8 or greater - run `npm --version` and the output should be like **8**.0.0
 
 > Note: If your version of _node_ or _npm_ are not sufficient, then: 
-> * (Recommended) Use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to manage multiple version of Node.js, then running `nvm install` within the root code directory.
- > * Or, install or update the [latest version of Node.js](https://nodejs.org/en/download/)
-
+> * (Recommended) Use [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) to manage multiple version of Node.js and run `nvm install` within the root code directory.
+ > * Or, install or update the [latest version of Node.js](https://nodejs.org/en/download/). Be sure to close and re-open your terminal for the changes to take effect.
 
 Now, run `npm i` to install all of the necessary dependencies.
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes nothing.

I'm getting a new device setup and wanted to install node and npm via nvm, so I too a moment to refine the docs related to NVM.

We had a reference to NVM the earlier _Prepare the Development Environment_ section, but that section is focused on the shell and git commands.

node and npm aren't needed for those git steps, so I renamed the section to _Step 2 - Prepare the Terminal and Git Environment_ and migrated the somewhat duplicate notes about node and nvm to the more focused section of _Running the Application | Step 1 - Install Node.js and Dependencies_.

Expanded the notes section under _Step 1 - Install Node.js and Dependencies_ to show that we recommend nvm, but still list the global install option.

@ojeytonwilliams the only thing I left out in these changes is a note about running
`npm i -g npm@8`

because I figured nvm would take care of that, or else npm would be upgraded if someone upgraded/installed to the latest version of Node.  Is there a situation where `npm i -g npm@8` would still need to be run if either of the two bullet points (shown below) are followed?

![image](https://user-images.githubusercontent.com/1777776/154780558-5fe9b636-726a-44d4-ab86-f0637589f883.png)
