### PR TITLE
refactor: use object as parameter in constructor

### DIFF
--- a/server/reminders/reminders.ts
+++ b/server/reminders/reminders.ts
@@ -162,7 +162,11 @@ const getEmailData = (reminder: EventReminder) => {
 
 const sendEmailForReminder = async (reminder: EventReminder) => {
   const { email, subject } = getEmailData(reminder);
-  await new MailerService([reminder.user.email], subject, email).sendEmail();
+  await new MailerService({
+    emailList: [reminder.user.email],
+    subject: subject,
+    htmlEmail: email,
+  }).sendEmail();
 };
 
 const deleteReminder = async (reminder: EventReminder) =>

--- a/server/src/controllers/Auth/resolver.ts
+++ b/server/src/controllers/Auth/resolver.ts
@@ -67,11 +67,11 @@ export class AuthResolver {
       console.log(
         `Code: ${code}\nhttp://localhost:3000/auth/token?token=${token}`,
       );
-      await new MailerService(
-        [data.email],
-        'Login to Chapter',
-        `<a href=http://localhost:3000/auth/token?token=${token}>Click here to log in to chapter</a>`,
-      ).sendEmail();
+      await new MailerService({
+        emailList: [data.email],
+        subject: 'Login to Chapter',
+        htmlEmail: `<a href=http://localhost:3000/auth/token?token=${token}>Click here to log in to chapter</a>`,
+      }).sendEmail();
     }
 
     // TODO: Send email in production

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -229,10 +229,10 @@ export class EventResolver {
     };
     if (event.venue?.name) linkDetails.location = event.venue?.name;
 
-    await new MailerService(
-      [ctx.user.email],
-      `Invitation: ${event.name}`,
-      `Hi ${ctx.user.first_name},</br>
+    await new MailerService({
+      emailList: [ctx.user.email],
+      subject: `Invitation: ${event.name}`,
+      htmlEmail: `Hi ${ctx.user.first_name},</br>
 To add this event to your calendar(s) you can use these links:
 </br>
 <a href=${google(linkDetails)}>Google</a>
@@ -241,16 +241,16 @@ To add this event to your calendar(s) you can use these links:
 
 ${unsubscribe}
       `,
-    ).sendEmail();
+    }).sendEmail();
 
     const organizersEmails = event.user_event_roles.map(
       (role) => role.users.email,
     );
-    await new MailerService(
-      organizersEmails,
-      `New RSVP for ${event.name}`,
-      `User ${ctx.user.first_name} ${ctx.user.last_name} has RSVP'd. ${unsubscribe}`,
-    ).sendEmail();
+    await new MailerService({
+      emailList: organizersEmails,
+      subject: `New RSVP for ${event.name}`,
+      htmlEmail: `User ${ctx.user.first_name} ${ctx.user.last_name} has RSVP'd. ${unsubscribe}`,
+    }).sendEmail();
     return rsvp;
   }
 
@@ -524,7 +524,11 @@ ${venue.postal_code} <br>
       const body = `We have had to change the location of ${event.name}.<br>
 ${venueDetails}
 ${unsubscribe}`;
