### PR TITLE
fix: remove redundant cancelled/lock elements

### DIFF
--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -1,5 +1,5 @@
 import { LockIcon } from '@chakra-ui/icons';
-import { Heading, Text, Tag, Box, Flex, Image, Spacer } from '@chakra-ui/react';
+import { Heading, Tag, Box, Flex, Image, Spacer } from '@chakra-ui/react';
 import { Link } from 'chakra-next-link';
 import React from 'react';
 import { Chapter, Event, EventTag } from '../generated/graphql';
@@ -22,54 +22,45 @@ type EventCardProps = {
 };
 
 export const EventCard: React.FC<EventCardProps> = ({ event }) => {
-  const metaTag = event.canceled ? (
-    <Tag
-      data-cy="event-canceled"
-      borderRadius="full"
-      pl="2"
-      px="2"
-      colorScheme="red"
-    >
-      Canceled
-    </Tag>
-  ) : event.invite_only ? (
-    <Tag
-      data-cy="event-invite-only"
-      borderRadius="full"
-      pl="2"
-      px="2"
-      colorScheme="gray"
-    >
-      <LockIcon />
-    </Tag>
-  ) : (
-    ''
+  const metaTag = (
+    <>
+      {event.canceled && (
+        <Tag
+          data-cy="event-canceled"
+          borderRadius="full"
+          pl="2"
+          px="2"
+          colorScheme="red"
+        >
+          Canceled
+        </Tag>
+      )}
+      {event.invite_only && (
+        <Tag
+          data-cy="event-invite-only"
+          borderRadius="full"
+          pl="2"
+          px="2"
+          colorScheme="gray"
+        >
+          <LockIcon />
+        </Tag>
+      )}
+    </>
   );
   return (
     <Flex borderWidth="1px" borderRadius="lg" overflow="hidden" width={'full'}>
       <Image h={'auto'} w={'200px'} src={event.image_url} objectFit={'cover'} />
       <Box p="3" py={3} width="full" data-cy="event-card">
-        <Flex
-          mb="2"
-          fontWeight="semibold"
-          as="h4"
-          lineHeight="tight"
-          noOfLines={1}
-        >
+        <Flex mb="2" fontWeight="semibold" as="h4" lineHeight="tight">
           {formatDate(event.start_at)}
           <Spacer />
           {metaTag}
         </Flex>
         <Box>
-          {event.invite_only && <LockIcon />}{' '}
           <Link data-cy="event-link" href={`/events/${event.id}`}>
             <Heading size="sm">{event.name}</Heading>
           </Link>
-          {event.canceled && (
-            <Text as="span" color="red.500" ml="2">
-              Canceled
-            </Text>
-          )}
         </Box>
         <Box>
           <Link href={`/chapters/${event.chapter.id}`}>

--- a/client/tests/__snapshots__/EventCard.test.tsx.snap
+++ b/client/tests/__snapshots__/EventCard.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`EventCard should render 1`] = `
       data-cy="event-card"
     >
       <h4
-        class="css-hevq84"
+        class="css-1vbua13"
       >
         Thu, Jan 1 @ 00:00
         <div
@@ -39,17 +39,6 @@ exports[`EventCard should render 1`] = `
       <div
         class="css-0"
       >
-        <svg
-          class="chakra-icon css-onkibi"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19.5,9.5h-.75V6.75a6.75,6.75,0,0,0-13.5,0V9.5H4.5a2,2,0,0,0-2,2V22a2,2,0,0,0,2,2h15a2,2,0,0,0,2-2V11.5A2,2,0,0,0,19.5,9.5Zm-9.5,6a2,2,0,1,1,3,1.723V19.5a1,1,0,0,1-2,0V17.223A1.994,1.994,0,0,1,10,15.5ZM7.75,6.75a4.25,4.25,0,0,1,8.5,0V9a.5.5,0,0,1-.5.5H8.25a.5.5,0,0,1-.5-.5Z"
-            fill="currentColor"
-          />
-        </svg>
-         
         <a
           class="chakra-link css-0"
           data-cy="event-link"
@@ -91,7 +80,7 @@ exports[`EventCard should render with tags 1`] = `
       data-cy="event-card"
     >
       <h4
-        class="css-hevq84"
+        class="css-1vbua13"
       >
         Thu, Jan 1 @ 00:00
         <div
@@ -116,17 +105,6 @@ exports[`EventCard should render with tags 1`] = `
       <div
         class="css-0"
       >
-        <svg
-          class="chakra-icon css-onkibi"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19.5,9.5h-.75V6.75a6.75,6.75,0,0,0-13.5,0V9.5H4.5a2,2,0,0,0-2,2V22a2,2,0,0,0,2,2h15a2,2,0,0,0,2-2V11.5A2,2,0,0,0,19.5,9.5Zm-9.5,6a2,2,0,1,1,3,1.723V19.5a1,1,0,0,1-2,0V17.223A1.994,1.994,0,0,1,10,15.5ZM7.75,6.75a4.25,4.25,0,0,1,8.5,0V9a.5.5,0,0,1-.5.5H8.25a.5.5,0,0,1-.5-.5Z"
-            fill="currentColor"
-          />
-        </svg>
-         
         <a
           class="chakra-link css-0"
           data-cy="event-link"


### PR DESCRIPTION
The extra UI elements were not necessary. Also, occasionally the tests
would fail since showing the canceled tag would hide the lock icon and
the tests assumed at least one lock icon would exist.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->



<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
