### PR TITLE
refactor: Reminders service

### DIFF
--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -24,6 +24,11 @@ import {
 } from '../../graphql-types';
 import { prisma } from '../../prisma';
 import MailerService from '../../services/MailerService';
+import {
+  createReminder,
+  deleteEventReminders,
+  updateRemindAt,
+} from '../../services/Reminders';
 import { CreateEventInputs, UpdateEventInputs } from './inputs';
 
 //Place holder for unsubscribe
@@ -230,18 +235,10 @@ export class EventResolver {
             });
 
             if (acceptedRsvp.subscribed) {
-              await prisma.event_reminders.create({
-                data: {
-                  event_user: {
-                    connect: {
-                      user_id_event_id: {
-                        event_id: acceptedRsvp.event_id,
-                        user_id: acceptedRsvp.user_id,
-                      },
-                    },
-                  },
-                  remind_at: sub(event.start_at, { days: 1 }),
-                },
+              await createReminder({
+                eventId: acceptedRsvp.event_id,
+                remindAt: sub(event.start_at, { days: 1 }),
+                userId: acceptedRsvp.user_id,
               });
             }
           }
@@ -302,15 +299,10 @@ export class EventResolver {
       },
     });
     if (rsvpName !== 'waitlist' && eventUserData.subscribed) {
-      await prisma.event_reminders.create({
-        data: {
-          event_user: {
-            connect: {
-              user_id_event_id: { event_id: eventId, user_id: ctx.user.id },
-            },
-          },
-          remind_at: sub(event.start_at, { days: 1 }),
-        },
+      await createReminder({
+        eventId: eventId,
+        remindAt: sub(event.start_at, { days: 1 }),
+        userId: ctx.user.id,
       });
     }
 
@@ -533,16 +525,10 @@ export class EventResolver {
     if (!isEqual(start_at, event.start_at)) {
       event.event_users.forEach(({ event_reminder }) => {
         if (event_reminder) {
-          prisma.event_reminders.update({
-            data: {
-              remind_at: sub(start_at, { days: 1 }),
-            },
-            where: {
-              user_id_event_id: {
-                user_id: event_reminder.user_id,
-                event_id: event_reminder.event_id,
-              },
-            },
+          updateRemindAt({
+            eventId: event_reminder.event_id,
+            remindAt: sub(start_at, { days: 1 }),
+            userId: event_reminder.user_id,
           });
         }
       });
@@ -609,11 +595,7 @@ ${unsubscribe}`;
         },
       },
     });
-    await prisma.event_reminders.deleteMany({
-      where: {
-        event_id: id,
-      },
-    });
+    await deleteEventReminders(id);
 
     const notCanceledRsvps = event.event_users;
 

--- a/server/src/services/Reminders.ts
+++ b/server/src/services/Reminders.ts
@@ -1,0 +1,38 @@
+import { prisma } from '../prisma';
+
+export interface ReminderData {
+  eventId: number;
+  remindAt: Date;
+  userId: number;
+}
+
+export const createReminder = async ({
+  eventId,
+  remindAt,
+  userId,
+}: ReminderData) =>
+  await prisma.event_reminders.create({
+    data: {
+      event_user: {
+        connect: {
+          user_id_event_id: { event_id: eventId, user_id: userId },
+        },
+      },
+      remind_at: remindAt,
+    },
+  });
+
+export const deleteEventReminders = async (eventId: number) =>
+  await prisma.event_reminders.deleteMany({ where: { event_id: eventId } });
+
+export const updateRemindAt = async ({
+  eventId,
+  remindAt,
+  userId,
+}: ReminderData) =>
+  await prisma.event_reminders.update({
+    data: { remind_at: remindAt },
+    where: {
+      user_id_event_id: { event_id: eventId, user_id: userId },
+    },
+  });

--- a/server/src/services/Reminders.ts
+++ b/server/src/services/Reminders.ts
@@ -1,5 +1,9 @@
 import { prisma } from '../prisma';
 
+export type Reminder = Awaited<
+  ReturnType<typeof getRemindersOlderThanDate>
+>[number];
+
 export interface ReminderData {
   eventId: number;
   remindAt: Date;
@@ -22,8 +26,32 @@ export const createReminder = async ({
     },
   });
 
+export const deleteReminder = async (reminder: Reminder) =>
+  await prisma.event_reminders.delete({
+    where: {
+      user_id_event_id: {
+        user_id: reminder.user_id,
+        event_id: reminder.event_id,
+      },
+    },
+  });
+
 export const deleteEventReminders = async (eventId: number) =>
   await prisma.event_reminders.deleteMany({ where: { event_id: eventId } });
+
+const reminderIncludes = {
+  event_user: {
+    include: {
+      user: true,
+      event: {
+        include: {
+          venue: true,
+          chapter: true,
+        },
+      },
+    },
+  },
+};
 
 export const updateRemindAt = async ({
   eventId,
@@ -36,3 +64,52 @@ export const updateRemindAt = async ({
       user_id_event_id: { event_id: eventId, user_id: userId },
     },
   });
+
+export const getRemindersOlderThanDate = async (date: Date) =>
+  await prisma.event_reminders.findMany({
+    include: reminderIncludes,
+    where: {
+      remind_at: {
+        lte: date,
+      },
+      notifying: false,
+    },
+    orderBy: {
+      remind_at: 'asc',
+    },
+  });
+
+export const getOldReminders = async (date: Date) =>
+  await prisma.event_reminders.findMany({
+    include: reminderIncludes,
+    where: {
+      notifying: true,
+      updated_at: {
+        lte: date,
+      },
+    },
+  });
+
+export const lockForNotifying = async (reminder: Reminder) => {
+  const lock = await prisma.event_reminders.updateMany({
+    data: { notifying: true },
+    where: {
+      user_id: reminder.user_id,
+      event_id: reminder.event_id,
+      notifying: false,
+    },
+  });
+  return { hasLock: lock.count !== 0 };
+};
+
+export const lockForRetry = async (reminder: Reminder) => {
+  const lock = await prisma.event_reminders.updateMany({
+    data: { updated_at: new Date() },
+    where: {
+      user_id: reminder.user_id,
+      event_id: reminder.event_id,
+      updated_at: reminder.updated_at,
+    },
+  });
+  return { hasLock: lock.count !== 0 };
+};


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Extracts creating, deleting, getting, etc. of reminders to separate _service_ from resolver and reminders sending. This basically means any direct interaction with prisma.
- Other than replacing old code with function call there aren't any changes.
- Name _service_ might not be too accurate, but moving this to _util_ seems a bit more out of place.
- Thing that currently sticks out the most is whole locking while processing reminders. Sending reminder might not need to care about that. Some further step, for better isolating, could be extracting that to service as well, and using custom iterator. Which would yield specific reminder only if lock is obtained.