### PR TITLE
fix(gitpod): move db:reset to command

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,13 +13,13 @@ tasks:
   - before: |
       echo NEXT_PUBLIC_APOLLO_SERVER=$(gp url 5000) > client/.env.development.local &&
       nvm install lts/gallium && nvm alias default lts/gallium
-    # the rest, environment variables, installation and db setup, get persisted,
-    # so we can save time and use init:
+    # the rest, get persisted, so we can save time and use init:
     init: |
       cp .env.example .env &&
-      npm ci &&
-      npm run db:reset
-    command: npm run both
+      npm ci
+    command: |
+      npm run db:reset &&
+      npm run both
 github:
   prebuilds:
     # enable for all branches in this repo (defaults to false)


### PR DESCRIPTION
Gitpod is still intermittently failing, so this PR is an experiment to see if helps to wait for the last task, `command`, before interacting with the DB.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #XXXXX

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
