### PR TITLE
feat: add iCal file to email invitation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10031,6 +10031,57 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/ical-generator": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-3.4.1.tgz",
+      "integrity": "sha512-Ijvh/MoH1xTlxOTVZIONWjZffjwjzhPBjDX/aTyULryRbD6WXLzcDdcNGKZQzExsFJOAvqxZeCjB2D5koAjkHg==",
+      "dependencies": {
+        "uuid-random": "^1.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@touch4it/ical-timezones": ">=1.6.0",
+        "@types/luxon": ">= 1.26.0",
+        "@types/mocha": ">= 8.2.1",
+        "@types/node": ">= 15.0.0",
+        "dayjs": ">= 1.10.0",
+        "luxon": ">= 1.26.0",
+        "moment": ">= 2.29.0",
+        "moment-timezone": ">= 0.5.33",
+        "rrule": ">= 2.6.8"
+      },
+      "peerDependenciesMeta": {
+        "@touch4it/ical-timezones": {
+          "optional": true
+        },
+        "@types/luxon": {
+          "optional": true
+        },
+        "@types/mocha": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-timezone": {
+          "optional": true
+        },
+        "rrule": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -18096,6 +18147,11 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -18558,6 +18614,7 @@
         "express": "4.17.3",
         "express-response-errors": "1.0.5",
         "graphql": "15.8.0",
+        "ical-generator": "^3.4.1",
         "is-docker": "2.2.1",
         "jsonwebtoken": "8.5.1",
         "nodemailer": "6.7.3",
@@ -23635,6 +23692,7 @@
         "express-response-errors": "1.0.5",
         "get-port": "6.1.2",
         "graphql": "15.8.0",
+        "ical-generator": "3.4.1",
         "is-docker": "2.2.1",
         "jsonwebtoken": "8.5.1",
         "node-dev": "7.4.2",
@@ -26271,6 +26329,14 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
       "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
       "dev": true
