### PR TITLE
fix: ensure seeded events are upcoming

### DIFF
--- a/server/prisma/generator/factories/events.factory.ts
+++ b/server/prisma/generator/factories/events.factory.ts
@@ -38,7 +38,7 @@ const createEvents = async (
     date.setMinutes(0);
 
     const start_at = add(date, {
-      days: random(10),
+      days: random(10) + 1,
       hours: random(5),
       minutes: random(4) * 15,
     });


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- `cypress/integration/events/index.js` intermittent fails (ie. https://github.com/freeCodeCamp/chapter/runs/6427610818?check_suite_focus=true), test seems to be caused by `/events` displaying only upcoming events. In the rare occurrence of event being seeded as already passed, the number of displayed events will be less.
- Adds one day to the random date of event, ensuring all seeded events are upcoming.
- Some alternative might be changing test seeding from `before` to `beforeEach`, but it might be not ideal to still have seeds for which test can't success.
