### PR TITLE
refactor: generic $id to named ids

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -3093,7 +3093,7 @@
             "description": null,
             "args": [
               {
-                "name": "event_id",
+                "name": "id",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -3781,7 +3781,7 @@
             "description": null,
             "args": [
               {
-                "name": "chapter_id",
+                "name": "id",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -650,7 +650,7 @@ export type ToggleChapterSubscriptionMutation = {
 };
 
 export type ChapterQueryVariables = Exact<{
-  id: Scalars['Int'];
+  chapterId: Scalars['Int'];
 }>;
 
 export type ChapterQuery = {
@@ -684,7 +684,7 @@ export type ChapterQuery = {
 };
 
 export type ChapterUsersQueryVariables = Exact<{
-  id: Scalars['Int'];
+  chapterId: Scalars['Int'];
 }>;
 
 export type ChapterUsersQuery = {
@@ -752,7 +752,7 @@ export type CreateChapterMutation = {
 };
 
 export type UpdateChapterMutationVariables = Exact<{
-  id: Scalars['Int'];
+  chapterId: Scalars['Int'];
   data: UpdateChapterInputs;
 }>;
 
@@ -1587,8 +1587,8 @@ export type ToggleChapterSubscriptionMutationOptions =
     ToggleChapterSubscriptionMutationVariables
   >;
 export const ChapterDocument = gql`
-  query chapter($id: Int!) {
-    chapter(id: $id) {
+  query chapter($chapterId: Int!) {
+    chapter(id: $chapterId) {
       id
       name
       description
@@ -1631,7 +1631,7 @@ export const ChapterDocument = gql`
  * @example
  * const { data, loading, error } = useChapterQuery({
  *   variables: {
- *      id: // value for 'id'
+ *      chapterId: // value for 'chapterId'
  *   },
  * });
  */
@@ -1663,8 +1663,8 @@ export type ChapterQueryResult = Apollo.QueryResult<
   ChapterQueryVariables
 >;
 export const ChapterUsersDocument = gql`
-  query chapterUsers($id: Int!) {
-    chapter(id: $id) {
+  query chapterUsers($chapterId: Int!) {
+    chapter(id: $chapterId) {
       chapter_users {
         user {
           id
@@ -1699,7 +1699,7 @@ export const ChapterUsersDocument = gql`
  * @example
  * const { data, loading, error } = useChapterUsersQuery({
  *   variables: {
- *      id: // value for 'id'
+ *      chapterId: // value for 'chapterId'
  *   },
  * });
  */
@@ -1912,8 +1912,8 @@ export type CreateChapterMutationOptions = Apollo.BaseMutationOptions<
   CreateChapterMutationVariables
 >;
 export const UpdateChapterDocument = gql`
-  mutation updateChapter($id: Int!, $data: UpdateChapterInputs!) {
-    updateChapter(id: $id, data: $data) {
+  mutation updateChapter($chapterId: Int!, $data: UpdateChapterInputs!) {
+    updateChapter(id: $chapterId, data: $data) {
       id
       name
       description
@@ -1942,7 +1942,7 @@ export type UpdateChapterMutationFn = Apollo.MutationFunction<
  * @example
  * const [updateChapterMutation, { data, loading, error }] = useUpdateChapterMutation({
  *   variables: {
- *      id: // value for 'id'
+ *      chapterId: // value for 'chapterId'
  *      data: // value for 'data'
  *   },
  * });

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -343,7 +343,7 @@ export type MutationDeleteVenueArgs = {
 };
 
 export type MutationInitUserInterestForChapterArgs = {
-  event_id: Scalars['Int'];
+  id: Scalars['Int'];
 };
 
 export type MutationJoinChapterArgs = {
@@ -435,7 +435,7 @@ export type QueryChapterUserArgs = {
 };
 
 export type QueryChapterUsersArgs = {
-  chapter_id: Scalars['Int'];
+  id: Scalars['Int'];
 };
 
 export type QueryEventArgs = {
@@ -863,7 +863,7 @@ export type UpdateEventMutation = {
 };
 
 export type CancelEventMutationVariables = Exact<{
-  id: Scalars['Int'];
+  eventId: Scalars['Int'];
 }>;
 
 export type CancelEventMutation = {
@@ -872,7 +872,7 @@ export type CancelEventMutation = {
 };
 
 export type DeleteEventMutationVariables = Exact<{
-  id: Scalars['Int'];
+  eventId: Scalars['Int'];
 }>;
 
 export type DeleteEventMutation = {
@@ -904,7 +904,7 @@ export type DeleteRsvpMutation = {
 };
 
 export type SendEventInviteMutationVariables = Exact<{
-  id: Scalars['Int'];
+  eventId: Scalars['Int'];
   emailGroups?: InputMaybe<Array<Scalars['String']> | Scalars['String']>;
 }>;
 
@@ -914,7 +914,7 @@ export type SendEventInviteMutation = {
 };
 
 export type InitUserInterestForChapterMutationVariables = Exact<{
-  event_id: Scalars['Int'];
+  eventId: Scalars['Int'];
 }>;
 
 export type InitUserInterestForChapterMutation = {
@@ -2316,8 +2316,8 @@ export type UpdateEventMutationOptions = Apollo.BaseMutationOptions<
   UpdateEventMutationVariables
 >;
 export const CancelEventDocument = gql`
-  mutation cancelEvent($id: Int!) {
-    cancelEvent(id: $id) {
+  mutation cancelEvent($eventId: Int!) {
+    cancelEvent(id: $eventId) {
       id
       canceled
     }
@@ -2341,7 +2341,7 @@ export type CancelEventMutationFn = Apollo.MutationFunction<
  * @example
  * const [cancelEventMutation, { data, loading, error }] = useCancelEventMutation({
  *   variables: {
- *      id: // value for 'id'
+ *      eventId: // value for 'eventId'
  *   },
  * });
  */
@@ -2367,8 +2367,8 @@ export type CancelEventMutationOptions = Apollo.BaseMutationOptions<
   CancelEventMutationVariables
 >;
 export const DeleteEventDocument = gql`
-  mutation deleteEvent($id: Int!) {
-    deleteEvent(id: $id) {
+  mutation deleteEvent($eventId: Int!) {
+    deleteEvent(id: $eventId) {
       id
     }
   }
@@ -2391,7 +2391,7 @@ export type DeleteEventMutationFn = Apollo.MutationFunction<
  * @example
  * const [deleteEventMutation, { data, loading, error }] = useDeleteEventMutation({
  *   variables: {
- *      id: // value for 'id'
+ *      eventId: // value for 'eventId'
  *   },
  * });
  */
@@ -2520,8 +2520,8 @@ export type DeleteRsvpMutationOptions = Apollo.BaseMutationOptions<
   DeleteRsvpMutationVariables
 >;
 export const SendEventInviteDocument = gql`
-  mutation sendEventInvite($id: Int!, $emailGroups: [String!]) {
-    sendEventInvite(id: $id, emailGroups: $emailGroups)
+  mutation sendEventInvite($eventId: Int!, $emailGroups: [String!]) {
+    sendEventInvite(id: $eventId, emailGroups: $emailGroups)
   }
 `;
 export type SendEventInviteMutationFn = Apollo.MutationFunction<
@@ -2542,7 +2542,7 @@ export type SendEventInviteMutationFn = Apollo.MutationFunction<
  * @example
  * const [sendEventInviteMutation, { data, loading, error }] = useSendEventInviteMutation({
  *   variables: {
- *      id: // value for 'id'
+ *      eventId: // value for 'eventId'
  *      emailGroups: // value for 'emailGroups'
  *   },
  * });
@@ -2569,8 +2569,8 @@ export type SendEventInviteMutationOptions = Apollo.BaseMutationOptions<
   SendEventInviteMutationVariables
 >;
 export const InitUserInterestForChapterDocument = gql`
-  mutation initUserInterestForChapter($event_id: Int!) {
-    initUserInterestForChapter(event_id: $event_id)
+  mutation initUserInterestForChapter($eventId: Int!) {
+    initUserInterestForChapter(id: $eventId)
   }
 `;
 export type InitUserInterestForChapterMutationFn = Apollo.MutationFunction<
@@ -2591,7 +2591,7 @@ export type InitUserInterestForChapterMutationFn = Apollo.MutationFunction<
  * @example
  * const [initUserInterestForChapterMutation, { data, loading, error }] = useInitUserInterestForChapterMutation({
  *   variables: {
- *      event_id: // value for 'event_id'
+ *      eventId: // value for 'eventId'
  *   },
  * });
  */

--- a/client/src/modules/chapters/graphql/queries.ts
+++ b/client/src/modules/chapters/graphql/queries.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export const CHAPTER = gql`
-  query chapter($id: Int!) {
-    chapter(id: $id) {
+  query chapter($chapterId: Int!) {
+    chapter(id: $chapterId) {
       id
       name
       description
@@ -34,8 +34,8 @@ export const CHAPTER = gql`
 `;
 
 export const CHAPTER_USERS = gql`
-  query chapterUsers($id: Int!) {
-    chapter(id: $id) {
+  query chapterUsers($chapterId: Int!) {
+    chapter(id: $chapterId) {
       chapter_users {
         user {
           id

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -27,11 +27,11 @@ import {
 import { useParam } from 'hooks/useParam';
 
 export const ChapterPage: NextPage = () => {
-  const id = useParam('chapterId');
+  const chapterId = useParam('chapterId');
   const { user } = useAuth();
 
   const { loading, error, data } = useChapterQuery({
-    variables: { id: id || -1 },
+    variables: { chapterId },
   });
 
   const confirm = useConfirm();
@@ -39,11 +39,11 @@ export const ChapterPage: NextPage = () => {
 
   const { loading: loadingChapterUser, data: dataChapterUser } =
     useChapterUserQuery({
-      variables: { chapterId: id },
+      variables: { chapterId: chapterId },
     });
 
   const refetch = {
-    refetchQueries: [{ query: CHAPTER_USER, variables: { chapterId: id } }],
+    refetchQueries: [{ query: CHAPTER_USER, variables: { chapterId } }],
   };
   const [joinChapterFn] = useJoinChapterMutation(refetch);
   const [chapterSubscribeFn] = useToggleChapterSubscriptionMutation(refetch);
@@ -52,7 +52,7 @@ export const ChapterPage: NextPage = () => {
     const ok = await confirm();
     if (ok) {
       try {
-        await joinChapterFn({ variables: { chapterId: id } });
+        await joinChapterFn({ variables: { chapterId } });
         toast({ title: 'You successfully joined chapter', status: 'success' });
       } catch (err) {
         toast({ title: 'Something went wrong', status: 'error' });
@@ -73,7 +73,7 @@ export const ChapterPage: NextPage = () => {
 
     if (ok) {
       try {
-        await chapterSubscribeFn({ variables: { chapterId: id } });
+        await chapterSubscribeFn({ variables: { chapterId: chapterId } });
         toast(
           toSubscribe
             ? {
@@ -179,7 +179,7 @@ export const ChapterPage: NextPage = () => {
             event={{
               ...event,
               // Fix this | undefined
-              chapter: { id, name: data.chapter?.name || '' },
+              chapter: { id: chapterId, name: data.chapter?.name || '' },
             }}
           />
         ))}

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -39,7 +39,7 @@ export const ChapterPage: NextPage = () => {
 
   const { loading: loadingChapterUser, data: dataChapterUser } =
     useChapterUserQuery({
-      variables: { chapterId: chapterId },
+      variables: { chapterId },
     });
 
   const refetch = {

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -73,7 +73,7 @@ export const ChapterPage: NextPage = () => {
 
     if (ok) {
       try {
-        await chapterSubscribeFn({ variables: { chapterId: chapterId } });
+        await chapterSubscribeFn({ variables: { chapterId } });
         toast(
           toSubscribe
             ? {

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -33,10 +33,10 @@ import { CHAPTER_USERS } from '../../../../chapters/graphql/queries';
 export const ChapterUsersPage: NextPage = () => {
   const router = useRouter();
 
-  const id = getId(router.query) || -1;
+  const chapterId = getId(router.query) || -1;
 
   const { loading, error, data } = useChapterUsersQuery({
-    variables: { id },
+    variables: { chapterId },
   });
   const { data: chapterRoles } = useChapterRolesQuery();
   const modalProps = useDisclosure();
@@ -44,7 +44,7 @@ export const ChapterUsersPage: NextPage = () => {
   const [chapterUser, setChapterUser] = useState<RoleChangeModalData>();
 
   const refetch = {
-    refetchQueries: [{ query: CHAPTER_USERS, variables: { id } }],
+    refetchQueries: [{ query: CHAPTER_USERS, variables: { chapterId } }],
   };
 
   const [changeRoleMutation] = useChangeChapterUserRoleMutation(refetch);
@@ -56,7 +56,7 @@ export const ChapterUsersPage: NextPage = () => {
   const onModalSubmit = async (data: { newRoleId: number; userId: number }) => {
     changeRoleMutation({
       variables: {
-        chapterId: id,
+        chapterId: chapterId,
         roleId: data.newRoleId,
         userId: data.userId,
       },
@@ -83,7 +83,7 @@ export const ChapterUsersPage: NextPage = () => {
 
     if (ok) {
       try {
-        await banUser({ variables: { userId, chapterId: id } });
+        await banUser({ variables: { userId, chapterId } });
         toast({ title: 'User was banned', status: 'success' });
       } catch (err) {
         console.error(err);
@@ -100,7 +100,7 @@ export const ChapterUsersPage: NextPage = () => {
 
     if (ok) {
       try {
-        await unbanUser({ variables: { userId, chapterId: id } });
+        await unbanUser({ variables: { userId, chapterId } });
         toast({ title: 'User was unbanned', status: 'success' });
       } catch (err) {
         console.error(err);

--- a/client/src/modules/dashboard/Chapters/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Chapters/graphql/mutations.ts
@@ -15,8 +15,8 @@ export const createChapter = gql`
 `;
 
 export const updateChapter = gql`
-  mutation updateChapter($id: Int!, $data: UpdateChapterInputs!) {
-    updateChapter(id: $id, data: $data) {
+  mutation updateChapter($chapterId: Int!, $data: UpdateChapterInputs!) {
+    updateChapter(id: $chapterId, data: $data) {
       id
       name
       description

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -12,9 +12,11 @@ import { Layout } from '../../shared/components/Layout';
 
 export const ChapterPage: NextPage = () => {
   const router = useRouter();
-  const id = getId(router.query) || -1;
+  const chapterId = getId(router.query) || -1;
 
-  const { loading, error, data } = useChapterQuery({ variables: { id } });
+  const { loading, error, data } = useChapterQuery({
+    variables: { chapterId },
+  });
 
   if (loading || error || !data?.chapter) {
     return (
@@ -33,11 +35,11 @@ export const ChapterPage: NextPage = () => {
             {data.chapter.name}
           </Heading>
           <Box>
-            <Link href={`${id}/users`} target="_blank">
+            <Link href={`${chapterId}/users`} target="_blank">
               Chapter Users
             </Link>
           </Box>
-          <LinkButton size="sm" href={`${id}/new_event`}>
+          <LinkButton size="sm" href={`${chapterId}/new_event`}>
             Add new event
           </LinkButton>
         </ProgressCardContent>

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -16,9 +16,11 @@ export const EditChapterPage: NextPage = () => {
   const [loadingUpdate, setLoadingUpdate] = useState(false);
 
   const router = useRouter();
-  const id = getId(router.query) || -1;
+  const chapterId = getId(router.query) || -1;
 
-  const { loading, error, data } = useChapterQuery({ variables: { id } });
+  const { loading, error, data } = useChapterQuery({
+    variables: { chapterId },
+  });
   const [updateChapter] = useUpdateChapterMutation({
     refetchQueries: [{ query: CHAPTERS }],
   });
@@ -27,7 +29,7 @@ export const EditChapterPage: NextPage = () => {
     setLoadingUpdate(true);
     try {
       await updateChapter({
-        variables: { id, data: { ...data } },
+        variables: { chapterId, data: { ...data } },
       });
       await router.push('/dashboard/chapters');
     } catch (err) {

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -21,9 +21,9 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
 
   const data = useMemo(
     () => ({
-      variables: { id: event.id },
+      variables: { eventId: event.id },
       refetchQueries: [
-        { query: EVENT, variables: { id: event.id } },
+        { query: EVENT, variables: { eventId: event.id } },
         { query: EVENTS },
         { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
       ],

--- a/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
+++ b/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
@@ -24,9 +24,9 @@ const EventCancelButton = (props: EventCancelButtonProps) => {
   });
 
   const data = {
-    variables: { id: event.id },
+    variables: { eventId: event.id },
     refetchQueries: [
-      { query: EVENT, variables: { id: event.id } },
+      { query: EVENT, variables: { eventId: event.id } },
       { query: EVENTS },
       { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
     ],

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -50,7 +50,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
     error: errorChapter,
     data: dataChapter,
   } = useChapterQuery({
-    variables: { id: chapterId },
+    variables: { chapterId },
   });
   const {
     loading: loadingVenues,

--- a/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
+++ b/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
@@ -56,7 +56,7 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
     if (data.on_waitlist) {
       emailGroups.push('on_waitlist');
     }
-    publish({ variables: { id: eventId, emailGroups } });
+    publish({ variables: { eventId, emailGroups } });
     onClose();
   };
   return (

--- a/client/src/modules/dashboard/Events/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Events/graphql/mutations.ts
@@ -41,8 +41,8 @@ export const updateEvent = gql`
 `;
 
 export const cancelEvent = gql`
-  mutation cancelEvent($id: Int!) {
-    cancelEvent(id: $id) {
+  mutation cancelEvent($eventId: Int!) {
+    cancelEvent(id: $eventId) {
       id
       canceled
     }
@@ -50,8 +50,8 @@ export const cancelEvent = gql`
 `;
 
 export const deleteEvent = gql`
-  mutation deleteEvent($id: Int!) {
-    deleteEvent(id: $id) {
+  mutation deleteEvent($eventId: Int!) {
+    deleteEvent(id: $eventId) {
       id
     }
   }
@@ -75,14 +75,14 @@ export const deleteRSVP = gql`
 `;
 
 export const sendEventInvite = gql`
-  mutation sendEventInvite($id: Int!, $emailGroups: [String!]) {
-    sendEventInvite(id: $id, emailGroups: $emailGroups)
+  mutation sendEventInvite($eventId: Int!, $emailGroups: [String!]) {
+    sendEventInvite(id: $eventId, emailGroups: $emailGroups)
   }
 `;
 
 export const initUserInterestForChapter = gql`
-  mutation initUserInterestForChapter($event_id: Int!) {
-    initUserInterestForChapter(event_id: $event_id)
+  mutation initUserInterestForChapter($eventId: Int!) {
+    initUserInterestForChapter(id: $eventId)
   }
 `;
 

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -56,7 +56,7 @@ export const NewEventPage: NextPage = () => {
       });
 
       if (event.data) {
-        publish({ variables: { id: event.data.createEvent.id } });
+        publish({ variables: { eventId: event.data.createEvent.id } });
         router.replace(
           `/dashboard/events/[id]`,
           `/dashboard/events/${event.data.createEvent.id}`,

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -115,7 +115,7 @@ export const EventPage: NextPage = () => {
         );
         if (add) {
           await initUserInterestForChapter({
-            variables: { event_id: eventId },
+            variables: { eventId },
           });
         }
       } catch (err) {

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -46,7 +46,7 @@ export const EventPage: NextPage = () => {
   const [unsubscribeFromEvent] = useUnsubscribeFromEventMutation(refetch);
   // TODO: check if we need to default to -1 here
   const { loading, error, data } = useEventQuery({
-    variables: { eventId: eventId },
+    variables: { eventId },
   });
 
   const toast = useToast();

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -46,7 +46,7 @@ export const EventPage: NextPage = () => {
   const [unsubscribeFromEvent] = useUnsubscribeFromEventMutation(refetch);
   // TODO: check if we need to default to -1 here
   const { loading, error, data } = useEventQuery({
-    variables: { eventId: eventId || -1 },
+    variables: { eventId: eventId },
   });
 
   const toast = useToast();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -98,7 +98,7 @@ Cypress.Commands.add('getChapterMembers', (chapterId) => {
   const chapterQuery = {
     operationName: 'chapterUsers',
     variables: {
-      id: chapterId,
+      chapterId,
     },
     query: `query chapterUsers($chapterId: Int!) {
       chapter(id: $chapterId) {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -150,8 +150,8 @@ Cypress.Commands.add('getRSVPs', (eventId) => {
     variables: {
       id: eventId,
     },
-    query: `query rsvpsForEvent($id: Int!) {
-      event(id: $id) {
+    query: `query rsvpsForEvent($eventId: Int!) {
+      event(id: $eventId) {
         rsvps {
           on_waitlist
           canceled
@@ -210,8 +210,8 @@ Cypress.Commands.add('deleteEvent', (eventId) => {
     variables: {
       id: eventId,
     },
-    query: `mutation deleteEvent($id: Int!) {
-      deleteEvent(id: $id) {
+    query: `mutation deleteEvent($eventId: Int!) {
+      deleteEvent(id: $eventId) {
         id
       }
     }`,

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -208,7 +208,7 @@ Cypress.Commands.add('deleteEvent', (eventId) => {
   const eventMutation = {
     operationName: 'deleteEvent',
     variables: {
-      id: eventId,
+      eventId,
     },
     query: `mutation deleteEvent($eventId: Int!) {
       deleteEvent(id: $eventId) {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -100,8 +100,8 @@ Cypress.Commands.add('getChapterMembers', (chapterId) => {
     variables: {
       id: chapterId,
     },
-    query: `query chapterUsers($id: Int!) {
-      chapter(id: $id) {
+    query: `query chapterUsers($chapterId: Int!) {
+      chapter(id: $chapterId) {
         chapter_users {
           user {
             name

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -158,18 +158,18 @@ export class ChapterUserResolver {
 
   @Mutation(() => Boolean)
   async initUserInterestForChapter(
-    @Arg('event_id', () => Int) event_id: number,
+    @Arg('id', () => Int) id: number,
     @Ctx() ctx: GQLCtx,
   ): Promise<boolean> {
     if (!ctx.user) {
       throw Error('User must be logged in to update role ');
     }
     const event = await prisma.events.findUnique({
-      where: { id: event_id },
+      where: { id },
       include: { chapter: true },
     });
     if (!event.chapter) {
-      throw Error('Cannot find the chapter of the event with id ' + event_id);
+      throw Error('Cannot find the chapter of the event with id ' + id);
     }
 
     try {

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -195,11 +195,9 @@ export class ChapterUserResolver {
   }
 
   @Query(() => [ChapterUser])
-  async chapterUsers(
-    @Arg('chapter_id', () => Int) chapterId: number,
-  ): Promise<ChapterUser[]> {
+  async chapterUsers(@Arg('id', () => Int) id: number): Promise<ChapterUser[]> {
     return await prisma.chapter_users.findMany({
-      where: { chapter_id: chapterId },
+      where: { chapter_id: id },
       include: {
         chapter_role: {
           include: {


### PR DESCRIPTION
This is necessary for authorization, since the checker cares about which chapter/event a request wants to affect.  It lacks context about how a variable will be used, so the variable must be named appropriately (`chapterId` if it targets a chapter, `eventId` for events).

It only cares about the variable name, not what the resolver is actually called with, so I normalised them to use `id` as their argument.  For consistency, it's probably an idea to change those too, but I didn't want to do too much in one PR.