+    },
+    "ical-generator": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/ical-generator/-/ical-generator-3.4.1.tgz",
+      "integrity": "sha512-Ijvh/MoH1xTlxOTVZIONWjZffjwjzhPBjDX/aTyULryRbD6WXLzcDdcNGKZQzExsFJOAvqxZeCjB2D5koAjkHg==",
+      "requires": {
+        "uuid-random": "^1.3.2"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -32304,6 +32370,11 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "uuid-random": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.2.tgz",
+      "integrity": "sha512-UOzej0Le/UgkbWEO8flm+0y+G+ljUon1QWTEZOq1rnMAsxo2+SckbiZdKzAHHlVh6gJqI1TjC/xwgR50MuCrBQ=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -40,6 +40,7 @@
     "express": "4.17.3",
     "express-response-errors": "1.0.5",
     "graphql": "15.8.0",
+    "ical-generator": "3.4.1",
     "is-docker": "2.2.1",
     "jsonwebtoken": "8.5.1",
     "nodemailer": "6.7.3",

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -658,7 +658,8 @@ ${unsubscribe}`;
 
     const chapterURL = `${process.env.CLIENT_LOCATION}/chapters/${event.chapter?.id}`;
     const eventURL = `${process.env.CLIENT_LOCATION}/events/${event.id}?emaillink=true`;
-    const calendar = ical().createEvent({
+    const calendar = ical();
+    calendar.createEvent({
       start: event.start_at,
       end: event.ends_at,
       summary: event.name,

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -3,6 +3,7 @@ import { CalendarEvent, google, outlook } from 'calendar-link';
 import { Resolver, Query, Arg, Int, Mutation, Ctx } from 'type-graphql';
 
 import { isEqual, sub } from 'date-fns';
+import ical from 'ical-generator';
 
 import { GQLCtx } from '../../common-types/gql';
 import {
@@ -657,7 +658,12 @@ ${unsubscribe}`;
 
     const chapterURL = `${process.env.CLIENT_LOCATION}/chapters/${event.chapter?.id}`;
     const eventURL = `${process.env.CLIENT_LOCATION}/events/${event.id}?emaillink=true`;
-    // TODO: this needs to include an ical file
+    const calendar = ical().createEvent({
+      start: event.start_at,
+      end: event.ends_at,
+      summary: event.name,
+      url: eventURL,
+    });
     // TODO: it needs a link to unsubscribe from just this event.  See
     // https://github.com/freeCodeCamp/chapter/issues/276#issuecomment-596913322
     // Update the place holder with actual
@@ -678,7 +684,13 @@ Event Details: <a href="${eventURL}">${eventURL}</a><br>
     ${unsubscribe}
     `;
 
-    await new MailerService(addresses, subject, body).sendEmail();
+    await new MailerService(
+      addresses,
+      subject,
+      body,
+      '',
+      calendar.toString(),
+    ).sendEmail();
 
     return true;
   }

--- a/server/src/services/MailerService.ts
+++ b/server/src/services/MailerService.ts
@@ -16,17 +16,20 @@ export default class MailerService {
   emailPassword: string;
   emailService: string;
   emailHost: string;
+  iCalEvent?: string;
 
   constructor(
     emailList: Array<string>,
     subject: string,
     htmlEmail: string,
     backupText?: string,
+    iCalEvent?: string,
   ) {
     this.emailList = emailList;
     this.subject = subject;
     this.htmlEmail = htmlEmail;
     this.backupText = backupText || '';
+    this.iCalEvent = iCalEvent;
 
     // to be replaced with env vars
     this.ourEmail =
@@ -66,12 +69,21 @@ export default class MailerService {
 
   public async sendEmail(): Promise<SentMessageInfo> {
     try {
+      const calendarEvent = this.iCalEvent
+        ? {
+            icalEvent: {
+              filename: 'calendar.ics',
+              content: this.iCalEvent,
+            },
+          }
+        : {};
       return await this.transporter.sendMail({
         from: this.ourEmail,
         to: this.emailList,
         subject: this.subject,
         text: this.backupText,
         html: this.htmlEmail,
+        ...calendarEvent,
       });
     } catch (e) {
       console.log('Email failed to send. ', e);

--- a/server/tests/Mailer.test.ts
+++ b/server/tests/Mailer.test.ts
@@ -26,6 +26,19 @@ const emailAddresses = [
 const subject = 'Welcome To Chapter!';
 const htmlEmail = '<div><h1>Hello Test</h1></div>';
 const backupText = 'Email html failed to load';
+const calendar = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//sebbo.net//ical-generator//EN
+BEGIN:VEVENT
+UID:3b4a4873-161f-43e0-873d-10aa90488339
+SEQUENCE:0
+DTSTAMP:20220403T072207Z
+DTSTART:20220325T234500Z
+DTEND:20220326T014500Z
+SUMMARY:Rolfson, Emmerich and Davis
+URL;VALUE=URI:http://localhost:3000/events/15?emaillink=true
+END:VEVENT
+END:VCALENDAR`;
 
 describe('MailerService Class', () => {
   it('Should assign the email username, password, and service to transporter', () => {
@@ -34,6 +47,7 @@ describe('MailerService Class', () => {
       subject,
       htmlEmail,
       backupText,
+      calendar,
     );
 
     const { auth, service } = mailer.transporter.options as any;
@@ -48,17 +62,24 @@ describe('MailerService Class', () => {
       subject,
       htmlEmail,
       backupText,
+      calendar,
     );
 
     assert.equal(subject, mailer.subject);
     assert.equal(htmlEmail, mailer.htmlEmail);
     assert.equal(backupText, mailer.backupText);
+    assert.equal(calendar, mailer.iCalEvent);
     expect(emailAddresses).to.have.members(mailer.emailList);
   });
 
   it('Should provide a blank string if backup text is undefined', () => {
     const mailer = new MailerService(emailAddresses, subject, htmlEmail);
     assert.equal(mailer.backupText, '');
+  });
+
+  it('Should default iCalEvent to undefined', () => {
+    const mailer = new MailerService(emailAddresses, subject, htmlEmail);
+    expect(mailer.iCalEvent).to.be.undefined;
   });
 
   it('Should log a warning if emailUsername, emailPassword, or emailService is not specified', () => {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Adds `ical-generator` dependency, for generating iCal files/events.
- Generates iCal file/event with couple of basic fields.
- Adds generated iCal file/event to email invitation.
- I'm not entirely sure on what's the usual convention for referring to iCal calendar files with events. Some name adjusting might be in order.
- Adjusts some basic tests.
- I'll be refactoring `MailerService` constructor, to use single object as an argument, in a separate PR.