### PR TITLE
fix: wait for server before generating graphql files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "db:seed": "npm run prisma -- db seed",
     "db:sync": "npm run prisma -- db push --force-reset",
     "db:reset": "npm run build:server && npm run db:sync && npm run db:seed",
-    "both": "concurrently \"npm run dev:server\" \"npm run dev:client\" \"npm -w=client run gen:dev\"",
+    "both": "concurrently \"npm run dev:server\" \"npm run dev:client\" \"./server/wait-for localhost:5000 -- npm -w=client run gen:dev\"",
     "build": "npm run build:client && npm run build:server",
     "build:client": "npm -w=client run build",
     "build:server": "npm -w=server run build",


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #999

---

- Waits for server before starting generating graphql files.