### PR TITLE
feat: require authorization to rsvp

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -3225,6 +3225,22 @@
             "description": null,
             "args": [
               {
+                "name": "chapterId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "eventId",
                 "description": null,
                 "type": {

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -359,6 +359,7 @@ export type MutationRegisterArgs = {
 };
 
 export type MutationRsvpEventArgs = {
+  chapterId: Scalars['Int'];
   eventId: Scalars['Int'];
 };
 
@@ -1198,6 +1199,7 @@ export type VenueQuery = {
 
 export type RsvpToEventMutationVariables = Exact<{
   eventId: Scalars['Int'];
+  chapterId: Scalars['Int'];
 }>;
 
 export type RsvpToEventMutation = {
@@ -3422,8 +3424,8 @@ export type VenueQueryResult = Apollo.QueryResult<
   VenueQueryVariables
 >;
 export const RsvpToEventDocument = gql`
-  mutation rsvpToEvent($eventId: Int!) {
-    rsvpEvent(eventId: $eventId) {
+  mutation rsvpToEvent($eventId: Int!, $chapterId: Int!) {
+    rsvpEvent(eventId: $eventId, chapterId: $chapterId) {
       updated_at
     }
   }
@@ -3447,6 +3449,7 @@ export type RsvpToEventMutationFn = Apollo.MutationFunction<
  * const [rsvpToEventMutation, { data, loading, error }] = useRsvpToEventMutation({
  *   variables: {
  *      eventId: // value for 'eventId'
+ *      chapterId: // value for 'chapterId'
  *   },
  * });
  */

--- a/client/src/modules/events/graphql/mutations.ts
+++ b/client/src/modules/events/graphql/mutations.ts
@@ -3,8 +3,8 @@ import { gql } from '@apollo/client';
 // TODO: mutations must return something, so it returns confirmed_at for now.
 // Should it return something the client can use?
 export const rsvpToEvent = gql`
-  mutation rsvpToEvent($eventId: Int!) {
-    rsvpEvent(eventId: $eventId) {
+  mutation rsvpToEvent($eventId: Int!, $chapterId: Int!) {
+    rsvpEvent(eventId: $eventId, chapterId: $chapterId) {
       updated_at
     }
   }

--- a/cypress/integration/auth/login.js
+++ b/cypress/integration/auth/login.js
@@ -64,4 +64,23 @@ describe('login', () => {
       expect(win.localStorage.getItem('token')).to.be.null;
     });
   });
+
+  it('should return an error if the user is no longer in the db', () => {
+    const body = {
+      operationName: 'me',
+      query: 'query me { me {id} }',
+    };
+    cy.request({
+      method: 'POST',
+      url: 'http://localhost:5000/graphql',
+      body,
+      headers: {
+        authorization: `Bearer ${Cypress.env('TOKEN_DELETED_USER')}`,
+      },
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401);
+      expect(response.body.message).to.eq('User not found');
+    });
+  });
 });

--- a/cypress/integration/events/[eventId].js
+++ b/cypress/integration/events/[eventId].js
@@ -118,4 +118,23 @@ describe('event page', () => {
     cy.findByRole('button', { name: 'Confirm' }).click();
     cy.contains(/subscribed/);
   });
+
+  it.only('should reject requests from logged out users', () => {
+    cy.logout();
+    cy.rsvpToEvent(1).then((response) => {
+      const errors = response.body.errors;
+      expect(errors).to.have.length(1);
+      expect(errors[0].message).to.eq(
+        "Access denied! You don't have permission for this action!",
+      );
+    });
+
+    cy.register();
+    cy.login();
+    cy.reload();
+    cy.rsvpToEvent(1).then((response) => {
+      const errors = response.body.errors;
+      expect(errors).to.have.length(0);
+    });
+  });
 });

--- a/cypress/integration/events/[eventId].js
+++ b/cypress/integration/events/[eventId].js
@@ -22,7 +22,7 @@ describe('event page', () => {
       .and('have.attr', 'alt', '');
   });
 
