### PR TITLE
fix: refetch home page query on event changes

### DIFF
--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -4,6 +4,7 @@ import { useConfirmDelete } from 'chakra-confirm';
 import { LinkButton } from 'chakra-next-link';
 import React, { useMemo } from 'react';
 import { EVENT, EVENTS } from '../graphql/queries';
+import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 import EventCancelButton from './EventCancelButton';
 import SendEmailModal from './SendEmailModal';
 import { Event, useDeleteEventMutation } from 'generated/graphql';
@@ -24,6 +25,7 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
       refetchQueries: [
         { query: EVENT, variables: { id: event.id } },
         { query: EVENTS },
+        { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
       ],
     }),
     [event],

--- a/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
+++ b/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
@@ -3,6 +3,7 @@ import { useConfirm } from 'chakra-confirm';
 import React from 'react';
 import { Event, useCancelEventMutation } from '../../../../generated/graphql';
 import { EVENT, EVENTS } from '../graphql/queries';
+import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 
 interface EventCancelButtonProps extends ButtonProps {
   isFullWidth?: boolean;
@@ -26,6 +27,7 @@ const EventCancelButton: React.FC<EventCancelButtonProps> = (props) => {
     refetchQueries: [
       { query: EVENT, variables: { id: event.id } },
       { query: EVENTS },
+      { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
     ],
   };
 

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -12,6 +12,7 @@ import { Layout } from '../../shared/components/Layout';
 import EventForm from '../components/EventForm';
 import { EventFormData } from '../components/EventFormUtils';
 import { EVENTS, EVENT } from '../graphql/queries';
+import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 
 export const EditEventPage: NextPage = () => {
   const router = useRouter();
@@ -29,7 +30,11 @@ export const EditEventPage: NextPage = () => {
   // TODO: update the cache directly:
   // https://www.apollographql.com/docs/react/data/mutations/#updating-the-cache-directly
   const [updateEvent] = useUpdateEventMutation({
-    refetchQueries: [{ query: EVENTS }, { query: EVENT, variables: { id } }],
+    refetchQueries: [
+      { query: EVENTS },
+      { query: EVENT, variables: { id } },
+      { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
+    ],
   });
 
   const onSubmit = async (data: EventFormData, chapterId: number) => {

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -10,6 +10,7 @@ import { Layout } from '../../shared/components/Layout';
 import EventForm from '../components/EventForm';
 import { EventFormData } from '../components/EventFormUtils';
 import { EVENTS } from '../graphql/queries';
+import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 import { useParam } from '../../../../hooks/useParam';
 
 export const NewEventPage: NextPage = () => {
@@ -18,7 +19,10 @@ export const NewEventPage: NextPage = () => {
   const [loading, setLoading] = useState<boolean>(false);
 
   const [createEvent] = useCreateEventMutation({
-    refetchQueries: [{ query: EVENTS }],
+    refetchQueries: [
+      { query: EVENTS },
+      { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
+    ],
   });
 
   const [publish] = useSendEventInviteMutation();

--- a/cypress/integration/dashboard/events.js
+++ b/cypress/integration/dashboard/events.js
@@ -219,6 +219,66 @@ describe('events dashboard', () => {
     });
   });
 
+  it('editing event updates cached events on home page', () => {
+    cy.visit('');
+    cy.get('a[href*="/events/"').first().as('eventToEdit');
+    cy.get('@eventToEdit').invoke('text').as('eventTitle');
+    cy.get('@eventToEdit').invoke('attr', 'href').as('eventHref');
+
+    cy.findByRole('link', { name: 'Dashboard' }).click();
+    cy.findByRole('link', { name: 'Events' }).click();
+    cy.get('#page-heading').contains('Events');
+    cy.contains('Loading...').should('not.exist');
+    cy.get('@eventTitle').then((eventTitle) => {
+      cy.findByRole('link', { name: eventTitle }).click();
+    });
+
+    cy.findByRole('link', { name: 'Edit' }).click();
+    const titleAddon = ' new title';
+
+    cy.findByRole('textbox', { name: 'Event title' }).type(titleAddon);
+    cy.findByRole('form', { name: 'Save Event Changes' })
+      .findByRole('button', {
+        name: 'Save Event Changes',
+      })
+      .click();
+
+    cy.get('@eventTitle').then((eventTitle) => {
+      cy.findByRole('link', { name: `${eventTitle}${titleAddon}` });
+    });
+    cy.get('a[href="/"]').click();
+    cy.get('@eventHref').then((eventHref) => {
+      cy.get(`a[href="${eventHref}"]`)
+        .invoke('text')
+        .should('contain', titleAddon);
+    });
+  });
+
+  it('deleting event updates cached events on home page', () => {
+    cy.visit('');
+    cy.get('a[href*="/events/"').first().as('eventToDelete');
+    cy.get('@eventToDelete').invoke('text').as('eventTitle');
+
+    cy.findByRole('link', { name: 'Dashboard' }).click();
+    cy.findByRole('link', { name: 'Events' }).click();
+    cy.get('#page-heading').contains('Events');
+    cy.contains('Loading...').should('not.exist');
+    cy.get('@eventTitle').then((eventTitle) => {
+      cy.findByRole('link', { name: eventTitle }).click();
+    });
+
+    cy.findByRole('button', { name: 'Delete' }).click();
+    cy.findByRole('button', { name: 'Delete' }).click();
+
+    cy.get('@eventTitle').then((eventTitle) => {
+      cy.contains(eventTitle).should('not.exist');
+    });
+    cy.get('a[href="/"]').click();
+    cy.get('@eventTitle').then((eventTitle) => {
+      cy.contains(eventTitle).should('not.exist');
+    });
+  });
+
   it('emails not cancelled rsvps when event is cancelled', () => {
     cy.visit('/dashboard/events');
     cy.findAllByRole('row')


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Adds refetching of the home page query when event is canceled, created, edited, deleted.
- Adds tests checking refetching for two of these cases: editing and deleting of event. To ensure cache is being used, navigation is done with on-page links, instead of visiting pages directly.
- With data generating, to test two other cases, some additional tinkering is needed to make tests consistent.