### PR TITLE
feat: handle bans in authorization

### DIFF
--- a/server/src/common-types/gql.ts
+++ b/server/src/common-types/gql.ts
@@ -1,15 +1,15 @@
 import { Request as ExpressRequest, Response } from 'express';
 
-import { UserWithRoles } from '../graphql-types';
+import type { User } from '../controllers/Auth/middleware';
 
 // TODO: User seems to be duplicated.  Both on req.user and in the context. Why?
 // Can we get rid of one?
 export interface GQLCtx {
-  user?: UserWithRoles;
+  user?: User;
   res: Response;
   req: ExpressRequest;
 }
 
 export interface Request extends ExpressRequest {
-  user?: UserWithRoles;
+  user?: User;
 }

--- a/server/src/controllers/Auth/middleware.ts
+++ b/server/src/controllers/Auth/middleware.ts
@@ -31,6 +31,7 @@ export const userMiddleware = (
     .findUnique({
       where: { id: value.id },
       include: {
+        user_bans: true,
         user_chapters: {
           include: {
             chapter_role: {

--- a/server/src/controllers/Auth/middleware.ts
+++ b/server/src/controllers/Auth/middleware.ts
@@ -1,9 +1,57 @@
 import { NextFunction, Response } from 'express';
 import { TokenExpiredError, JsonWebTokenError, verify } from 'jsonwebtoken';
+import { Prisma } from '@prisma/client';
 
 import { Request } from '../../common-types/gql';
 import { getConfig } from '../../config';
 import { prisma } from '../../prisma';
+
+const userInclude = {
+  include: {
+    user_bans: true,
+    user_chapters: {
+      include: {
+        chapter_role: {
+          include: {
+            chapter_role_permissions: {
+              include: { chapter_permission: true },
+            },
+          },
+        },
+        user: true,
+      },
+    },
+    user_events: {
+      include: {
+        event: {
+          select: {
+            chapter_id: true,
+          },
+        },
+        event_role: {
+          include: {
+            event_role_permissions: {
+              include: { event_permission: true },
+            },
+          },
+        },
+      },
+    },
+    instance_role: {
+      include: {
+        instance_role_permissions: {
+          include: { instance_permission: true },
+        },
+      },
+    },
+  },
+};
+
+type Merge<T> = {
+  [Key in keyof T]: T[Key];
+};
+
+export type User = Merge<Prisma.usersGetPayload<typeof userInclude>>;
 
 export const userMiddleware = (
   req: Request,
@@ -30,44 +78,7 @@ export const userMiddleware = (
   prisma.users
     .findUnique({
       where: { id: value.id },
-      include: {
-        user_bans: true,
-        user_chapters: {
-          include: {
-            chapter_role: {
-              include: {
-                chapter_role_permissions: {
-                  include: { chapter_permission: true },
-                },
-              },
-            },
-            user: true,
-          },
-        },
-        user_events: {
-          include: {
-            event: {
-              select: {
-                chapter_id: true,
-              },
-            },
-            event_role: {
-              include: {
-                event_role_permissions: {
-                  include: { event_permission: true },
-                },
-              },
-            },
-          },
-        },
-        instance_role: {
-          include: {
-            instance_role_permissions: {
-              include: { instance_permission: true },
-            },
-          },
-        },
-      },
+      ...userInclude,
       rejectOnNotFound: false,
     })
     .then((user) => {

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -9,7 +9,15 @@ import {
   venues,
 } from '@prisma/client';
 import { CalendarEvent, google, outlook } from 'calendar-link';
-import { Resolver, Query, Arg, Int, Mutation, Ctx } from 'type-graphql';
+import {
+  Resolver,
+  Query,
+  Arg,
+  Int,
+  Mutation,
+  Ctx,
+  Authorized,
+} from 'type-graphql';
 
 import { isEqual, sub } from 'date-fns';
 import ical from 'ical-generator';
@@ -174,6 +182,7 @@ export class EventResolver {
     });
   }
 
+  @Authorized('rsvp')
   @Mutation(() => EventUser, { nullable: true })
   async rsvpEvent(
     @Arg('eventId', () => Int) eventId: number,

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -9,15 +9,7 @@ import {
   venues,
 } from '@prisma/client';
 import { CalendarEvent, google, outlook } from 'calendar-link';
-import {
-  Resolver,
-  Query,
-  Arg,
-  Int,
-  Mutation,
-  Ctx,
-  Authorized,
-} from 'type-graphql';
+import { Resolver, Query, Arg, Int, Mutation, Ctx } from 'type-graphql';
 
 import { isEqual, sub } from 'date-fns';
 import ical from 'ical-generator';
@@ -182,7 +174,6 @@ export class EventResolver {
     });
   }
 
-  @Authorized('rsvp')
   @Mutation(() => EventUser, { nullable: true })
   async rsvpEvent(
     @Arg('eventId', () => Int) eventId: number,

--- a/server/src/graphql-types/EventUser.ts
+++ b/server/src/graphql-types/EventUser.ts
@@ -1,4 +1,4 @@
-import { Field, Int, ObjectType } from 'type-graphql';
+import { Field, ObjectType } from 'type-graphql';
 import { BaseObject } from './BaseObject';
 import { Rsvp, User } from '.';
 
@@ -39,18 +39,4 @@ export class EventUser {
 
   @Field(() => User)
   user: User;
-}
-
-@ObjectType()
-export class EventUserOnlyRolesAndIds {
-  @Field(() => ({
-    chapter_id: Int,
-  }))
-  event: { chapter_id: number };
-
-  @Field(() => Int)
-  event_id: number;
-
-  @Field(() => EventRole)
-  event_role: EventRole;
 }

--- a/server/src/graphql-types/User.ts
+++ b/server/src/graphql-types/User.ts
@@ -51,4 +51,7 @@ export class UserWithRoles extends User {
 
   @Field(() => [EventUserOnlyRolesAndIds])
   user_events: EventUserOnlyRolesAndIds[];
+
+  @Field(() => [UserBan])
+  user_bans: UserBan[];
 }

--- a/server/src/graphql-types/User.ts
+++ b/server/src/graphql-types/User.ts
@@ -1,6 +1,5 @@
 import { ObjectType, Field, Resolver, Root, FieldResolver } from 'type-graphql';
 import { BaseObject } from './BaseObject';
-import { EventUserOnlyRolesAndIds } from './EventUser';
 import { Chapter, ChapterUser, EventUser, InstanceRole, UserBan } from '.';
 
 @ObjectType()
@@ -39,19 +38,4 @@ export class UserWithRelations extends User {
 
   @Field(() => [EventUser])
   event_users: EventUser[];
-}
-
-@ObjectType()
-export class UserWithRoles extends User {
-  @Field(() => [ChapterUser])
-  user_chapters: ChapterUser[];
-
-  @Field(() => InstanceRole)
-  instance_role: InstanceRole;
-
-  @Field(() => [EventUserOnlyRolesAndIds])
-  user_events: EventUserOnlyRolesAndIds[];
-
-  @Field(() => [UserBan])
-  user_bans: UserBan[];
 }

--- a/server/tests/authorization.test.ts
+++ b/server/tests/authorization.test.ts
@@ -24,131 +24,143 @@ const baseResolverData = {
 };
 
 describe('authorizationChecker', () => {
-  it('should return false if there is no user', async () => {
-    const result = await authorizationChecker(baseResolverData, [
-      'some-permission',
-    ]);
-
-    expect(result).toBe(false);
-  });
-  it('should return true if a user has an instance role granting permission', async () => {
-    const resolverData = merge(baseResolverData, {
-      context: { user: userWithInstanceRole },
-    });
-
-    expect(await authorizationChecker(resolverData, ['some-permission'])).toBe(
-      true,
-    );
-  });
-
-  it('should return false if a user does not have an instance role granting permission', async () => {
-    const resolverData = merge(baseResolverData, {
-      context: { user: userWithInstanceRole },
-    });
-
-    expect(
-      await authorizationChecker(resolverData, ['some-other-permission']),
-    ).toBe(false);
-  });
-
-  it('should return true if a user has a chapter role granting permission', async () => {
-    const resolverData = merge(baseResolverData, {
-      context: { user: userWithRoleForChapterOne },
-      info: {
-        variableValues: { chapterId: 1 },
-      },
-    });
-
-    expect(await authorizationChecker(resolverData, ['some-permission'])).toBe(
-      true,
-    );
-  });
-
-  it('should return false if a user only has a chapter role granting permission for another chapter', async () => {
-    const resolverData = merge(baseResolverData, {
-      context: { user: userWithRoleForChapterOne },
-      info: {
-        variableValues: { chapterId: 2 },
-      },
-    });
-
-    expect(await authorizationChecker(resolverData, ['some-permission'])).toBe(
-      false,
-    );
-  });
-
-  it('should return true if a user has an event role granting permission', async () => {
-    const resolverData = merge(baseResolverData, {
-      context: { user: userWithRoleForEventOne },
-      info: {
-        variableValues: { eventId: 1 },
-      },
-    });
-
-    expect(await authorizationChecker(resolverData, ['some-permission'])).toBe(
-      true,
-    );
-  });
-
-  it('should return false if a user only has an event role granting permission for another event', async () => {
-    const eventTwoUserResolverData = merge(baseResolverData, {
-      context: { user: userWithRoleForEventOne },
-      info: {
-        variableValues: { eventId: 2 },
-      },
-    });
-
-    expect(
-      await authorizationChecker(eventTwoUserResolverData, ['some-permission']),
-    ).toBe(false);
-  });
-
-  it('should return false if the event is in a chapter for which the user has no role', async () => {
-    const user = merge(userWithRoleForChapterOne, {
-      user_events: chapterTwoUserEvent,
-    });
-    const resolverData = merge(baseResolverData, {
-      context: { user },
-      info: { variableValues: { eventId: 2 } },
-    });
-
-    expect(await authorizationChecker(resolverData, ['some-permission'])).toBe(
-      false,
-    );
-  });
-
-  it('should return true if a user has a chapter role, even if they do not have an event role', async () => {
-    const user = merge(userWithRoleForChapterOne, {
-      user_events: chapterOneUserEvent,
-    });
-    const resolverData = merge(baseResolverData, {
-      context: { user },
-      info: { variableValues: { eventId: 2 } },
-    });
-
-    expect(await authorizationChecker(resolverData, ['some-permission'])).toBe(
-      true,
-    );
-  });
-
-  it('should return false unless the number of required permissions is 1', async () => {
-    expect.assertions(4);
-    const resolverData = merge(baseResolverData, {
-      context: { user: userWithInstanceRole },
-    });
-
-    expect(await authorizationChecker(resolverData, [])).toBe(false);
-    expect(await authorizationChecker(resolverData, ['some-permission'])).toBe(
-      true,
-    );
-    expect(
-      await authorizationChecker(resolverData, ['a-different-permission']),
-    ).toBe(true);
-    expect(
-      await authorizationChecker(resolverData, [
+  describe('unbanned', () => {
+    it('should return false if there is no user', async () => {
+      const result = await authorizationChecker(baseResolverData, [
         'some-permission',
-        'a-different-permission',
-      ]),
-    ).toBe(false);
+      ]);
+
+      expect(result).toBe(false);
+    });
+    it('should return true if a user has an instance role granting permission', async () => {
+      const resolverData = merge(baseResolverData, {
+        context: { user: userWithInstanceRole },
+      });
+
+      expect(
+        await authorizationChecker(resolverData, ['some-permission']),
+      ).toBe(true);
+    });
+
+    it('should return false if a user does not have an instance role granting permission', async () => {
+      const resolverData = merge(baseResolverData, {
+        context: { user: userWithInstanceRole },
+      });
+
+      expect(
+        await authorizationChecker(resolverData, ['some-other-permission']),
+      ).toBe(false);
+    });
+
+    it('should return true if a user has a chapter role granting permission', async () => {
+      const resolverData = merge(baseResolverData, {
+        context: { user: userWithRoleForChapterOne },
+        info: {
+          variableValues: { chapterId: 1 },
+        },
+      });
+
+      expect(
+        await authorizationChecker(resolverData, ['some-permission']),
+      ).toBe(true);
+    });
+
+    it('should return false if a user only has a chapter role granting permission for another chapter', async () => {
+      const resolverData = merge(baseResolverData, {
+        context: { user: userWithRoleForChapterOne },
+        info: {
+          variableValues: { chapterId: 2 },
+        },
+      });
+
+      expect(
+        await authorizationChecker(resolverData, ['some-permission']),
+      ).toBe(false);
+    });
+
+    it('should return true if a user has an event role granting permission', async () => {
+      const resolverData = merge(baseResolverData, {
+        context: { user: userWithRoleForEventOne },
+        info: {
+          variableValues: { eventId: 1 },
+        },
+      });
+
+      expect(
+        await authorizationChecker(resolverData, ['some-permission']),
+      ).toBe(true);
+    });
+
+    it('should return false if a user only has an event role granting permission for another event', async () => {
+      const eventTwoUserResolverData = merge(baseResolverData, {
+        context: { user: userWithRoleForEventOne },
+        info: {
+          variableValues: { eventId: 2 },
+        },
+      });
+
+      expect(
+        await authorizationChecker(eventTwoUserResolverData, [
+          'some-permission',
+        ]),
+      ).toBe(false);
+    });
+
+    it('should return false if the event is in a chapter for which the user has no role', async () => {
+      const user = merge(userWithRoleForChapterOne, {
+        user_events: chapterTwoUserEvent,
+      });
+      const resolverData = merge(baseResolverData, {
+        context: { user },
+        info: { variableValues: { eventId: 2 } },
+      });
+
+      expect(
+        await authorizationChecker(resolverData, ['some-permission']),
+      ).toBe(false);
+    });
+
+    it('should return true if a user has a chapter role, even if they do not have an event role', async () => {
+      const user = merge(userWithRoleForChapterOne, {
+        user_events: chapterOneUserEvent,
+      });
+      const resolverData = merge(baseResolverData, {
+        context: { user },
+        info: { variableValues: { eventId: 2 } },
+      });
+
+      expect(
+        await authorizationChecker(resolverData, ['some-permission']),
+      ).toBe(true);
+    });
+
+    it('should return false unless the number of required permissions is 1', async () => {
+      expect.assertions(4);
+      const resolverData = merge(baseResolverData, {
+        context: { user: userWithInstanceRole },
+      });
+
+      expect(await authorizationChecker(resolverData, [])).toBe(false);
+      expect(
+        await authorizationChecker(resolverData, ['some-permission']),
+      ).toBe(true);
+      expect(
+        await authorizationChecker(resolverData, ['a-different-permission']),
+      ).toBe(true);
+      expect(
+        await authorizationChecker(resolverData, [
+          'some-permission',
+          'a-different-permission',
+        ]),
+      ).toBe(false);
+    });
+  });
+
+  describe('banned', () => {
+    it('should return true if a user has an instance role and a chapter ban', async () => {});
+    it('should return false if a user has a chapter role and a ban for that chapter', async () => {});
+    it('should return true if a user has a chapter role and a ban for another chapter', async () => {});
+    it('should return false if a user has an event role and a ban for the owning chapter', async () => {});
+    it('should return true if a user has an event role and a ban for the another chapter', async () => {});
   });
 });

--- a/server/tests/authorization.test.ts
+++ b/server/tests/authorization.test.ts
@@ -27,34 +27,34 @@ const baseResolverData = {
 
 describe('authorizationChecker', () => {
   describe('when user is NOT banned', () => {
-    it('should return false if there is no user', async () => {
-      const result = await authorizationChecker(baseResolverData, [
+    it('should return false if there is no user', () => {
+      const result = authorizationChecker(baseResolverData, [
         'some-permission',
       ]);
 
       expect(result).toBe(false);
     });
-    it('should return true if a user has an instance role granting permission', async () => {
+    it('should return true if a user has an instance role granting permission', () => {
       const resolverData = merge(baseResolverData, {
         context: { user: userWithInstanceRole },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(true);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        true,
+      );
     });
 
-    it('should return false if a user does not have an instance role granting permission', async () => {
+    it('should return false if a user does not have an instance role granting permission', () => {
       const resolverData = merge(baseResolverData, {
         context: { user: userWithInstanceRole },
       });
 
       expect(
-        await authorizationChecker(resolverData, ['some-other-permission']),
+        authorizationChecker(resolverData, ['some-other-permission']),
       ).toBe(false);
     });
 
-    it('should return true if a user has a chapter role granting permission', async () => {
+    it('should return true if a user has a chapter role granting permission', () => {
       const resolverData = merge(baseResolverData, {
         context: { user: userWithRoleForChapterOne },
         info: {
@@ -62,12 +62,12 @@ describe('authorizationChecker', () => {
         },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(true);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        true,
+      );
     });
 
-    it('should return false if a user only has a chapter role granting permission for another chapter', async () => {
+    it('should return false if a user only has a chapter role granting permission for another chapter', () => {
       const resolverData = merge(baseResolverData, {
         context: { user: userWithRoleForChapterOne },
         info: {
@@ -75,12 +75,12 @@ describe('authorizationChecker', () => {
         },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(false);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        false,
+      );
     });
 
-    it('should return true if a user has an event role granting permission', async () => {
+    it('should return true if a user has an event role granting permission', () => {
       const resolverData = merge(baseResolverData, {
         context: { user: userWithRoleForEventOne },
         info: {
@@ -88,12 +88,12 @@ describe('authorizationChecker', () => {
         },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(true);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        true,
+      );
     });
 
-    it('should return false if a user only has an event role granting permission for another event', async () => {
+    it('should return false if a user only has an event role granting permission for another event', () => {
       const eventTwoUserResolverData = merge(baseResolverData, {
         context: { user: userWithRoleForEventOne },
         info: {
@@ -102,13 +102,11 @@ describe('authorizationChecker', () => {
       });
 
       expect(
-        await authorizationChecker(eventTwoUserResolverData, [
-          'some-permission',
-        ]),
+        authorizationChecker(eventTwoUserResolverData, ['some-permission']),
       ).toBe(false);
     });
 
-    it('should return false if the event is in a chapter for which the user has no role', async () => {
+    it('should return false if the event is in a chapter for which the user has no role', () => {
       const user = merge(userWithRoleForChapterOne, {
         user_events: chapterTwoUserEvent,
       });
@@ -117,12 +115,12 @@ describe('authorizationChecker', () => {
         info: { variableValues: { eventId: 2 } },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(false);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        false,
+      );
     });
 
-    it('should return true if a user has a chapter role, even if they do not have an event role', async () => {
+    it('should return true if a user has a chapter role, even if they do not have an event role', () => {
       const user = merge(userWithRoleForChapterOne, {
         user_events: chapterOneUserEvent,
       });
@@ -131,26 +129,26 @@ describe('authorizationChecker', () => {
         info: { variableValues: { eventId: 2 } },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(true);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        true,
+      );
     });
 
-    it('should return false unless the number of required permissions is 1', async () => {
+    it('should return false unless the number of required permissions is 1', () => {
       expect.assertions(4);
       const resolverData = merge(baseResolverData, {
         context: { user: userWithInstanceRole },
       });
 
-      expect(await authorizationChecker(resolverData, [])).toBe(false);
+      expect(authorizationChecker(resolverData, [])).toBe(false);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        true,
+      );
       expect(
-        await authorizationChecker(resolverData, ['some-permission']),
+        authorizationChecker(resolverData, ['a-different-permission']),
       ).toBe(true);
       expect(
-        await authorizationChecker(resolverData, ['a-different-permission']),
-      ).toBe(true);
-      expect(
-        await authorizationChecker(resolverData, [
+        authorizationChecker(resolverData, [
           'some-permission',
           'a-different-permission',
         ]),
@@ -159,7 +157,7 @@ describe('authorizationChecker', () => {
   });
 
   describe('when user is banned', () => {
-    it('should return true if a user has an instance role and a chapter ban', async () => {
+    it('should return true if a user has an instance role and a chapter ban', () => {
       const user = merge(userWithInstanceRole, {
         user_bans: userBansChapterOne,
       });
@@ -167,11 +165,11 @@ describe('authorizationChecker', () => {
         context: { user },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(true);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        true,
+      );
     });
-    it('should return false if a user has a chapter role and a ban for that chapter', async () => {
+    it('should return false if a user has a chapter role and a ban for that chapter', () => {
       const user = merge(userWithRoleForChapterOne, {
         user_bans: userBansChapterOne,
       });
@@ -182,11 +180,11 @@ describe('authorizationChecker', () => {
         },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(false);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        false,
+      );
     });
-    it('should return true if a user has a chapter role for one chapter, but is banned from a different one', async () => {
+    it('should return true if a user has a chapter role for one chapter, but is banned from a different one', () => {
       const user = merge(userWithRoleForChapterOne, {
         user_bans: userBansChapterTwo,
       });
@@ -197,11 +195,11 @@ describe('authorizationChecker', () => {
         },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(true);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        true,
+      );
     });
-    it('should return false if a user has an event role and a ban for the owning chapter', async () => {
+    it('should return false if a user has an event role and a ban for the owning chapter', () => {
       const user = merge(userWithRoleForEventOne, {
         user_bans: userBansChapterOne,
       });
@@ -212,11 +210,11 @@ describe('authorizationChecker', () => {
         },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(false);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        false,
+      );
     });
-    it('should return true if a user has an event role and a ban for another chapter', async () => {
+    it('should return true if a user has an event role and a ban for another chapter', () => {
       const user = merge(userWithRoleForEventOne, {
         user_bans: userBansChapterTwo,
       });
@@ -227,9 +225,9 @@ describe('authorizationChecker', () => {
         },
       });
 
-      expect(
-        await authorizationChecker(resolverData, ['some-permission']),
-      ).toBe(true);
+      expect(authorizationChecker(resolverData, ['some-permission'])).toBe(
+        true,
+      );
     });
   });
 });

--- a/server/tests/fixtures/users.ts
+++ b/server/tests/fixtures/users.ts
@@ -9,6 +9,7 @@ import {
   event_users,
   event_roles,
   event_permissions,
+  user_bans,
 } from '@prisma/client';
 
 type User = users & {
@@ -145,3 +146,23 @@ export const userWithRoleForEventOne: User = merge(baseUser, {
     },
   ],
 });
+
+// The user's id is not used directly. Instead we rely on their bans being
+// returned with the original user query.
+export const userBansChapterOne: user_bans[] = [
+  {
+    created_at: new Date(),
+    updated_at: new Date(),
+    chapter_id: 1,
+    user_id: -1,
+  },
+];
+
+export const userBansChapterTwo: user_bans[] = [
+  {
+    created_at: new Date(),
+    updated_at: new Date(),
+    chapter_id: 2,
+    user_id: -1,
+  },
+];

--- a/server/tests/fixtures/users.ts
+++ b/server/tests/fixtures/users.ts
@@ -1,19 +1,46 @@
 import { merge } from 'lodash/fp';
 
-const baseUser = {
+import {
+  users,
+  events,
+  instance_roles,
+  chapter_users,
+  instance_role_permissions,
+  event_users,
+  event_roles,
+  event_permissions,
+} from '@prisma/client';
+
+type User = users & {
+  instance_role: instance_roles & {
+    instance_role_permissions: instance_role_permissions[];
+  };
+} & {
+  user_chapters: chapter_users[];
+} & {
+  user_events: event_users[];
+};
+
+const baseUser: User = {
   instance_role: {
+    id: 1,
+    created_at: new Date(),
+    updated_at: new Date(),
     name: 'zero-permissions-role',
     instance_role_permissions: [],
   },
+  instance_role_id: 1,
   user_chapters: [],
   user_events: [],
   first_name: 'any',
   last_name: 'one',
   id: 1,
+  created_at: new Date(),
+  updated_at: new Date(),
   email: 'an@add.ress',
 };
 
-export const userWithInstanceRole = merge(baseUser, {
+export const userWithInstanceRole: User = merge(baseUser, {
   instance_role: {
     name: 'some-role',
     instance_role_permissions: [
@@ -31,7 +58,18 @@ export const userWithInstanceRole = merge(baseUser, {
   },
 });
 
-export const chapterTwoUserEvent = [
+type EventRolePermissions = {
+  event_permission: Pick<event_permissions, 'name'>;
+};
+
+type EventUser = Pick<event_users, 'event_id'> & {
+  event: Pick<events, 'chapter_id'>;
+  event_role: Pick<event_roles, 'name'> & {
+    event_role_permissions: EventRolePermissions[];
+  };
+};
+
+export const chapterTwoUserEvent: EventUser[] = [
   {
     event: {
       chapter_id: 2,
@@ -50,7 +88,7 @@ export const chapterTwoUserEvent = [
   },
 ];
 
-export const chapterOneUserEvent = [
+export const chapterOneUserEvent: EventUser[] = [
   {
     event: {
       chapter_id: 1,
@@ -69,7 +107,7 @@ export const chapterOneUserEvent = [
   },
 ];
 
-export const userWithRoleForChapterOne = merge(baseUser, {
+export const userWithRoleForChapterOne: User = merge(baseUser, {
   user_chapters: [
     {
       chapter_role: {
@@ -87,7 +125,7 @@ export const userWithRoleForChapterOne = merge(baseUser, {
   ],
 });
 
-export const userWithRoleForEventOne = merge(baseUser, {
+export const userWithRoleForEventOne: User = merge(baseUser, {
   user_events: [
     {
       event: {

--- a/server/tests/testUtils/App.ts
+++ b/server/tests/testUtils/App.ts
@@ -5,7 +5,7 @@ import getPort, { portNumbers } from 'get-port';
 import request from 'supertest';
 
 import { Request } from '../../src/common-types/gql';
-import { UserWithRoles } from '../../src/graphql-types';
+import { User } from '../../src/controllers/Auth/middleware';
 
 type InitProps = {
   withRouter?: express.Router;
@@ -15,7 +15,7 @@ class App {
   server: express.Application;
   request: request.SuperTest<request.Test>;
   private _server: Server;
-  authedUser: UserWithRoles | null = null;
+  authedUser: User | null = null;
 
   constructor() {
     const app = express();
@@ -49,7 +49,7 @@ class App {
     this._server.close();
   }
 
-  login(user: UserWithRoles) {
+  login(user: User) {
     this.authedUser = user;
   }
 

--- a/server/tests/testUtils/createSchema.ts
+++ b/server/tests/testUtils/createSchema.ts
@@ -1,8 +1,10 @@
 import { buildSchema } from 'type-graphql';
+import { authorizationChecker } from '../../src/authorization';
 
 import { resolvers } from '../../src/controllers';
 
 export const createSchema = () =>
   buildSchema({
     resolvers,
+    authChecker: authorizationChecker,
   });


### PR DESCRIPTION
With these changes a user that is banned from a Chapter will fail every authorization check for requests related to that Chapter. Users with instance level permissions will not be affected.

While implementing this I also cleaned up the types and made `authorizationChecker` explicitly synchronous.  Since we get the user's data in the _authentication_ middleware, there's no need to query the db during _authorization_.

Cypress tests to follow - I'd like to get https://github.com/freeCodeCamp/chapter/pull/1081 in first.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->
