### PR TITLE
fix: Dates not matching up on all pages

### DIFF
--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -56,7 +56,7 @@ export const EventCard: React.FC<EventCardProps> = ({ event }) => {
           lineHeight="tight"
           isTruncated
         >
-          {formatDate(event.start_at)}
+          {formatDate(new Date(event.start_at).toISOString().slice(0, 16))}
           <Spacer />
           {metaTag}
         </Flex>

--- a/client/src/modules/dashboard/Events/pages/EventsPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventsPage.tsx
@@ -12,6 +12,8 @@ import { useEventsQuery } from 'generated/graphql';
 export const EventsPage: NextPage = () => {
   const { error, loading, data } = useEventsQuery();
 
+  console.log('events ', data);
+
   return (
     <Layout>
       <VStack>
@@ -78,7 +80,8 @@ export const EventsPage: NextPage = () => {
                 isOnline(event.venue_type)
                   ? event.streaming_url
                   : 'In-person only',
-              date: (event) => formatDate(event.start_at),
+              date: (event) =>
+                formatDate(new Date(event.start_at).toISOString().slice(0, 16)),
               actions: (event) => (
                 <LinkButton
                   colorScheme="green"

--- a/client/src/modules/dashboard/Events/pages/EventsPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventsPage.tsx
@@ -12,8 +12,6 @@ import { useEventsQuery } from 'generated/graphql';
 export const EventsPage: NextPage = () => {
   const { error, loading, data } = useEventsQuery();
 
-  console.log('events ', data);
-
   return (
     <Layout>
       <VStack>


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #XXXXX

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
When viewing timestamp data vs the timestamp reflected in the events pages, there is a slight difference in the timestamps. By adding some logic to the input in `formatDate` we can correct this issue without having to modify the way we edit events.