### PR TITLE
fixes #1045: Server image builds on Apple Silicon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     env_file: .env
     depends_on:
       - db
+    platform: "linux/amd64"
     build: 
       context: .
       dockerfile: server.Dockerfile


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #1045

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
Previously the Server image did not build on aarch64 (Apple Silicon Macs). This PR fixes that by downloading and emulating the amd64 image on non-amd64 architectures. It should also fix the same issue for Windows on ARM. 

For considerations behind this solution, and possible other options, see #1045 
