### PR TITLE
refactor: stronger types for permissions

### DIFF
--- a/server/prisma/generator/factories/chapterRoles.factory.ts
+++ b/server/prisma/generator/factories/chapterRoles.factory.ts
@@ -1,22 +1,25 @@
 import { prisma } from '../../../src/prisma';
 
-export const chapterPermissions = [
-  'chapter-edit',
-  'event-create',
-  'event-edit',
-  'rsvp-delete',
-  'rsvp-confirm',
-  'rsvp',
-] as const;
+export enum ChapterPermission {
+  ChapterEdit = 'chapter-edit',
+  EventCreate = 'event-create',
+  EventEdit = 'event-edit',
+  Rsvp = 'rsvp',
+  RsvpDelete = 'rsvp-delete',
+  RsvpConfirm = 'rsvp-confirm',
+}
 
-type Permissions = typeof chapterPermissions[number];
+const chapterPermissions = Object.values(ChapterPermission);
 
-const roles: Array<{ name: string; permissions: readonly Permissions[] }> = [
+const roles: Array<{
+  name: string;
+  permissions: readonly ChapterPermission[];
+}> = [
   {
     name: 'administrator',
-    permissions: chapterPermissions,
+    permissions: Object.values(ChapterPermission),
   },
-  { name: 'member', permissions: ['rsvp'] },
+  { name: 'member', permissions: [ChapterPermission.Rsvp] },
 ];
 
 const createChapterRoles = async () => {

--- a/server/prisma/generator/factories/chapterRoles.factory.ts
+++ b/server/prisma/generator/factories/chapterRoles.factory.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../../src/prisma';
 
-const chapterPermissions = [
+export const chapterPermissions = [
   'chapter-edit',
   'event-create',
   'event-edit',
@@ -11,17 +11,10 @@ const chapterPermissions = [
 
 type Permissions = typeof chapterPermissions[number];
 
-const roles: Array<{ name: string; permissions: Permissions[] }> = [
+const roles: Array<{ name: string; permissions: readonly Permissions[] }> = [
   {
     name: 'administrator',
-    permissions: [
-      'chapter-edit',
-      'event-create',
-      'event-edit',
-      'rsvp-delete',
-      'rsvp-confirm',
-      'rsvp',
-    ],
+    permissions: chapterPermissions,
   },
   { name: 'member', permissions: ['rsvp'] },
 ];

--- a/server/prisma/generator/factories/instanceRoles.factory.ts
+++ b/server/prisma/generator/factories/instanceRoles.factory.ts
@@ -1,14 +1,14 @@
 import { prisma } from '../../../src/prisma';
 
+import { chapterPermissions } from './chapterRoles.factory';
+
 const instancePermissions = [
   'chapter-create',
-  'chapter-edit',
   'change-instance-role',
   'view-users',
-  'rsvp-confirm',
-  'rsvp-delete',
-  'rsvp',
+  ...chapterPermissions,
 ] as const;
+
 type Permissions = typeof instancePermissions[number];
 interface InstanceRole {
   name: string;
@@ -18,6 +18,7 @@ interface InstanceRole {
 const roles: InstanceRole[] = [
   {
     name: 'owner',
+    // the owners should be able to do everything
     permissions: instancePermissions,
   },
   { name: 'member', permissions: [] },

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -8,6 +8,7 @@ import {
   Ctx,
   Authorized,
 } from 'type-graphql';
+import { Permission } from '../../../prisma/generator/factories/instanceRoles.factory';
 
 import { GQLCtx } from '../../common-types/gql';
 import { Chapter, ChapterWithRelations } from '../../graphql-types';
@@ -47,7 +48,7 @@ export class ChapterResolver {
     });
   }
 
-  @Authorized('chapter-create')
+  @Authorized(Permission.ChapterCreate)
   @Mutation(() => Chapter)
   async createChapter(
     @Arg('data') data: CreateChapterInputs,
@@ -63,7 +64,7 @@ export class ChapterResolver {
     return prisma.chapters.create({ data: chapterData });
   }
 
-  @Authorized('chapter-edit')
+  @Authorized(Permission.ChapterEdit)
   @Mutation(() => Chapter)
   async updateChapter(
     @Arg('id', () => Int) id: number,

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -346,7 +346,7 @@ export class EventResolver {
     return userRole;
   }
 
-  @Authorized('rsvp-confirm')
+  @Authorized(Permission.RsvpConfirm)
   @Mutation(() => EventUser)
   async confirmRsvp(
     @Arg('eventId', () => Int) eventId: number,
@@ -389,7 +389,7 @@ export class EventResolver {
     });
   }
 
-  @Authorized('rsvp-delete')
+  @Authorized(Permission.RsvpDelete)
   @Mutation(() => Boolean)
   async deleteRsvp(
     @Arg('eventId', () => Int) eventId: number,

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -20,6 +20,7 @@ import {
 import { isEqual, sub } from 'date-fns';
 import ical from 'ical-generator';
 
+import { Permission } from '../../../prisma/generator/factories/instanceRoles.factory';
 import { GQLCtx } from '../../common-types/gql';
 import {
   Event,
@@ -195,7 +196,7 @@ export class EventResolver {
     });
   }
 
-  @Authorized('rsvp')
+  @Authorized(Permission.Rsvp)
   @Mutation(() => EventUser, { nullable: true })
   async rsvpEvent(
     @Arg('eventId', () => Int) eventId: number,

--- a/server/src/controllers/Users/resolver.ts
+++ b/server/src/controllers/Users/resolver.ts
@@ -3,10 +3,11 @@ import { Arg, Authorized, Int, Mutation, Query, Resolver } from 'type-graphql';
 import { prisma } from '../../prisma';
 
 import { UserWithInstanceRole } from '../../graphql-types';
+import { Permission } from '../../../prisma/generator/factories/instanceRoles.factory';
 
 @Resolver()
 export class UsersResolver {
-  @Authorized('view-users')
+  @Authorized(Permission.ViewUsers)
   @Query(() => [UserWithInstanceRole])
   async users(): Promise<UserWithInstanceRole[]> {
     return await prisma.users.findMany({
@@ -23,7 +24,7 @@ export class UsersResolver {
     });
   }
 
-  @Authorized('change-instance-role')
+  @Authorized(Permission.ChangeInstanceRole)
   @Mutation(() => UserWithInstanceRole)
   async changeInstanceUserRole(
     @Arg('roleId', () => Int) roleId: number,


### PR DESCRIPTION
- refactor: consolidate chapter and instance roles
- refactor: convert permissions to string enums
- refactor: use new Rsvp 'enum'

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

I think this should save us from a few confusing typo-generated bugs. What do you reckon @gikf?

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

Edit: I'll take it out of draft once I've converted all the strings to Permission properties.