### PR TITLE
chore: don't track cypress-coverage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ typings/
 # Cypress.io
 cypress/videos
 cypress/screenshots
+cypress-coverage/
 
 # tsc output
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Adds `cypress-coverage` folder - containing report artifacts - to `.gitignore`.