### PR TITLE
feat: display visual status of registration

### DIFF
--- a/client/src/components/LoginRegisterModal.tsx
+++ b/client/src/components/LoginRegisterModal.tsx
@@ -7,6 +7,7 @@ import {
   VStack,
   Spinner,
   Heading,
+  useToast,
 } from '@chakra-ui/react';
 import React, { useState } from 'react';
 
@@ -45,15 +46,16 @@ export const LoginRegisterModal: React.FC<{
 
   const { handleSubmit, register } = useForm<RegisterData>();
 
+  const toast = useToast();
+
   const onSubmit = async (data: LoginData | RegisterData) => {
     if (isRegister) {
       if ('last_name' in data) {
         try {
           await registerMutation({ variables: { ...data } });
-          // TODO: display success to user
-          console.log('registration successful');
+          toast({ title: 'User registered', status: 'success' });
         } catch (err) {
-          console.log('error during registration');
+          toast({ title: 'Something went wrong', status: 'error' });
           // TODO: error handling
         }
       }

--- a/client/src/components/LoginRegisterModal.tsx
+++ b/client/src/components/LoginRegisterModal.tsx
@@ -54,6 +54,7 @@ export const LoginRegisterModal: React.FC<{
         try {
           await registerMutation({ variables: { ...data } });
           toast({ title: 'User registered', status: 'success' });
+          toggle();
         } catch (err) {
           toast({ title: 'Something went wrong', status: 'error' });
           // TODO: error handling

--- a/client/src/modules/auth/pages/Register.tsx
+++ b/client/src/modules/auth/pages/Register.tsx
@@ -30,7 +30,7 @@ export const RegisterPage: NextPage = () => {
     console.log(data);
 
     try {
-      const res = await registerMutation({ variables: { ...data } });
+      await registerMutation({ variables: { ...data } });
       toast({ title: 'User registered', status: 'success' });
       router.push('/auth/login');
     } catch (err) {

--- a/client/src/modules/auth/pages/Register.tsx
+++ b/client/src/modules/auth/pages/Register.tsx
@@ -31,7 +31,6 @@ export const RegisterPage: NextPage = () => {
 
     try {
       const res = await registerMutation({ variables: { ...data } });
-      console.log(res);
       toast({ title: 'User registered', status: 'success' });
       router.push('/auth/login');
     } catch (err) {

--- a/client/src/modules/auth/pages/Register.tsx
+++ b/client/src/modules/auth/pages/Register.tsx
@@ -2,6 +2,7 @@ import { Heading, VStack } from '@chakra-ui/layout';
 import { Box, Button, Text, useToast } from '@chakra-ui/react';
 import { LinkButton } from 'chakra-next-link';
 import { NextPage } from 'next';
+import { useRouter } from 'next/router';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -23,6 +24,7 @@ export const RegisterPage: NextPage = () => {
   const [registerMutation] = useRegisterMutation();
 
   const toast = useToast();
+  const router = useRouter();
 
   const onSubmit = async (data: RegisterFormData) => {
     console.log(data);
@@ -31,6 +33,7 @@ export const RegisterPage: NextPage = () => {
       const res = await registerMutation({ variables: { ...data } });
       console.log(res);
       toast({ title: 'User registered', status: 'success' });
+      router.push('/auth/login');
     } catch (err) {
       toast({ title: 'Something went wrong', status: 'error' });
       // TODO: Setup error handling

--- a/client/src/modules/auth/pages/Register.tsx
+++ b/client/src/modules/auth/pages/Register.tsx
@@ -1,5 +1,5 @@
 import { Heading, VStack } from '@chakra-ui/layout';
-import { Box, Button, Text } from '@chakra-ui/react';
+import { Box, Button, Text, useToast } from '@chakra-ui/react';
 import { LinkButton } from 'chakra-next-link';
 import { NextPage } from 'next';
 import React from 'react';
@@ -22,13 +22,17 @@ export const RegisterPage: NextPage = () => {
   } = useForm<RegisterFormData>();
   const [registerMutation] = useRegisterMutation();
 
+  const toast = useToast();
+
   const onSubmit = async (data: RegisterFormData) => {
     console.log(data);
 
     try {
       const res = await registerMutation({ variables: { ...data } });
       console.log(res);
+      toast({ title: 'User registered', status: 'success' });
     } catch (err) {
+      toast({ title: 'Something went wrong', status: 'error' });
       // TODO: Setup error handling
       // if (err.name === 'EMAIL_IN_USE') {
       //   setError('email', { message: 'Email alredy in use' });

--- a/cypress/integration/auth/register.js
+++ b/cypress/integration/auth/register.js
@@ -1,14 +1,9 @@
 describe('registration', () => {
-  beforeEach(() => {
-    // This is a bit slow and somewhat overkill, since we only care about the
-    // users.  It could be worth just truncating the user table.
+  before(() => {
     cy.exec('npm run db:seed');
   });
-
-  it('should redirect to login after successful registration', () => {
-    cy.registerViaUI('An', 'User', 'an@user.com');
-    cy.contains(/User registered/);
-    cy.location('pathname').should('eq', '/auth/login');
+  beforeEach(() => {
+    cy.exec('npm run db:reset:users');
   });
 
   it('should not allow registation, when using the same email twice', () => {

--- a/cypress/integration/auth/register.js
+++ b/cypress/integration/auth/register.js
@@ -6,9 +6,8 @@ describe('registration', () => {
     cy.exec('npm run db:reset:users');
   });
 
-  it('should not allow registation, when using the same email twice', () => {
+  it('should redirect to login after successful registration', () => {
     cy.interceptGQL('register');
-
     cy.registerViaUI('An', 'User', 'an@user.com');
     cy.wait('@GQLregister')
       .its('response')
@@ -17,7 +16,13 @@ describe('registration', () => {
         cy.wrap(response.statusCode).should('eq', 200);
       });
     cy.contains(/User registered/);
+    cy.location('pathname').should('eq', '/auth/login');
+  });
 
+  it('should not allow registation, when using the same email twice', () => {
+    cy.register('An', 'User', 'an@user.com');
+
+    cy.interceptGQL('register');
     cy.registerViaUI('An', 'User', 'an@user.com');
     cy.wait('@GQLregister')
       .its('response')

--- a/cypress/integration/dashboard/chapters.js
+++ b/cypress/integration/dashboard/chapters.js
@@ -1,4 +1,8 @@
 describe('chapters dashboard', () => {
+  before(() => {
+    cy.exec('npm run db:seed');
+  });
+
   it('should be the active dashboard link', () => {
     cy.visit('/dashboard/');
     cy.get('a[aria-current="page"]').should('not.exist');

--- a/cypress/integration/dashboard/chapters/users.js
+++ b/cypress/integration/dashboard/chapters/users.js
@@ -1,4 +1,8 @@
 describe('Chapter Users dashboard', () => {
+  before(() => {
+    cy.exec('npm run db:seed');
+  });
+
   beforeEach(() => {
     cy.login();
   });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:seed": "npm run prisma -- db seed",
     "db:sync": "npm run prisma -- db push --force-reset",
     "db:reset": "npm run build:server && npm run db:sync && npm run db:seed",
+    "db:reset:users": "npm -w=server run reset:users",
     "both": "concurrently \"npm run dev:server\" \"npm run dev:client\" \"./server/wait-for localhost:5000 -- npm -w=client run gen:dev\"",
     "build": "npm run build:client && npm run build:server",
     "build:client": "npm -w=client run build",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "dev": "tsc && concurrently \"tsc --watch --preserveWatchOutput\" \"node-dev --notify=false src/app.js\"",
     "prepare": "rimraf tsconfig.tsbuildinfo && prisma generate",
     "start": "node ./src/app.js",
-    "reminders:send": "node ./reminders/reminders.js"
+    "reminders:send": "node ./reminders/reminders.js",
+    "reset:users": "node prisma/generator/resetUsers.js"
   },
   "repository": {
     "type": "git",

--- a/server/prisma/generator/resetUsers.ts
+++ b/server/prisma/generator/resetUsers.ts
@@ -1,0 +1,5 @@
+import { prisma } from '../../src/prisma';
+
+(async () => {
+  await prisma.$executeRaw`TRUNCATE TABLE "users" CASCADE;`;
+})();


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Displays toast with success/error when registering.
- Swaps/redirects to the login form after successful registration.
- I've played around a bit with tests, reorganized test checking registration with the same email twice, added script for clearing users (quicker setup).