### PR TITLE
fix: handle string enums

### DIFF
--- a/server/prisma/generator/lib/random.ts
+++ b/server/prisma/generator/lib/random.ts
@@ -27,10 +27,21 @@ export const randomItems = <T>(arr: T[], n: number, uniq = true): T[] => {
   return out;
 };
 
-export const randomEnum = <T>(anEnum: Record<number, T>): T => {
-  const enumNumericKeys = Object.keys(anEnum)
+export const randomEnum = <T>(anEnum: Record<number | string, T>): T => {
+  const numericKeys = Object.keys(anEnum)
     .map((n) => Number.parseInt(n))
     .filter((n) => !Number.isNaN(n));
-  const randomIndex = Math.floor(Math.random() * enumNumericKeys.length);
-  return anEnum[randomIndex];
+  const stringKeys = Object.keys(anEnum).filter((s) => Number.isNaN(Number(s)));
+
+  if (numericKeys.length && stringKeys.length !== numericKeys.length)
+    throw new Error(
+      `This enum appears to be heterogeneous, if you're sure you need one, you should probably
+create a randomHeterogeneousEnum function`,
+    );
+  const randomIndex = Math.floor(Math.random() * stringKeys.length);
+  // String enums cannot have numeric keys, so if numeric keys exist, we can
+  // assume it is a numeric enum.
+  const keys = numericKeys.length ? numericKeys : stringKeys;
+
+  return anEnum[keys[randomIndex]];
 };


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

This allows the factories to pick randomly from both numeric and string enums.  Previously the events.factory was only creating Physical venues.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
