### PR TITLE
feat: restrict sponsors management

### DIFF
--- a/client/src/modules/dashboard/Sponsors/pages/EditSponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/EditSponsorPage.tsx
@@ -46,7 +46,7 @@ const EditSponsorPage: NextPage = () => {
   if (sponsorLoading || error || !data?.sponsor) {
     return (
       <Layout>
-        <h1>{loading ? 'Loading...' : 'Error...'}</h1>
+        <h1>{sponsorLoading ? 'Loading...' : 'Error...'}</h1>
         {error && <div>{error.message}</div>}
       </Layout>
     );

--- a/client/src/modules/dashboard/Sponsors/pages/SponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/SponsorPage.tsx
@@ -27,7 +27,7 @@ export const SponsorPage: NextPage = () => {
     <Layout>
       <Card className={styles.card}>
         <ProgressCardContent>
-          <Heading as="h2" fontWeight="normal" mb="2">
+          <Heading data-cy="name" as="h2" fontWeight="normal" mb="2">
             {data?.sponsor?.name}
           </Heading>
         </ProgressCardContent>
@@ -38,8 +38,8 @@ export const SponsorPage: NextPage = () => {
           Details{' '}
         </Heading>
         <Flex mt="2" justifyContent="space-between">
-          <Text>Type: {data?.sponsor?.type}</Text>
-          <Text>
+          <Text data-cy="type">Type: {data?.sponsor?.type}</Text>
+          <Text data-cy="website">
             Website: <Link>{data?.sponsor?.website}</Link>
           </Text>
         </Flex>

--- a/client/src/modules/dashboard/shared/components/Layout.tsx
+++ b/client/src/modules/dashboard/shared/components/Layout.tsx
@@ -11,7 +11,7 @@ const links = [
   {
     text: 'Sponsors',
     link: '/dashboard/sponsors',
-    permission: 'sponsors-manage',
+    requiredPermission: 'sponsors-manage',
   },
   { text: 'Users', link: '/dashboard/users' },
 ];
@@ -24,16 +24,15 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
       <HStack as="nav" my="2">
         {links
           .filter(
-            ({ permission }) =>
-              typeof permission === 'undefined' ||
-              useCheckPermission(permission),
+            ({ requiredPermission }) =>
+              !requiredPermission || useCheckPermission(requiredPermission),
           )
           .map((item) => (
             <LinkButton
               key={item.link}
               href={item.link}
               colorScheme={
-                router.pathname.startsWith(item.link) ? 'blue' : undefined
+                router.pathname.startsWith(item.link) ? 'blue' : 'gray'
               }
             >
               {item.text}

--- a/client/src/modules/dashboard/shared/components/Layout.tsx
+++ b/client/src/modules/dashboard/shared/components/Layout.tsx
@@ -2,12 +2,17 @@ import { HStack } from '@chakra-ui/layout';
 import { LinkButton } from 'chakra-next-link';
 import { useRouter } from 'next/router';
 import React from 'react';
+import { useCheckPermission } from 'hooks/useCheckPermission';
 
 const links = [
   { text: 'Chapters', link: '/dashboard/chapters' },
   { text: 'Events', link: '/dashboard/events' },
   { text: 'Venues', link: '/dashboard/venues' },
-  { text: 'Sponsors', link: '/dashboard/sponsors' },
+  {
+    text: 'Sponsors',
+    link: '/dashboard/sponsors',
+    permission: 'sponsors-manage',
+  },
   { text: 'Users', link: '/dashboard/users' },
 ];
 
@@ -17,17 +22,23 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <HStack as="nav" my="2">
-        {links.map((item) => (
-          <LinkButton
-            key={item.link}
-            href={item.link}
-            colorScheme={
-              router.pathname.startsWith(item.link) ? 'blue' : undefined
-            }
-          >
-            {item.text}
-          </LinkButton>
-        ))}
+        {links
+          .filter(
+            ({ permission }) =>
+              typeof permission === 'undefined' ||
+              useCheckPermission(permission),
+          )
+          .map((item) => (
+            <LinkButton
+              key={item.link}
+              href={item.link}
+              colorScheme={
+                router.pathname.startsWith(item.link) ? 'blue' : undefined
+              }
+            >
+              {item.text}
+            </LinkButton>
+          ))}
       </HStack>
       {children}
     </>

--- a/cypress/e2e/dashboard/sponsors.cy.js
+++ b/cypress/e2e/dashboard/sponsors.cy.js
@@ -56,9 +56,9 @@ describe('sponsors dashboard', () => {
     cy.get('[data-cy=type]').contains(testSponsor.type);
   });
 
-  it('prevents members from managing sponsors', () => {
+  it('prevents chapter admins from managing sponsors', () => {
     cy.register();
-    cy.login(Cypress.env('JWT_TEST_USER'));
+    cy.login(Cypress.env('JWT_ADMIN_USER'));
 
     cy.visit('/dashboard/');
     cy.findByRole('link', { name: 'Sponsors' }).should('not.exist');

--- a/cypress/e2e/dashboard/sponsors.cy.js
+++ b/cypress/e2e/dashboard/sponsors.cy.js
@@ -1,0 +1,69 @@
+import { expectToBeRejected } from '../../support/util';
+
+const testSponsor = {
+  name: 'Test Sponsor',
+  website: 'http://example.com',
+  logo_path: 'logo.png',
+  type: 'OTHER',
+};
+
+describe('sponsors dashboard', () => {
+  beforeEach(() => {
+    cy.exec('npm run db:seed');
+  });
+
+  it('lets an instance owner create sponsors', () => {
+    cy.login();
+    cy.visit('/dashboard/sponsors/new');
+
+    cy.findByRole('textbox', { name: 'Sponsor Name' }).type(testSponsor.name);
+    cy.findByRole('textbox', { name: 'Website Url' }).type(testSponsor.website);
+    cy.findByRole('textbox', { name: 'Logo Path' }).type(testSponsor.logo_path);
+    cy.findByRole('combobox', { name: 'Sponsor Type' }).select(
+      testSponsor.type,
+    );
+    cy.findByRole('button', { name: 'Add New Sponsor' }).click();
+
+    cy.findByRole('heading', { name: 'Sponsors' });
+    cy.findByRole('link', { name: testSponsor.name }).click();
+    cy.get('[data-cy=name]').contains(testSponsor.name);
+    cy.get('[data-cy=website]').contains(testSponsor.website);
+    cy.get('[data-cy=type]').contains(testSponsor.type);
+  });
+
+  it('lets an instance owner edit sponsors', () => {
+    cy.login();
+
+    cy.visit('/dashboard/sponsors/1/edit');
+    cy.findByRole('textbox', { name: 'Sponsor Name' })
+      .clear()
+      .type(testSponsor.name);
+    cy.findByRole('textbox', { name: 'Website Url' })
+      .clear()
+      .type(testSponsor.website);
+    cy.findByRole('textbox', { name: 'Logo Path' })
+      .clear()
+      .type(testSponsor.logo_path);
+    cy.findByRole('combobox', { name: 'Sponsor Type' }).select(
+      testSponsor.type,
+    );
+
+    cy.findByRole('button', { name: 'Save Sponsor Changes' }).click();
+    cy.findByRole('heading', { name: 'Sponsors' });
+    cy.findByRole('link', { name: testSponsor.name }).click();
+    cy.get('[data-cy=name]').contains(testSponsor.name);
+    cy.get('[data-cy=website]').contains(testSponsor.website);
+    cy.get('[data-cy=type]').contains(testSponsor.type);
+  });
+
+  it('prevents members from managing sponsors', () => {
+    cy.register();
+    cy.login(Cypress.env('JWT_TEST_USER'));
+
+    cy.visit('/dashboard/');
+    cy.findByRole('link', { name: 'Sponsors' }).should('not.exist');
+
+    cy.createSponsor(testSponsor).then(expectToBeRejected);
+    cy.updateSponsor(1, testSponsor).then(expectToBeRejected);
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -333,3 +333,39 @@ Cypress.Commands.add('authedRequest', (options) => {
     },
   });
 });
+
+Cypress.Commands.add('createSponsor', (data) => {
+  const createSponsorData = {
+    operationName: 'createSponsor',
+    variables: { data },
+    query: `mutation createSponsor($data: CreateSponsorInputs!) {
+      createSponsor(data: $data) {
+        id
+      }
+    }`,
+  };
+  const requestOptions = {
+    method: 'POST',
+    url: 'http://localhost:5000/graphql',
+    body: createSponsorData,
+  };
+  return cy.authedRequest(requestOptions);
+});
+
+Cypress.Commands.add('updateSponsor', (id, data) => {
+  const updateSponsorData = {
+    operationName: 'updateSponsor',
+    variables: { id, data },
+    query: `mutation updateSponsor($id: Int!, $data: UpdateSponsorInputs!) {
+      updateSponsor(id: $id, data: $data) {
+        id
+      }
+    }`,
+  };
+  const requestOptions = {
+    method: 'POST',
+    url: 'http://localhost:5000/graphql',
+    body: updateSponsorData,
+  };
+  return cy.authedRequest(requestOptions);
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -101,5 +101,18 @@ declare namespace Cypress {
      * @param options Request options
      */
     authedRequest(options): Chainable<any>;
+
+    /**
+     * Create sponsor using GQL mutation
+     * @param data Data of the sponsor. Equivalent of CreateSponsorInputs for the Sponsor resolver.
+     */
+    createSponsor(data): Chainable<any>;
+
+    /**
+     * Update sponsor using GQL mutation
+     * @param id Sponsor id
+     * @param data Data of the sponsor. Equivalent of UpdateSponsorInputs for the Sponsor resolver.
+     */
+    updateSponsor(id: number, data): Chainable<any>;
   }
 }

--- a/server/prisma/generator/factories/chapterRoles.factory.ts
+++ b/server/prisma/generator/factories/chapterRoles.factory.ts
@@ -4,7 +4,6 @@ export enum ChapterPermission {
   ChapterEdit = 'chapter-edit',
   EventCreate = 'event-create',
   EventEdit = 'event-edit',
-  SponsorsManage = 'sponsors-manage',
   Rsvp = 'rsvp',
   RsvpDelete = 'rsvp-delete',
   RsvpConfirm = 'rsvp-confirm',

--- a/server/prisma/generator/factories/chapterRoles.factory.ts
+++ b/server/prisma/generator/factories/chapterRoles.factory.ts
@@ -4,6 +4,7 @@ export enum ChapterPermission {
   ChapterEdit = 'chapter-edit',
   EventCreate = 'event-create',
   EventEdit = 'event-edit',
+  SponsorsManage = 'sponsors-manage',
   Rsvp = 'rsvp',
   RsvpDelete = 'rsvp-delete',
   RsvpConfirm = 'rsvp-confirm',

--- a/server/prisma/generator/factories/instanceRoles.factory.ts
+++ b/server/prisma/generator/factories/instanceRoles.factory.ts
@@ -5,6 +5,7 @@ import { ChapterPermission } from './chapterRoles.factory';
 enum InstancePermission {
   ChapterCreate = 'chapter-create',
   ChangeInstanceRole = 'change-instance-role',
+  SponsorsManage = 'sponsors-manage',
   ViewUsers = 'view-users',
 }
 

--- a/server/src/controllers/Sponsors/resolver.ts
+++ b/server/src/controllers/Sponsors/resolver.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
-import { Resolver, Query, Arg, Int, Mutation } from 'type-graphql';
+import { Arg, Authorized, Int, Mutation, Query, Resolver } from 'type-graphql';
 
+import { Permission } from '../../../prisma/generator/factories/instanceRoles.factory';
 import { Sponsor } from '../../graphql-types/Sponsor';
 import { prisma } from '../../prisma';
 import { CreateSponsorInputs, UpdateSponsorInputs } from './inputs';
@@ -16,12 +17,14 @@ export class SponsorResolver {
     return prisma.sponsors.findUnique({ where: { id } });
   }
 
+  @Authorized(Permission.SponsorsManage)
   @Mutation(() => Sponsor)
   createSponsor(@Arg('data') data: CreateSponsorInputs): Promise<Sponsor> {
     const sponsorData: Prisma.sponsorsCreateInput = data;
     return prisma.sponsors.create({ data: sponsorData });
   }
 
+  @Authorized(Permission.SponsorsManage)
   @Mutation(() => Sponsor)
   updateSponsor(
     @Arg('id', () => Int) id: number,


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Restricts management of sponsors to owner ~~and chapter admin~~. (It doesn't make sense for this to be chapter role permission).
- Uses just single single permission, scope here seemed little enough to not split it in two.
- Doesn't display _Sponsors_ button in dashboard if user doesn't have permission. A bit of experimentation.
- Adding deleting sponsors for MVP might be worth consideration (and also venues).