### PR TITLE
fix: throw when no id in query

### DIFF
--- a/client/src/hooks/useFetchIfId.ts
+++ b/client/src/hooks/useFetchIfId.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+interface Options {
+  variables: {
+    id: number;
+  };
+}
+
+export function useFetchIfId(
+  id: number | null,
+  fetchData: (options: Options) => void,
+): void {
+  useEffect(() => {
+    if (id !== null) {
+      fetchData({
+        variables: { id },
+      });
+    }
+  }, [id]);
+}

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -11,7 +11,7 @@ import { getId } from '../../../../../util/getId';
 export const ChapterUsersPage: NextPage = () => {
   const router = useRouter();
 
-  const id = getId(router.query) || -1;
+  const id = getId(router.query);
 
   const { loading, error, data } = useChapterUsersQuery({
     variables: { id },

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -12,7 +12,7 @@ import { Layout } from '../../shared/components/Layout';
 
 export const ChapterPage: NextPage = () => {
   const router = useRouter();
-  const id = getId(router.query) || -1;
+  const id = getId(router.query);
 
   const { loading, error, data } = useChapterQuery({ variables: { id } });
 

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -16,7 +16,7 @@ export const EditChapterPage: NextPage = () => {
   const [loadingUpdate, setLoadingUpdate] = useState(false);
 
   const router = useRouter();
-  const id = getId(router.query) || -1;
+  const id = getId(router.query);
 
   const { loading, error, data } = useChapterQuery({ variables: { id } });
   const [updateChapter] = useUpdateChapterMutation({

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -16,7 +16,7 @@ import { EVENTS, EVENT } from '../graphql/queries';
 export const EditEventPage: NextPage = () => {
   const router = useRouter();
   const [loadingUpdate, setLoadingUpdate] = useState<boolean>(false);
-  const id = getId(router.query) || -1;
+  const id = getId(router.query);
 
   const {
     loading: eventLoading,

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -26,7 +26,7 @@ const args = (id: number) => ({
 
 export const EventPage: NextPage = () => {
   const router = useRouter();
-  const eventId = getId(router.query) || -1;
+  const eventId = getId(router.query);
   const { loading, error, data } = useEventQuery({
     variables: { id: eventId },
   });

--- a/client/src/modules/dashboard/Sponsors/pages/EditSponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/EditSponsorPage.tsx
@@ -10,7 +10,7 @@ import { useSponsorQuery, useUpdateSponsorMutation } from 'generated/graphql';
 const EditSponsorPage: NextPage = () => {
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const id = getId(router.query) || -1;
+  const id = getId(router.query);
   const {
     loading: sponsorLoading,
     error,

--- a/client/src/modules/dashboard/Sponsors/pages/SponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/SponsorPage.tsx
@@ -11,7 +11,7 @@ import { Layout } from '../../shared/components/Layout';
 
 export const SponsorPage: NextPage = () => {
   const router = useRouter();
-  const id = getId(router.query) || -1;
+  const id = getId(router.query);
   const { loading, error, data } = useSponsorQuery({
     variables: { sponsorId: id },
   });

--- a/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
@@ -16,7 +16,7 @@ export const EditVenuePage: NextPage = () => {
   const [loadingUpdate, setLoadingUpdate] = useState(false);
 
   const router = useRouter();
-  const id = getId(router.query) || -1;
+  const id = getId(router.query);
 
   const { loading, error, data } = useVenueQuery({ variables: { id } });
   const [updateVenue] = useUpdateVenueMutation({

--- a/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
@@ -12,7 +12,7 @@ import { Layout } from '../../shared/components/Layout';
 
 export const VenuePage: NextPage = () => {
   const router = useRouter();
-  const id = getId(router.query) || -1;
+  const id = getId(router.query);
 
   const { loading, error, data } = useVenueQuery({ variables: { id } });
   console.log('In Venue Page');

--- a/client/src/util/getId.ts
+++ b/client/src/util/getId.ts
@@ -1,13 +1,7 @@
 import type { ParsedUrlQuery } from 'querystring';
 
-export const getId = (query: ParsedUrlQuery): number => {
-  if (query.id) {
-    if (Array.isArray(query.id)) {
-      return parseInt(query.id[0]);
-    }
-
-    return parseInt(query.id);
-  }
-
-  throw new Error('No id in query');
+export const getId = (query: ParsedUrlQuery): number | null => {
+  if (query?.id === undefined) return null;
+  if (Array.isArray(query.id)) return parseInt(query.id[0]);
+  return parseInt(query.id);
 };

--- a/client/src/util/getId.ts
+++ b/client/src/util/getId.ts
@@ -9,5 +9,5 @@ export const getId = (query: ParsedUrlQuery): number => {
     return parseInt(query.id);
   }
 
-  return 1;
+  throw new Error('No id in query');
 };


### PR DESCRIPTION
Co-authored-by: Oliver Eyton-Williams <ojeytonwilliams@gmail.com>

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- `getId` throws when there's no id in query.
- Removes obsolete ` || -1` from where it's used.