-      new MailerService(emailList, subject, body).sendEmail();
+      new MailerService({
+        emailList: emailList,
+        subject: subject,
+        htmlEmail: body,
+      }).sendEmail();
     }
 
     return await prisma.events.update({
@@ -560,7 +564,11 @@ ${unsubscribe}`;
       const subject = `Event ${event.name} cancelled`;
       const body = `placeholder body`;
 
-      new MailerService(emailList, subject, body).sendEmail();
+      new MailerService({
+        emailList: emailList,
+        subject: subject,
+        htmlEmail: body,
+      }).sendEmail();
     }
 
     return event;
@@ -685,13 +693,12 @@ Event Details: <a href="${eventURL}">${eventURL}</a><br>
     ${unsubscribe}
     `;
 
-    await new MailerService(
-      addresses,
-      subject,
-      body,
-      '',
-      calendar.toString(),
-    ).sendEmail();
+    await new MailerService({
+      emailList: addresses,
+      subject: subject,
+      htmlEmail: body,
+      iCalEvent: calendar.toString(),
+    }).sendEmail();
 
     return true;
   }

--- a/server/src/controllers/Messages/resolver.ts
+++ b/server/src/controllers/Messages/resolver.ts
@@ -9,7 +9,11 @@ export class EmailResolver {
   @Mutation(() => Email) async sendEmail(
     @Arg('data') data: SendEmailInputs,
   ): Promise<Email> {
-    const email = new MailerService(data.to, data.subject, data.html);
+    const email = new MailerService({
+      emailList: data.to,
+      subject: data.subject,
+      htmlEmail: data.html,
+    });
     await email.sendEmail();
     return {
       ourEmail: email.ourEmail,

--- a/server/src/services/MailerService.ts
+++ b/server/src/services/MailerService.ts
@@ -2,6 +2,14 @@ import nodemailer, { Transporter, SentMessageInfo } from 'nodemailer';
 
 import Utilities from '../util/Utilities';
 
+export interface MailerData {
+  emailList: Array<string>;
+  subject: string;
+  htmlEmail: string;
+  backupText?: string;
+  iCalEvent?: string;
+}
+
 // @todo add ourEmail, emailUsername, emailPassword, and emailService as
 // environment variables when they become available. Temporary placeholders
 // provided until updated info available.
@@ -18,18 +26,12 @@ export default class MailerService {
   emailHost: string;
   iCalEvent?: string;
 
-  constructor(
-    emailList: Array<string>,
-    subject: string,
-    htmlEmail: string,
-    backupText?: string,
-    iCalEvent?: string,
-  ) {
-    this.emailList = emailList;
-    this.subject = subject;
-    this.htmlEmail = htmlEmail;
-    this.backupText = backupText || '';
-    this.iCalEvent = iCalEvent;
+  constructor(data: MailerData) {
+    this.emailList = data.emailList;
+    this.subject = data.subject;
+    this.htmlEmail = data.htmlEmail;
+    this.backupText = data.backupText || '';
+    this.iCalEvent = data.iCalEvent;
 
     // to be replaced with env vars
     this.ourEmail =

--- a/server/tests/Mailer.test.ts
+++ b/server/tests/Mailer.test.ts
@@ -3,7 +3,7 @@ import chai, { expect } from 'chai';
 import { stub, restore } from 'sinon';
 import sinonChai from 'sinon-chai';
 
-import MailerService from '../src/services/MailerService';
+import MailerService, { MailerData } from '../src/services/MailerService';
 import Utilities from '../src/util/Utilities';
 
 chai.use(sinonChai);
@@ -40,15 +40,21 @@ URL;VALUE=URI:http://localhost:3000/events/15?emaillink=true
 END:VEVENT
 END:VCALENDAR`;
 
+const data: MailerData = {
+  emailList: emailAddresses,
+  subject: subject,
+  htmlEmail: htmlEmail,
+};
+
+const dataWithOptional: MailerData = {
+  ...data,
+  backupText: backupText,
+  iCalEvent: calendar,
+};
+
 describe('MailerService Class', () => {
   it('Should assign the email username, password, and service to transporter', () => {
-    const mailer = new MailerService(
-      emailAddresses,
-      subject,
-      htmlEmail,
-      backupText,
-      calendar,
-    );
+    const mailer = new MailerService(dataWithOptional);
 
     const { auth, service } = mailer.transporter.options as any;
     assert.equal(service, mailer.emailService);
@@ -57,13 +63,7 @@ describe('MailerService Class', () => {
   });
 
   it('Should correctly instantiate values', () => {
-    const mailer = new MailerService(
-      emailAddresses,
-      subject,
-      htmlEmail,
-      backupText,
-      calendar,
-    );
+    const mailer = new MailerService(dataWithOptional);
 
     assert.equal(subject, mailer.subject);
     assert.equal(htmlEmail, mailer.htmlEmail);
@@ -73,18 +73,18 @@ describe('MailerService Class', () => {
   });
 
   it('Should provide a blank string if backup text is undefined', () => {
-    const mailer = new MailerService(emailAddresses, subject, htmlEmail);
+    const mailer = new MailerService(data);
     assert.equal(mailer.backupText, '');
   });
 
   it('Should default iCalEvent to undefined', () => {
-    const mailer = new MailerService(emailAddresses, subject, htmlEmail);
+    const mailer = new MailerService(data);
     expect(mailer.iCalEvent).to.be.undefined;
   });
 
   it('Should log a warning if emailUsername, emailPassword, or emailService is not specified', () => {
     stub(Utilities, 'allValuesAreDefined').callsFake(() => false);
-    new MailerService(emailAddresses, subject, htmlEmail);
+    new MailerService(data);
     expect(console.warn).to.have.been.calledOnce;
   });
 });


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Small refactoring, replaces few parameters in `MailerService` constructor with single object.