### PR TITLE
fix(test): assert absence of specific query

### DIFF
--- a/cypress/e2e/dashboard/events/[eventId].cy.js
+++ b/cypress/e2e/dashboard/events/[eventId].cy.js
@@ -71,12 +71,13 @@ describe('event dashboard', () => {
 
       cy.get('@waitlist').find('[data-cy=confirm]').first().click();
 
-      cy.intercept('/graphql', cy.spy().as('request'));
+      cy.intercept('http://localhost:5000/graphql', (req) => {
+        expect(req.body?.operationName?.includes('confirmRsvp')).to.be.false;
+      });
       cy.findByRole('alertdialog')
         .findByRole('button', { name: 'Cancel' })
         .click();
 
-      cy.get('@request').should('not.have.been.called');
       cy.get('@userName').then((userName) => {
         cy.get('@waitlist').contains(userName);
       });


### PR DESCRIPTION
This test was flaky. Presumably this was due to a race condition causing
other graphQL queries to be fired while the test asserted that no
requests were made.

Making the assertion check for a specific request should solve this.
