### PR TITLE
feat: use bcc field to send email

### DIFF
--- a/cypress/integration/dashboard/events.js
+++ b/cypress/integration/dashboard/events.js
@@ -63,6 +63,9 @@ describe('events dashboard', () => {
         .mhGetRecipients()
         .should('have.members', subscriberEmails);
     });
+    cy.get('@invitation').then((mail) => {
+      cy.checkBcc(mail).should('eq', true);
+    });
   });
 
   function createEvent(chapterId) {
@@ -152,6 +155,9 @@ describe('events dashboard', () => {
       .filter(filterCallback)
       .map(({ user: { email } }) => email);
     cy.get('@emails').mhGetRecipients().should('have.members', emails);
+    cy.get('@emails').then((mail) => {
+      cy.checkBcc(mail).should('eq', true);
+    });
     cy.mhDeleteAll();
   }
 
@@ -238,6 +244,10 @@ describe('events dashboard', () => {
         cy.findAllByRole('row')
           .filter(`:contains(${eventData['name']})`)
           .should('contain.text', venueTitle);
+      });
+
+      cy.get('@venueMail').then((mail) => {
+        cy.checkBcc(mail).should('eq', true);
       });
 
       cy.deleteEvent(eventId);
@@ -337,6 +347,11 @@ describe('events dashboard', () => {
     cy.get('@eventTitle').then((eventTitle) => {
       cy.get('@emails').mhGetSubject().should('include', eventTitle);
     });
+
+    cy.get('@emails').then((emails) => {
+      cy.checkBcc(emails).should('eq', true);
+    });
+
     cy.mhDeleteAll();
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -220,3 +220,8 @@ Cypress.Commands.add('deleteEvent', (eventId) => {
     .request('POST', 'http://localhost:5000/graphql', eventMutation)
     .then((response) => response.body.data.deleteEvent.id);
 });
+
+Cypress.Commands.add('checkBcc', (mail) => {
+  const headers = mail.Content.Headers;
+  return cy.wrap(!('To' in headers));
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -51,5 +51,11 @@ declare namespace Cypress {
      * @param eventId Id of the event for deletion
      */
     deleteEvent(eventId: number): Chainable<any>;
+
+    /**
+     * Check if mail recipients are bcc
+     * @param mail The sent mail of type Item(cypress-mailhog)
+     */
+    checkBcc(mail): Chainable<boolean>;
   }
 }

--- a/server/src/services/MailerService.ts
+++ b/server/src/services/MailerService.ts
@@ -81,7 +81,7 @@ export default class MailerService {
         : {};
       return await this.transporter.sendMail({
         from: this.ourEmail,
-        to: this.emailList,
+        bcc: this.emailList,
         subject: this.subject,
         text: this.backupText,
         html: this.htmlEmail,


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #956

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
This PR sends all emails with the recipients in the `BCC` field instead of the `To` field. The tests have also been updated to check for it and I've created a custom command for it. 

I was unsure if **every** or only bulk emails should use `BCC` so I went with every mail for now. If it's only for bulk emails then I think the `sendEmail` function will need an extra argument for the case where bulk emails are sent to the event organizers(assuming these recipients are not to be BCCed).