### PR TITLE
feat: restrict venue creation

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -3181,7 +3181,23 @@
             "description": null,
             "args": [
               {
-                "name": "id",
+                "name": "chapterId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "venueId",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -3201,8 +3217,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
+                "kind": "OBJECT",
+                "name": "Venue",
                 "ofType": null
               }
             },

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -5405,6 +5405,22 @@
         "description": null,
         "fields": [
           {
+            "name": "chapter_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "city",
             "description": null,
             "args": [],

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -3017,6 +3017,22 @@
             "description": null,
             "args": [
               {
+                "name": "chapterId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "data",
                 "description": null,
                 "type": {

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -3772,6 +3772,22 @@
             "description": null,
             "args": [
               {
+                "name": "chapterId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "data",
                 "description": null,
                 "type": {
@@ -3788,7 +3804,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "id",
+                "name": "venueId",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -337,6 +337,7 @@ export type MutationCreateSponsorArgs = {
 };
 
 export type MutationCreateVenueArgs = {
+  chapterId: Scalars['Int'];
   data: CreateVenueInputs;
 };
 
@@ -1189,6 +1190,7 @@ export type UsersQuery = {
 };
 
 export type CreateVenueMutationVariables = Exact<{
+  chapterId: Scalars['Int'];
   data: CreateVenueInputs;
 }>;
 
@@ -3390,8 +3392,8 @@ export type UsersQueryResult = Apollo.QueryResult<
   UsersQueryVariables
 >;
 export const CreateVenueDocument = gql`
-  mutation createVenue($data: CreateVenueInputs!) {
-    createVenue(data: $data) {
+  mutation createVenue($chapterId: Int!, $data: CreateVenueInputs!) {
+    createVenue(chapterId: $chapterId, data: $data) {
       id
       name
       street_address
@@ -3422,6 +3424,7 @@ export type CreateVenueMutationFn = Apollo.MutationFunction<
  * @example
  * const [createVenueMutation, { data, loading, error }] = useCreateVenueMutation({
  *   variables: {
+ *      chapterId: // value for 'chapterId'
  *      data: // value for 'data'
  *   },
  * });

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -588,6 +588,7 @@ export type UserWithInstanceRole = {
 
 export type Venue = {
   __typename?: 'Venue';
+  chapter_id: Scalars['Int'];
   city: Scalars['String'];
   country: Scalars['String'];
   id: Scalars['Int'];
@@ -1241,6 +1242,7 @@ export type VenuesQuery = {
   venues: Array<{
     __typename?: 'Venue';
     id: number;
+    chapter_id: number;
     name: string;
     street_address?: string | null;
     city: string;
@@ -3521,6 +3523,7 @@ export const VenuesDocument = gql`
   query venues {
     venues {
       id
+      chapter_id
       name
       street_address
       city

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -421,8 +421,9 @@ export type MutationUpdateSponsorArgs = {
 };
 
 export type MutationUpdateVenueArgs = {
+  chapterId: Scalars['Int'];
   data: UpdateVenueInputs;
-  id: Scalars['Int'];
+  venueId: Scalars['Int'];
 };
 
 export type Query = {
@@ -1211,7 +1212,8 @@ export type CreateVenueMutation = {
 };
 
 export type UpdateVenueMutationVariables = Exact<{
-  id: Scalars['Int'];
+  venueId: Scalars['Int'];
+  chapterId: Scalars['Int'];
   data: UpdateVenueInputs;
 }>;
 
@@ -3451,8 +3453,12 @@ export type CreateVenueMutationOptions = Apollo.BaseMutationOptions<
   CreateVenueMutationVariables
 >;
 export const UpdateVenueDocument = gql`
-  mutation updateVenue($id: Int!, $data: UpdateVenueInputs!) {
-    updateVenue(id: $id, data: $data) {
+  mutation updateVenue(
+    $venueId: Int!
+    $chapterId: Int!
+    $data: UpdateVenueInputs!
+  ) {
+    updateVenue(venueId: $venueId, chapterId: $chapterId, data: $data) {
       id
       name
       street_address
@@ -3483,7 +3489,8 @@ export type UpdateVenueMutationFn = Apollo.MutationFunction<
  * @example
  * const [updateVenueMutation, { data, loading, error }] = useUpdateVenueMutation({
  *   variables: {
- *      id: // value for 'id'
+ *      venueId: // value for 'venueId'
+ *      chapterId: // value for 'chapterId'
  *      data: // value for 'data'
  *   },
  * });

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -276,7 +276,7 @@ export type Mutation = {
   deleteChapter: Chapter;
   deleteEvent: Event;
   deleteRsvp: Scalars['Boolean'];
-  deleteVenue: Scalars['Boolean'];
+  deleteVenue: Venue;
   initUserInterestForChapter: Scalars['Boolean'];
   joinChapter: ChapterUser;
   login: LoginType;
@@ -355,7 +355,8 @@ export type MutationDeleteRsvpArgs = {
 };
 
 export type MutationDeleteVenueArgs = {
-  id: Scalars['Int'];
+  chapterId: Scalars['Int'];
+  venueId: Scalars['Int'];
 };
 
 export type MutationInitUserInterestForChapterArgs = {

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -1,4 +1,4 @@
-import { Heading, Link, Box } from '@chakra-ui/layout';
+import { Heading, Link, Box, HStack } from '@chakra-ui/layout';
 import { LinkButton } from 'chakra-next-link';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -42,6 +42,13 @@ export const ChapterPage: NextPage = () => {
           <LinkButton size="sm" href={`${chapterId}/new_event`}>
             Add new event
           </LinkButton>
+          <LinkButton
+            data-cy="create-venue"
+            size="sm"
+            href={`${chapterId}/new-venue`}
+          >
+            Add new venue
+          </LinkButton>
         </ProgressCardContent>
       </Card>
       <h3>Placeholder for events...</h3>

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -39,16 +39,18 @@ export const ChapterPage: NextPage = () => {
               Chapter Users
             </Link>
           </Box>
-          <LinkButton size="sm" href={`${chapterId}/new_event`}>
-            Add new event
-          </LinkButton>
-          <LinkButton
-            data-cy="create-venue"
-            size="sm"
-            href={`${chapterId}/new-venue`}
-          >
-            Add new venue
-          </LinkButton>
+          <HStack>
+            <LinkButton size="sm" href={`${chapterId}/new_event`}>
+              Add new event
+            </LinkButton>
+            <LinkButton
+              data-cy="create-venue"
+              size="sm"
+              href={`${chapterId}/new-venue`}
+            >
+              Add new venue
+            </LinkButton>
+          </HStack>
         </ProgressCardContent>
       </Card>
       <h3>Placeholder for events...</h3>

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -138,7 +138,7 @@ export type IEventData = Pick<
 > & {
   venue_id?: number;
   tags: EventTag[];
-  venue?: Omit<Venue, 'events'> | null;
+  venue?: Omit<Venue, 'events' | 'chapter_id'> | null;
   sponsors: EventSponsorInput[];
 };
 

--- a/client/src/modules/dashboard/Venues/components/VenueForm.tsx
+++ b/client/src/modules/dashboard/Venues/components/VenueForm.tsx
@@ -5,7 +5,7 @@ import { Input } from '../../../../components/Form/Input';
 import type { Venue, VenueQuery } from '../../../../generated/graphql';
 import styles from '../../../../styles/Form.module.css';
 
-export type VenueFormData = Omit<Venue, 'id' | 'events'>;
+export type VenueFormData = Omit<Venue, 'id' | 'events' | 'chapter_id'>;
 
 interface VenueFormProps {
   loading: boolean;

--- a/client/src/modules/dashboard/Venues/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Venues/graphql/mutations.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export const createVenue = gql`
-  mutation createVenue($data: CreateVenueInputs!) {
-    createVenue(data: $data) {
+  mutation createVenue($chapterId: Int!, $data: CreateVenueInputs!) {
+    createVenue(chapterId: $chapterId, data: $data) {
       id
       name
       street_address

--- a/client/src/modules/dashboard/Venues/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Venues/graphql/mutations.ts
@@ -17,8 +17,12 @@ export const createVenue = gql`
 `;
 
 export const updateVenue = gql`
-  mutation updateVenue($id: Int!, $data: UpdateVenueInputs!) {
-    updateVenue(id: $id, data: $data) {
+  mutation updateVenue(
+    $venueId: Int!
+    $chapterId: Int!
+    $data: UpdateVenueInputs!
+  ) {
+    updateVenue(venueId: $venueId, chapterId: $chapterId, data: $data) {
       id
       name
       street_address

--- a/client/src/modules/dashboard/Venues/graphql/queries.ts
+++ b/client/src/modules/dashboard/Venues/graphql/queries.ts
@@ -4,6 +4,7 @@ export const VENUES = gql`
   query venues {
     venues {
       id
+      chapter_id
       name
       street_address
       city

--- a/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
@@ -58,7 +58,7 @@ export const EditVenuePage: NextPage = () => {
   }
 
   return (
-    <Layout>
+    <Layout data-cy="edit-venue-page">
       <VenueForm
         data={data}
         loading={loadingUpdate}

--- a/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
@@ -6,19 +6,23 @@ import {
   useVenueQuery,
   useUpdateVenueMutation,
 } from '../../../../generated/graphql';
-import { getId } from '../../../../util/getId';
+
 import styles from '../../../../styles/Page.module.css';
 import { Layout } from '../../shared/components/Layout';
 import VenueForm, { VenueFormData } from '../components/VenueForm';
 import { VENUES } from '../graphql/queries';
+import { useParam } from 'hooks/useParam';
 
 export const EditVenuePage: NextPage = () => {
   const [loadingUpdate, setLoadingUpdate] = useState(false);
 
   const router = useRouter();
-  const id = getId(router.query) || -1;
+  const venueId = useParam('venueId');
+  const chapterId = useParam('id');
 
-  const { loading, error, data } = useVenueQuery({ variables: { id } });
+  const { loading, error, data } = useVenueQuery({
+    variables: { id: venueId },
+  });
   const [updateVenue] = useUpdateVenueMutation({
     refetchQueries: [{ query: VENUES }],
   });
@@ -30,7 +34,11 @@ export const EditVenuePage: NextPage = () => {
       const longitude = parseFloat(String(data.longitude));
 
       await updateVenue({
-        variables: { id, data: { ...data, latitude, longitude } },
+        variables: {
+          venueId,
+          chapterId,
+          data: { ...data, latitude, longitude },
+        },
       });
       await router.push('/dashboard/venues');
     } catch (err) {

--- a/client/src/modules/dashboard/Venues/pages/NewVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/NewVenuePage.tsx
@@ -6,8 +6,10 @@ import { useCreateVenueMutation } from '../../../../generated/graphql';
 import { Layout } from '../../shared/components/Layout';
 import VenueForm, { VenueFormData } from '../components/VenueForm';
 import { VENUES } from '../graphql/queries';
+import { useParam } from 'hooks/useParam';
 
 export const NewVenuePage: NextPage = () => {
+  const chapterId = useParam('id');
   const [loading, setLoading] = useState(false);
   const router = useRouter();
 
@@ -22,7 +24,7 @@ export const NewVenuePage: NextPage = () => {
       const longitude = parseFloat(String(data.longitude));
 
       const venue = await createVenue({
-        variables: { data: { ...data, latitude, longitude } },
+        variables: { chapterId, data: { ...data, latitude, longitude } },
       });
       if (venue.data) {
         router.replace(`/dashboard/venues/${venue.data.createVenue.id}`);

--- a/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
@@ -26,7 +26,7 @@ export const VenuePage: NextPage = () => {
   }
 
   return (
-    <Layout>
+    <Layout data-cy="view-venue-page">
       <Card className={styles.card}>
         <ProgressCardContent>
           <Heading as="h2" fontWeight="normal" mb="2">

--- a/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
@@ -47,7 +47,7 @@ export const VenuesPage: NextPage = () => {
                   data-cy="edit-venue-button"
                   colorScheme="green"
                   size="xs"
-                  href={`/dashboard/venues/${venue.id}/edit`}
+                  href={`/dashboard/chapters/${venue.chapter_id}/venues/${venue.id}/edit`}
                 >
                   Edit
                 </LinkButton>

--- a/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
@@ -16,7 +16,6 @@ export const VenuesPage: NextPage = () => {
       <VStack>
         <Flex w="full" justify="space-between">
           <Heading id="page-heading">Venues</Heading>
-          <LinkButton href="/dashboard/venues/new">Add new</LinkButton>
         </Flex>
         {loading ? (
           <Heading>Loading...</Heading>

--- a/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
@@ -34,13 +34,17 @@ export const VenuesPage: NextPage = () => {
             keys={['name', 'location', 'actions'] as const}
             mapper={{
               name: (venue) => (
-                <LinkButton href={`/dashboard/venues/${venue.id}`}>
+                <LinkButton
+                  data-cy="view-venue-button"
+                  href={`/dashboard/venues/${venue.id}`}
+                >
                   {venue.name}
                 </LinkButton>
               ),
               location: (venue) => getLocationString(venue),
               actions: (venue) => (
                 <LinkButton
+                  data-cy="edit-venue-button"
                   colorScheme="green"
                   size="xs"
                   href={`/dashboard/venues/${venue.id}/edit`}

--- a/client/src/modules/dashboard/shared/components/Layout.tsx
+++ b/client/src/modules/dashboard/shared/components/Layout.tsx
@@ -18,12 +18,17 @@ const links = [
   { text: 'Users', link: '/dashboard/users' },
 ];
 
-export const Layout = ({ children }: { children: React.ReactNode }) => {
+export const Layout = ({
+  children,
+  ...rest
+}: {
+  children: React.ReactNode;
+  [prop: string]: unknown;
+}) => {
   const router = useRouter();
-
   return (
     <>
-      <HStack as="nav" my="2">
+      <HStack {...rest} as="nav" my="2">
         {links
           .filter(
             ({ requiredPermission }) =>

--- a/client/src/pages/dashboard/chapters/[id]/new-venue.tsx
+++ b/client/src/pages/dashboard/chapters/[id]/new-venue.tsx
@@ -1,0 +1,2 @@
+import { NewVenuePage } from '../../../../modules/dashboard/Venues';
+export default NewVenuePage;

--- a/client/src/pages/dashboard/chapters/[id]/venues/[venueId]/edit.tsx
+++ b/client/src/pages/dashboard/chapters/[id]/venues/[venueId]/edit.tsx
@@ -1,0 +1,2 @@
+import { EditVenuePage } from '../../../../../../modules/dashboard/Venues';
+export default EditVenuePage;

--- a/client/src/pages/dashboard/venues/[id]/edit.tsx
+++ b/client/src/pages/dashboard/venues/[id]/edit.tsx
@@ -1,2 +1,0 @@
-import { EditVenuePage } from '../../../../modules/dashboard/Venues/';
-export default EditVenuePage;

--- a/client/src/pages/dashboard/venues/new.tsx
+++ b/client/src/pages/dashboard/venues/new.tsx
@@ -1,2 +1,0 @@
-import { NewVenuePage } from '../../../modules/dashboard/Venues/';
-export default NewVenuePage;

--- a/common/permissions.ts
+++ b/common/permissions.ts
@@ -8,6 +8,7 @@ export enum ChapterPermission {
   RsvpConfirm = 'rsvp-confirm',
   VenueCreate = 'venue-create',
   VenueEdit = 'venue-edit',
+  VenueDelete = 'venue-delete',
 }
 
 export enum InstancePermission {

--- a/common/permissions.ts
+++ b/common/permissions.ts
@@ -6,6 +6,7 @@ export enum ChapterPermission {
   Rsvp = 'rsvp',
   RsvpDelete = 'rsvp-delete',
   RsvpConfirm = 'rsvp-confirm',
+  VenueCreate = 'venue-create',
 }
 
 export enum InstancePermission {

--- a/common/permissions.ts
+++ b/common/permissions.ts
@@ -7,6 +7,7 @@ export enum ChapterPermission {
   RsvpDelete = 'rsvp-delete',
   RsvpConfirm = 'rsvp-confirm',
   VenueCreate = 'venue-create',
+  VenueEdit = 'venue-edit',
 }
 
 export enum InstancePermission {

--- a/cypress/e2e/dashboard/venues.cy.js
+++ b/cypress/e2e/dashboard/venues.cy.js
@@ -22,14 +22,23 @@ describe('venues dashboard', () => {
     cy.get('a[aria-current="page"]').should('have.text', 'Venues');
   });
 
-  it('should have a table with links to view, create and edit venues', () => {
+  it('should have a table with links to view and edit venues', () => {
     cy.visit('/dashboard/venues');
     cy.findByRole('table', { name: 'Venues' }).should('be.visible');
     cy.findByRole('columnheader', { name: 'name' }).should('be.visible');
     cy.findByRole('columnheader', { name: 'actions' }).should('be.visible');
-    cy.get('a[href="/dashboard/venues/1"]').should('be.visible');
-    cy.get('a[href="/dashboard/venues/new"]').should('be.visible');
-    cy.get('a[href="/dashboard/venues/1/edit"]').should('be.visible');
+
+    cy.get('[data-cy="view-venue-button"]')
+      .should('be.visible')
+      .first()
+      .click();
+    cy.get('[data-cy="view-venue-page"]').should('exist');
+    cy.go('back');
+    cy.get('[data-cy="edit-venue-button"]')
+      .should('be.visible')
+      .first()
+      .click();
+    cy.get('[data-cy="edit-venue-page"]').should('exist');
   });
 
   it('lets an admin create a venue', () => {

--- a/cypress/e2e/dashboard/venues.cy.js
+++ b/cypress/e2e/dashboard/venues.cy.js
@@ -126,10 +126,11 @@ describe('venues dashboard', () => {
     cy.createVenue({ ...venueCreateVariables, chapterId: 2 }, venueData).then(
       expectToBeRejected,
     );
-    cy.updateVenue({ ...venueCreateVariables, chapterId: 2 }, venueData).then(
-      expectToBeRejected,
-    );
-    cy.deleteVenue({ ...venueCreateVariables, chapterId: 2 }).then(
+    cy.updateVenue(
+      { ...venueUpdateDeleteVariables, chapterId: 2 },
+      venueData,
+    ).then(expectToBeRejected);
+    cy.deleteVenue({ ...venueUpdateDeleteVariables, chapterId: 2 }).then(
       expectToBeRejected,
     );
   });

--- a/cypress/e2e/dashboard/venues.cy.js
+++ b/cypress/e2e/dashboard/venues.cy.js
@@ -12,6 +12,9 @@ const venueData = {
 };
 
 describe('venues dashboard', () => {
+  beforeEach(() => {
+    cy.exec('npm run db:seed');
+  });
   it('should be the active dashboard link', () => {
     cy.visit('/dashboard/');
     cy.get('a[aria-current="page"]').should('not.exist');

--- a/cypress/e2e/dashboard/venues.cy.js
+++ b/cypress/e2e/dashboard/venues.cy.js
@@ -43,8 +43,8 @@ describe('venues dashboard', () => {
 
     cy.login(Cypress.env('JWT_ADMIN_USER'));
 
-    cy.visit('/dashboard/venues');
-    cy.get('a[href="/dashboard/venues/new"]').click();
+    cy.visit('/dashboard/chapters/1/');
+    cy.get('[data-cy=create-venue]').click();
     cy.findByRole('textbox', { name: 'Venue name' }).type(fix.name);
     cy.findByRole('textbox', { name: 'Street address' }).type(
       fix.streetAddress,

--- a/cypress/e2e/dashboard/venues.cy.js
+++ b/cypress/e2e/dashboard/venues.cy.js
@@ -1,3 +1,16 @@
+import { expectToBeRejected } from '../../support/util';
+
+const venueData = {
+  name: 'Test Venue',
+  street_address: '123 Main St',
+  city: 'New York',
+  postal_code: '10001',
+  region: 'NY',
+  country: 'US',
+  latitude: 40.7128,
+  longitude: -74.006,
+};
+
 describe('venues dashboard', () => {
   it('should be the active dashboard link', () => {
     cy.visit('/dashboard/');
@@ -16,7 +29,7 @@ describe('venues dashboard', () => {
     cy.get('a[href="/dashboard/venues/1/edit"]').should('be.visible');
   });
 
-  it('lets a user create a venue', () => {
+  it('lets an admin create a venue', () => {
     const fix = {
       name: 'Name goes here',
       streetAddress: '10 Random Path',
@@ -27,6 +40,9 @@ describe('venues dashboard', () => {
       latitude: '-45',
       longitude: '35',
     };
+
+    cy.login(Cypress.env('JWT_ADMIN_USER'));
+
     cy.visit('/dashboard/venues');
     cy.get('a[href="/dashboard/venues/new"]').click();
     cy.findByRole('textbox', { name: 'Venue name' }).type(fix.name);
@@ -54,5 +70,64 @@ describe('venues dashboard', () => {
     cy.contains(fix.postalCode);
     cy.contains(fix.region);
     // TODO: display more details about the venue?
+  });
+
+  it('only accepts requests from owners and admins of the associated chapter', () => {
+    const venueCreateVariables = {
+      chapterId: 1,
+    };
+    const venueUpdateDeleteVariables = {
+      chapterId: 1,
+      venueId: 1,
+    };
+
+    // logged out user
+    cy.logout();
+    cy.reload();
+
+    cy.createVenue(venueCreateVariables, venueData, { withAuth: false }).then(
+      expectToBeRejected,
+    );
+    cy.updateVenue(venueUpdateDeleteVariables, venueData, {
+      withAuth: false,
+    }).then(expectToBeRejected);
+    cy.deleteVenue(venueUpdateDeleteVariables, { withAuth: false }).then(
+      expectToBeRejected,
+    );
+
+    // newly registered user (without a chapter_users record)
+    cy.register();
+    cy.login(Cypress.env('JWT_TEST_USER'));
+    cy.reload();
+
+    cy.createVenue(venueCreateVariables, venueData).then(expectToBeRejected);
+    cy.updateVenue(venueUpdateDeleteVariables, venueData).then(
+      expectToBeRejected,
+    );
+    cy.deleteVenue(venueUpdateDeleteVariables).then(expectToBeRejected);
+
+    // banned user
+    cy.login(Cypress.env('JWT_BANNED_ADMIN_USER'));
+    cy.reload();
+
+    cy.createVenue(venueCreateVariables, venueData).then(expectToBeRejected);
+    cy.updateVenue(venueUpdateDeleteVariables, venueData).then(
+      expectToBeRejected,
+    );
+    cy.deleteVenue(venueUpdateDeleteVariables).then(expectToBeRejected);
+
+    // Admin of different chapter
+    cy.login(Cypress.env('JWT_ADMIN_USER'));
+    cy.reload();
+
+    cy.createVenue({ ...venueCreateVariables, chapterId: 2 }, venueData).then(
+      expectToBeRejected,
+    );
+    cy.updateVenue({ ...venueCreateVariables, chapterId: 2 }, venueData).then(
+      expectToBeRejected,
+    );
+    cy.deleteVenue({ ...venueCreateVariables, chapterId: 2 }).then(
+      expectToBeRejected,
+    );
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -339,6 +339,77 @@ Cypress.Commands.add('confirmRsvp', (eventId, userId) => {
   return cy.authedRequest(gqlOptions(confirmMutation));
 });
 
+Cypress.Commands.add(
+  'createVenue',
+  ({ chapterId }, data, options = { withAuth: true }) => {
+    const queryData = {
+      operationName: 'createVenue',
+      variables: {
+        chapterId,
+        data,
+      },
+      query: `mutation createVenue($chapterId: Int!, $data: CreateVenueInputs!) {
+      createVenue(chapterId: $chapterId, data: $data) {
+        id
+      }
+    }`,
+    };
+
+    const requestOptions = gqlOptions(queryData);
+
+    return options.withAuth
+      ? cy.authedRequest(requestOptions)
+      : cy.request(requestOptions);
+  },
+);
+
+Cypress.Commands.add(
+  'updateVenue',
+  ({ chapterId, venueId }, data, options = { withAuth: true }) => {
+    const queryData = {
+      operationName: 'updateVenue',
+      variables: {
+        chapterId,
+        venueId,
+        data,
+      },
+      query: `mutation updateVenue($chapterId: Int!, $venueId: Int!, $data: UpdateVenueInputs!) {
+      updateVenue(chapterId: $chapterId, venueId: $venueId, data: $data) {
+        id
+      }
+    }`,
+    };
+    const requestOptions = gqlOptions(queryData);
+
+    return options.withAuth
+      ? cy.authedRequest(requestOptions)
+      : cy.request(requestOptions);
+  },
+);
+
+Cypress.Commands.add(
+  'deleteVenue',
+  ({ chapterId, venueId }, options = { withAuth: true }) => {
+    const queryData = {
+      operationName: 'deleteVenue',
+      variables: {
+        chapterId,
+        venueId,
+      },
+      query: `mutation deleteVenue($chapterId: Int!, $venueId: Int!) {
+      deleteVenue(chapterId: $chapterId, venueId: $venueId) {
+        id
+      }
+    }`,
+    };
+    const requestOptions = gqlOptions(queryData);
+
+    return options.withAuth
+      ? cy.authedRequest(requestOptions)
+      : cy.request(requestOptions);
+  },
+);
+
 Cypress.Commands.add('authedRequest', (options) => {
   return cy.request({
     ...options,

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -134,5 +134,41 @@ declare namespace Cypress {
       { eventId }: { eventId: number },
       options?: { withAuth: true },
     ): Chainable<any>;
+
+    /**
+     * Create venue using GQL mutation
+     * @param chapterId Id of the chapter
+     * @param data Data of the venue. Equivalent of CreateVenueInputs for the Venue resolver.
+     * @param {object} [options={ withAuth: true }] Optional options object.
+     */
+    createVenue(
+      { chapterId }: { chapterId: number },
+      data: any,
+      options?: { withAuth: true },
+    ): Chainable<any>;
+
+    /**
+     * Update venue using GQL mutation
+     * @param chapterId Id of the chapter
+     * @param venueId Id of the venue
+     * @param data Data of the venue. Equivalent of UpdateVenueInputs for the Venue resolver.
+     * @param {object} [options={ withAuth: true }] Optional options object.
+     */
+    updateVenue(
+      { venueId, chapterId }: { venueId: number; chapterId: number },
+      data: any,
+      options?: { withAuth: true },
+    ): Chainable<any>;
+
+    /**
+     * Delete venue using GQL mutation
+     * @param chapterId Id of the chapter
+     * @param venueId Id of the venue
+     * @param {object} [options={ withAuth: true }] Optional options object.
+     */
+    deleteVenue(
+      { venueId, chapterId }: { venueId: number; chapterId: number },
+      options?: { withAuth: true },
+    ): Chainable<any>;
   }
 }

--- a/server/prisma/generator/factories/venues.factory.ts
+++ b/server/prisma/generator/factories/venues.factory.ts
@@ -5,7 +5,7 @@ import { prisma } from '../../../src/prisma';
 
 const { company, address } = faker;
 
-const createVenues = async (): Promise<number[]> => {
+const createVenues = async (chapterId: number): Promise<number[]> => {
   const venueIds: number[] = [];
 
   for (let i = 0; i < 4; i++) {
@@ -16,6 +16,7 @@ const createVenues = async (): Promise<number[]> => {
       postal_code: address.zipCode(),
       country: address.country(),
       street_address: Math.random() > 0.5 ? address.streetAddress() : undefined,
+      chapter: { connect: { id: chapterId } },
     };
 
     // TODO: batch this once createMany returns the records.

--- a/server/prisma/generator/seed.ts
+++ b/server/prisma/generator/seed.ts
@@ -33,7 +33,7 @@ import setupRoles from './setupRoles';
   const sponsorIds = await createSponsors();
 
   const chapterIds = await createChapters(ownerId);
-  const venueIds = await createVenues();
+  const venueIds = await createVenues(chapterIds[0]);
 
   const eventIds = await createEvents(chapterIds, venueIds, sponsorIds, 15);
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -27,6 +27,7 @@ model chapters {
   events        events[]
   user_bans     user_bans[]
   chapter_users chapter_users[]
+  venues        venues[]
 }
 
 model chapter_users {
@@ -148,18 +149,18 @@ model event_permissions {
 }
 
 model event_users {
-  created_at     DateTime        @default(now())
-  updated_at     DateTime        @updatedAt
+  created_at     DateTime         @default(now())
+  updated_at     DateTime         @updatedAt
   user_id        Int
   event_id       Int
   event_role_id  Int
   rsvp_id        Int
   subscribed     Boolean
   title          String[]
-  user           users           @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  event          events          @relation(fields: [event_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  event_role     event_roles     @relation(fields: [event_role_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  rsvp           rsvp            @relation(fields: [rsvp_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  user           users            @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  event          events           @relation(fields: [event_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  event_role     event_roles      @relation(fields: [event_role_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  rsvp           rsvp             @relation(fields: [rsvp_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   event_reminder event_reminders?
 
   @@id([user_id, event_id])
@@ -209,8 +210,8 @@ model user_bans {
   updated_at DateTime @updatedAt
   user_id    Int
   chapter_id Int
-  chapter   chapters @relation(fields: [chapter_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  user      users    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  chapter    chapters @relation(fields: [chapter_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  user       users    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
   @@id([user_id, chapter_id])
 }
@@ -270,6 +271,8 @@ model venues {
   latitude       Float?
   longitude      Float?
   events         events[]
+  chapter        chapters @relation(fields: [chapter_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  chapter_id     Int
 }
 
 enum events_venue_type_enum {

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -273,8 +273,6 @@ model venues {
   events         events[]
   chapter        chapters @relation(fields: [chapter_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   chapter_id     Int
-
-  @@unique([id, chapter_id])
 }
 
 enum events_venue_type_enum {

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -273,6 +273,8 @@ model venues {
   events         events[]
   chapter        chapters @relation(fields: [chapter_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   chapter_id     Int
+
+  @@unique([id, chapter_id])
 }
 
 enum events_venue_type_enum {

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -37,12 +37,14 @@ export class VenueResolver {
   @Mutation(() => Venue)
   updateVenue(
     @Arg('venueId', () => Int) id: number,
-    @Arg('chapterId', () => Int) chapter_id: number,
+    // chapterId needs to be passed, so the authChecker can confirm the user has
+    // permission to edit the venue, but it's not used in the resolver
+    @Arg('chapterId', () => Int) _chapterId: number,
     @Arg('data') data: UpdateVenueInputs,
   ): Promise<Venue | null> {
     const venueData: Prisma.venuesUpdateInput = data;
     return prisma.venues.update({
-      where: { id_chapter_id: { id, chapter_id } },
+      where: { id },
       data: venueData,
     });
   }
@@ -51,11 +53,13 @@ export class VenueResolver {
   @Mutation(() => Venue)
   async deleteVenue(
     @Arg('venueId', () => Int) id: number,
-    @Arg('chapterId', () => Int) chapter_id: number,
+    // chapterId needs to be passed, so the authChecker can confirm the user has
+    // permission to delete the venue, but it's not used in the resolver
+    @Arg('chapterId', () => Int) _chapterId: number,
   ): Promise<{ id: number }> {
     // TODO: handle deletion of non-existent venue
     return await prisma.venues.delete({
-      where: { id_chapter_id: { id, chapter_id } },
+      where: { id },
     });
   }
 }

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -18,9 +18,17 @@ export class VenueResolver {
   }
 
   @Mutation(() => Venue)
-  async createVenue(@Arg('data') data: CreateVenueInputs): Promise<Venue> {
-    const venueData: Prisma.venuesCreateInput = data;
-    return prisma.venues.create({ data: venueData });
+  async createVenue(
+    @Arg('chapterId', () => Int) chapter_id: number,
+    @Arg('data') data: CreateVenueInputs,
+  ): Promise<Venue> {
+    const venueData: Prisma.venuesCreateInput = {
+      ...data,
+      chapter: { connect: { id: chapter_id } },
+    };
+    return prisma.venues.create({
+      data: venueData,
+    });
   }
 
   @Mutation(() => Venue)

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -35,11 +35,15 @@ export class VenueResolver {
 
   @Mutation(() => Venue)
   updateVenue(
-    @Arg('id', () => Int) id: number,
+    @Arg('venueId', () => Int) id: number,
+    @Arg('chapterId', () => Int) chapter_id: number,
     @Arg('data') data: UpdateVenueInputs,
   ): Promise<Venue | null> {
     const venueData: Prisma.venuesUpdateInput = data;
-    return prisma.venues.update({ where: { id }, data: venueData });
+    return prisma.venues.update({
+      where: { id_chapter_id: { id, chapter_id } },
+      data: venueData,
+    });
   }
 
   @Mutation(() => Boolean)

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -37,14 +37,12 @@ export class VenueResolver {
   @Mutation(() => Venue)
   updateVenue(
     @Arg('venueId', () => Int) id: number,
-    // chapterId needs to be passed, so the authChecker can confirm the user has
-    // permission to edit the venue, but it's not used in the resolver
-    @Arg('chapterId', () => Int) _chapterId: number,
+    @Arg('chapterId', () => Int) chapter_id: number,
     @Arg('data') data: UpdateVenueInputs,
   ): Promise<Venue | null> {
     const venueData: Prisma.venuesUpdateInput = data;
     return prisma.venues.update({
-      where: { id },
+      where: { id_chapter_id: { id, chapter_id } },
       data: venueData,
     });
   }
@@ -53,13 +51,11 @@ export class VenueResolver {
   @Mutation(() => Venue)
   async deleteVenue(
     @Arg('venueId', () => Int) id: number,
-    // chapterId needs to be passed, so the authChecker can confirm the user has
-    // permission to delete the venue, but it's not used in the resolver
-    @Arg('chapterId', () => Int) _chapterId: number,
+    @Arg('chapterId', () => Int) chapter_id: number,
   ): Promise<{ id: number }> {
     // TODO: handle deletion of non-existent venue
     return await prisma.venues.delete({
-      where: { id },
+      where: { id_chapter_id: { id, chapter_id } },
     });
   }
 }

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -34,6 +34,7 @@ export class VenueResolver {
   }
 
   @Mutation(() => Venue)
+  @Authorized(Permission.VenueEdit)
   updateVenue(
     @Arg('venueId', () => Int) id: number,
     @Arg('chapterId', () => Int) chapter_id: number,

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -33,8 +33,8 @@ export class VenueResolver {
     });
   }
 
-  @Mutation(() => Venue)
   @Authorized(Permission.VenueEdit)
+  @Mutation(() => Venue)
   updateVenue(
     @Arg('venueId', () => Int) id: number,
     @Arg('chapterId', () => Int) chapter_id: number,
@@ -47,8 +47,8 @@ export class VenueResolver {
     });
   }
 
-  @Mutation(() => Venue)
   @Authorized(Permission.VenueDelete)
+  @Mutation(() => Venue)
   async deleteVenue(
     @Arg('venueId', () => Int) id: number,
     @Arg('chapterId', () => Int) chapter_id: number,

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -47,10 +47,15 @@ export class VenueResolver {
     });
   }
 
-  @Mutation(() => Boolean)
-  async deleteVenue(@Arg('id', () => Int) id: number): Promise<boolean> {
+  @Mutation(() => Venue)
+  @Authorized(Permission.VenueDelete)
+  async deleteVenue(
+    @Arg('venueId', () => Int) id: number,
+    @Arg('chapterId', () => Int) chapter_id: number,
+  ): Promise<{ id: number }> {
     // TODO: handle deletion of non-existent venue
-    await prisma.venues.delete({ where: { id } });
-    return true;
+    return await prisma.venues.delete({
+      where: { id_chapter_id: { id, chapter_id } },
+    });
   }
 }

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
-import { Resolver, Query, Arg, Int, Mutation } from 'type-graphql';
+import { Resolver, Query, Arg, Int, Mutation, Authorized } from 'type-graphql';
+import { Permission } from '../../../../common/permissions';
 
 import { Venue } from '../../graphql-types';
 import { prisma } from '../../prisma';
@@ -17,6 +18,7 @@ export class VenueResolver {
     return prisma.venues.findUnique({ where: { id } });
   }
 
+  @Authorized(Permission.VenueCreate)
   @Mutation(() => Venue)
   async createVenue(
     @Arg('chapterId', () => Int) chapter_id: number,

--- a/server/src/graphql-types/Venue.ts
+++ b/server/src/graphql-types/Venue.ts
@@ -1,8 +1,11 @@
-import { Field, ObjectType, Float } from 'type-graphql';
+import { Field, ObjectType, Float, Int } from 'type-graphql';
 import { BaseObject } from './BaseObject';
 
 @ObjectType()
 export class Venue extends BaseObject {
+  @Field(() => Int)
+  chapter_id: number;
+
   @Field(() => String)
   name: string;
 


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes https://github.com/freeCodeCamp/chapter/issues/1195

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

This is a little more extensive than most auth PRs, because of the reasons mentioned in the linked issue.

To ensure that the associated chapterId was available for the request, I put venue creation inside /dashboard/chapters/[chapterId]/ much like event creation.  Similar story for editing events.


TODO:

- [x] ~~Move event edit page inside /dashboard/chapters/[chapterId]/~~ (necessary, but nothing to do with this) 
- [x] ~~Make sure VenueForm gets passed `chapter_id`~~ (it's fine, the `onSubmit` method is doing it)