### PR TITLE
fix: wait for ui before login try

### DIFF
--- a/cypress/integration/events/[eventId].js
+++ b/cypress/integration/events/[eventId].js
@@ -43,8 +43,7 @@ describe('event page', () => {
     cy.findByRole('button', { name: 'Register' }).click();
     cy.wait('@GQLregister');
 
-    // TODO: should this be called 'Switch to login'?
-    cy.findByRole('button', { name: 'Login' }).click();
+    cy.contains(/User registered/);
     cy.get('@login-submit').click();
     // TODO: data-cy? findByRole?
     cy.contains('We sent you a magic link to your email');


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Slight tweak to test going a bit spotty recently - https://github.com/freeCodeCamp/chapter/runs/6429048621?check_suite_focus=true.
- As right now modal changes automatically on successful registration, explicit clicking to swap back to login form is not needed.