### PR TITLE
chore: use chakra Link instead of `a` element

### DIFF
--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Box, Heading, Text } from '@chakra-ui/react';
+import { Button, Box, Heading, Link, Text } from '@chakra-ui/react';
 import { useConfirm, useConfirmDelete } from 'chakra-confirm';
 import { DataTable } from 'chakra-data-table';
 import { NextPage } from 'next';
@@ -72,18 +72,25 @@ export const EventPage: NextPage = () => {
         {data.event.image_url && (
           <Text>
             Event Image Url:{' '}
-            <a href={data.event.image_url}>{data.event.image_url}</a>
+            <Link href={data.event.image_url} isExternal>
+              {data.event.image_url}
+            </Link>
           </Text>
         )}
         {data.event.url && (
           <Text>
-            Event Url: <a href={data.event.url}>{data.event.url}</a>
+            Event Url:{' '}
+            <Link href={data.event.url} isExternal>
+              {data.event.url}
+            </Link>
           </Text>
         )}
         {data.event.streaming_url && (
           <Text>
             Streaming Url:{' '}
-            <a href={data.event.streaming_url}>{data.event.streaming_url}</a>
+            <Link href={data.event.streaming_url} isExternal>
+              {data.event.streaming_url}
+            </Link>
           </Text>
         )}
         <Text>Capacity: {data.event.capacity}</Text>


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Replaces standard `<a href` with chakra's `Link` component, on event dashboard.
- Adds prop opening these links in new tab.