### PR TITLE
fix: extend the fcc renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "prCreation": "not-pending",
-  "labels": ["renovate"],
+  "extends": ["github>freecodecamp/renovate-config:main"],
   "rangeStrategy": "pin",
   "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true,
-      "automergeType": "branch"
-    },
     {
       "groupName": "Jest and ts-jest",
       "matchPackageNames": ["jest", "ts-jest", "@types/jest"]


### PR DESCRIPTION
Some of the config was duplicated, but I also dropped the extra
automergeType and prCreation rules. This is motivated by the fact that
renovate is not currently creating PRs.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->


<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
