### PR TITLE
chore: add no-only-tests eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     "plugin:cypress/recommended",
     "plugin:import/recommended"
   ],
-  "plugins": ["react", "prettier", "import"],
+  "plugins": ["react", "prettier", "import", "no-only-tests"],
   "env": {
     "browser": true,
     "node": true,
@@ -61,7 +61,8 @@
     "react/display-name": 0,
     "react/prop-types": 0,
     "import/no-unresolved": "error",
-    "import/order": "error"
+    "import/order": "error",
+    "no-only-tests/no-only-tests": "error"
   },
   "settings": {
     "react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "eslint-plugin-cypress": "2.12.1",
         "eslint-plugin-import": "2.26.0",
         "eslint-plugin-jest": "26.1.5",
+        "eslint-plugin-no-only-tests": "2.6.0",
         "eslint-plugin-prettier": "4.0.0",
         "eslint-plugin-react": "7.29.4",
         "husky": "7.0.4",
@@ -9377,6 +9378,15 @@
         "jest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -27147,6 +27157,12 @@
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
       }
+    },
+    "eslint-plugin-no-only-tests": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
+      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint-plugin-cypress": "2.12.1",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "26.1.5",
+    "eslint-plugin-no-only-tests": "2.6.0",
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.29.4",
     "husky": "7.0.4",


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Adds no-only-tests eslint rule to catch leftover `.only` in the tests during linting.
- Editor will complain with it, and it will be caught during CI.
- This however won't stop committing it, as lint isn't run on commit (maybe it should be added?), but only prettier is run.