### PR TITLE
test: Ensure MailerService's sendEmail uses 'bcc'

### DIFF
--- a/server/tests/Mailer.test.ts
+++ b/server/tests/Mailer.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import chai, { expect } from 'chai';
-import { stub, restore } from 'sinon';
+import { match, mock, stub, restore } from 'sinon';
 import sinonChai from 'sinon-chai';
 
 import MailerService, { MailerData } from '../src/services/MailerService';
@@ -70,6 +70,16 @@ describe('MailerService Class', () => {
     assert.equal(backupText, mailer.backupText);
     assert.equal(calendar, mailer.iCalEvent);
     expect(emailAddresses).to.have.members(mailer.emailList);
+  });
+
+  it("Should use 'bcc' if sending to multiple email addresses", async () => {
+    const mailer = new MailerService(data);
+    const mockSendMail = mock(mailer.transporter).expects('sendMail');
+    mailer.sendEmail();
+
+    expect(mockSendMail.calledOnceWith(match({ bcc: emailAddresses }))).to.be
+      .true;
+    expect(mockSendMail.neverCalledWith(match.has('to'))).to.be.true;
   });
 
   it('Should provide a blank string if backup text is undefined', () => {


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
This is an addition to #1049 

Because of how important it is to make sure to never leak user email addresses, I think it might make sense to have a unit test to make sure that our own `sendEmail` doesn't send `to` to nodemailer's `sendMail`.

The test mocks `sendMail` and makes sure that the object it receives includes `bcc`, but not `to`.