-  it('ask the user to login before they can RSVP', () => {
+  it.only('ask the user to login before they can RSVP', () => {
     const fix = { email: 'test@user.org', firstName: 'Test', lastName: 'User' };
 
     cy.findByRole('button', { name: 'RSVP' }).click();
@@ -64,7 +64,7 @@ describe('event page', () => {
         // NOTE: we can't cy.get('@login-submit').should('not.exist') here
         // because that dom element is no longer in the DOM, resolves to
         // undefined and the test fails.
-        cy.findByRole('button', { name: 'Logout' }).should('be.visible');
+        cy.contains('You want to join this?');
         cy.findByRole('button', { name: 'Confirm' }).should('be.visible');
       });
   });

--- a/cypress/integration/events/[eventId].js
+++ b/cypress/integration/events/[eventId].js
@@ -22,7 +22,7 @@ describe('event page', () => {
       .and('have.attr', 'alt', '');
   });
 
-  it.only('ask the user to login before they can RSVP', () => {
+  it('ask the user to login before they can RSVP', () => {
     const fix = { email: 'test@user.org', firstName: 'Test', lastName: 'User' };
 
     cy.findByRole('button', { name: 'RSVP' }).click();

--- a/cypress/integration/events/[eventId].js
+++ b/cypress/integration/events/[eventId].js
@@ -64,7 +64,7 @@ describe('event page', () => {
         // NOTE: we can't cy.get('@login-submit').should('not.exist') here
         // because that dom element is no longer in the DOM, resolves to
         // undefined and the test fails.
-        cy.findByRole('button', { name: 'Login' }).should('not.exist');
+        cy.findByRole('button', { name: 'Logout' }).should('be.visible');
         cy.findByRole('button', { name: 'Confirm' }).should('be.visible');
       });
   });
@@ -119,9 +119,12 @@ describe('event page', () => {
     cy.contains(/subscribed/);
   });
 
-  it.only('should reject requests from logged out users', () => {
+  it('should reject requests from logged out users', { retries: 0 }, () => {
+    // logged out user
     cy.logout();
-    cy.rsvpToEvent(1).then((response) => {
+    cy.reload();
+    cy.rsvpToEvent(1, { withAuth: false }).then((response) => {
+      expect(response.status).to.eq(200);
       const errors = response.body.errors;
       expect(errors).to.have.length(1);
       expect(errors[0].message).to.eq(
@@ -129,12 +132,13 @@ describe('event page', () => {
       );
     });
 
+    // newly registered user
     cy.register();
-    cy.login();
+    cy.login(Cypress.env('JWT_TEST_USER'));
     cy.reload();
     cy.rsvpToEvent(1).then((response) => {
       const errors = response.body.errors;
-      expect(errors).to.have.length(0);
+      expect(errors).to.be.undefined;
     });
   });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -39,6 +39,10 @@ module.exports = (on, config) => {
     },
   );
 
+  config.env.TOKEN_DELETED_USER = jwt.sign({ id: -1 }, process.env.JWT_SECRET, {
+    expiresIn: '120min',
+  });
+
   config.env.JWT_EXPIRED = jwt.sign(
     { email: 'foo@bar.com' },
     process.env.JWT_SECRET,

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -67,6 +67,10 @@ Cypress.Commands.add('login', (token) => {
   );
 });
 
+Cypress.Commands.add('logout', () => {
+  window.localStorage.removeItem('token');
+});
+
 Cypress.Commands.add('register', (firstName, lastName, email) => {
   const user = {
     operationName: 'register',
@@ -224,4 +228,21 @@ Cypress.Commands.add('deleteEvent', (eventId) => {
 Cypress.Commands.add('checkBcc', (mail) => {
   const headers = mail.Content.Headers;
   return cy.wrap(!('To' in headers));
+});
+
+Cypress.Commands.add('rsvpToEvent', (eventId) => {
+  const rsvpMutation = {
+    operationName: 'rsvpToEvent',
+    variables: {
+      eventId,
+    },
+    query: `
+    mutation rsvpToEvent($eventId: Int!) {
+      rsvpEvent(eventId: $eventId) {
+        updated_at
+      }
+    }
+    `,
+  };
+  return cy.request('POST', 'http://localhost:5000/graphql', rsvpMutation);
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -230,7 +230,7 @@ Cypress.Commands.add('checkBcc', (mail) => {
   return cy.wrap(!('To' in headers));
 });
 
-Cypress.Commands.add('rsvpToEvent', (eventId) => {
+Cypress.Commands.add('rsvpToEvent', (eventId, options = { withAuth: true }) => {
   const rsvpMutation = {
     operationName: 'rsvpToEvent',
     variables: {
@@ -244,5 +244,18 @@ Cypress.Commands.add('rsvpToEvent', (eventId) => {
     }
     `,
   };
-  return cy.request('POST', 'http://localhost:5000/graphql', rsvpMutation);
+
+  const requestOptions = {
+    method: 'POST',
+    url: 'http://localhost:5000/graphql',
+    body: rsvpMutation,
+    failOnStatusCode: false,
+  };
+
+  if (options.withAuth)
+    requestOptions.headers = {
+      Authorization: `Bearer ${window.localStorage.getItem('token')}`,
+    };
+
+  return cy.request(requestOptions);
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -230,32 +230,36 @@ Cypress.Commands.add('checkBcc', (mail) => {
   return cy.wrap(!('To' in headers));
 });
 
-Cypress.Commands.add('rsvpToEvent', (eventId, options = { withAuth: true }) => {
-  const rsvpMutation = {
-    operationName: 'rsvpToEvent',
-    variables: {
-      eventId,
-    },
-    query: `
-    mutation rsvpToEvent($eventId: Int!) {
-      rsvpEvent(eventId: $eventId) {
+Cypress.Commands.add(
+  'rsvpToEvent',
+  ({ eventId, chapterId }, options = { withAuth: true }) => {
+    const rsvpMutation = {
+      operationName: 'rsvpToEvent',
+      variables: {
+        eventId,
+        chapterId,
+      },
+      query: `
+    mutation rsvpToEvent($eventId: Int!, $chapterId: Int!) {
+      rsvpEvent(eventId: $eventId, chapterId: $chapterId) {
         updated_at
       }
     }
     `,
-  };
-
-  const requestOptions = {
-    method: 'POST',
-    url: 'http://localhost:5000/graphql',
-    body: rsvpMutation,
-    failOnStatusCode: false,
-  };
-
-  if (options.withAuth)
-    requestOptions.headers = {
-      Authorization: `Bearer ${window.localStorage.getItem('token')}`,
     };
 
-  return cy.request(requestOptions);
-});
+    const requestOptions = {
+      method: 'POST',
+      url: 'http://localhost:5000/graphql',
+      body: rsvpMutation,
+      failOnStatusCode: false,
+    };
+
+    if (options.withAuth)
+      requestOptions.headers = {
+        Authorization: `Bearer ${window.localStorage.getItem('token')}`,
+      };
+
+    return cy.request(requestOptions);
+  },
+);

--- a/server/prisma/generator/factories/chapterRoles.factory.ts
+++ b/server/prisma/generator/factories/chapterRoles.factory.ts
@@ -4,6 +4,7 @@ const chapterPermissions = [
   'chapter-edit',
   'event-create',
   'event-edit',
+  'rsvp',
 ] as const;
 
 type Permissions = typeof chapterPermissions[number];
@@ -11,11 +12,11 @@ type Permissions = typeof chapterPermissions[number];
 const roles: Array<{ name: string; permissions: Permissions[] }> = [
   {
     name: 'administrator',
-    permissions: ['chapter-edit', 'event-create', 'event-edit'],
+    permissions: ['chapter-edit', 'event-create', 'event-edit', 'rsvp'],
   },
   { name: 'organizer', permissions: ['event-create', 'event-edit'] },
   { name: 'moderator', permissions: ['event-edit'] },
-  { name: 'member', permissions: [] },
+  { name: 'member', permissions: ['rsvp'] },
 ];
 
 const createChapterRoles = async () => {

--- a/server/prisma/generator/factories/events.factory.ts
+++ b/server/prisma/generator/factories/events.factory.ts
@@ -55,7 +55,7 @@ const createEvents = async (
 
     const eventData: Prisma.eventsCreateInput = {
       name: company.companyName(),
-      chapter: { connect: { id: randomItem(chapterIds) } },
+      chapter: { connect: { id: i == 0 ? 1 : randomItem(chapterIds) } },
       description: lorem.words(),
       url: internet.url(),
       venue_type: venueType,

--- a/server/prisma/generator/factories/instanceRoles.factory.ts
+++ b/server/prisma/generator/factories/instanceRoles.factory.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../../src/prisma';
 
-const instancePermissions = ['chapter-create', 'chapter-edit'] as const;
+const instancePermissions = ['chapter-create', 'chapter-edit', 'rsvp'] as const;
 type Permissions = typeof instancePermissions[number];
 interface InstanceRole {
   name: string;
@@ -8,8 +8,11 @@ interface InstanceRole {
 }
 
 const roles: InstanceRole[] = [
-  { name: 'administrator', permissions: ['chapter-create', 'chapter-edit'] },
-  { name: 'member', permissions: [] },
+  {
+    name: 'administrator',
+    permissions: ['chapter-create', 'chapter-edit', 'rsvp'],
+  },
+  { name: 'member', permissions: ['rsvp'] },
 ];
 
 const createRole = async ({ name, permissions }: InstanceRole) => {

--- a/server/prisma/generator/factories/instanceRoles.factory.ts
+++ b/server/prisma/generator/factories/instanceRoles.factory.ts
@@ -12,7 +12,7 @@ const roles: InstanceRole[] = [
     name: 'administrator',
     permissions: ['chapter-create', 'chapter-edit', 'rsvp'],
   },
-  { name: 'member', permissions: ['rsvp'] },
+  { name: 'member', permissions: [] },
 ];
 
 const createRole = async ({ name, permissions }: InstanceRole) => {

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -9,7 +9,15 @@ import {
   venues,
 } from '@prisma/client';
 import { CalendarEvent, google, outlook } from 'calendar-link';
-import { Resolver, Query, Arg, Int, Mutation, Ctx } from 'type-graphql';
+import {
+  Resolver,
+  Query,
+  Arg,
+  Int,
+  Mutation,
+  Ctx,
+  Authorized,
+} from 'type-graphql';
 
 import { isEqual, sub } from 'date-fns';
 import ical from 'ical-generator';
@@ -174,14 +182,12 @@ export class EventResolver {
     });
   }
 
+  @Authorized('rsvp')
   @Mutation(() => EventUser, { nullable: true })
   async rsvpEvent(
     @Arg('eventId', () => Int) eventId: number,
-    @Ctx() ctx: GQLCtx,
+    @Ctx() ctx: Required<GQLCtx>,
   ): Promise<EventUser | null> {
-    if (!ctx.user) {
-      throw new Error('You need to be logged in');
-    }
     const event = await prisma.events.findUnique({
       where: { id: eventId },
       include: {

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -186,6 +186,7 @@ export class EventResolver {
   @Mutation(() => EventUser, { nullable: true })
   async rsvpEvent(
     @Arg('eventId', () => Int) eventId: number,
+    @Arg('chapterId', () => Int) chapterId: number,
     @Ctx() ctx: Required<GQLCtx>,
   ): Promise<EventUser | null> {
     const event = await prisma.events.findUnique({
@@ -281,7 +282,7 @@ export class EventResolver {
     const rsvpName = getRsvpName(event);
 
     const userChapter = ctx.user.user_chapters.find(
-      (user_chapter) => user_chapter.chapter_id === event.chapter_id,
+      (user_chapter) => user_chapter.chapter_id === chapterId,
     );
     const isSubscribedToEvent = userChapter ? userChapter.subscribed : true; // TODO add default event subscription setting override
 

--- a/server/tests/testUtils/createSchema.ts
+++ b/server/tests/testUtils/createSchema.ts
@@ -1,8 +1,10 @@
 import { buildSchema } from 'type-graphql';
+import { authorizationChecker } from '../../src/authorization';
 
 import { resolvers } from '../../src/controllers';
 
 export const createSchema = () =>
   buildSchema({
     resolvers,
+    authChecker: authorizationChecker,
   });


### PR DESCRIPTION
This is a trivial requirement, because all instance members have it and
it might be smarter to modify the authorization checker to allow empty
`Authorized()` decorators, but let's try this approach for now.

