### PR TITLE
refactor: rename secrets to disabiguate them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,9 @@ EMAIL_HOST=localhost
 
 # change this variable to at least 32 random characters
 # to enforce 256-bit cryto security on Auth0's JsonWebToken
-JWT_SECRET=SetThisTo32orMoreRandomCharacters
+AUTH_JWT_SECRET=SetThisTo32orMoreRandomCharacters
 
-UNSUBSCRIBE_SECRET=SetThisToDifferent32orMoreCharacters
+UNSUBSCRIBE_JWT_SECRET=SetThisToDifferent32orMoreCharacters
 
 # When running remotely, this should be the full url of the landing page
 CLIENT_LOCATION=http://localhost:3000

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -15,22 +15,22 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       // `on` is used to hook into various events Cypress emits
       // `config` is the resolved Cypress config
-      if (!process.env.JWT_SECRET)
-        throw Error('JWT_SECRET must be set for e2e tests');
+      if (!process.env.AUTH_JWT_SECRET)
+        throw Error('AUTH_JWT_SECRET must be set for e2e tests');
 
       config.env = config.env || {};
       // TODO: ideally the email address should have a common source (since it's
       // used in the db generator, too)
       config.env.JWT = jwt.sign(
         { email: 'foo@bar.com' },
-        process.env.JWT_SECRET,
+        process.env.AUTH_JWT_SECRET,
         {
           expiresIn: '120min',
         },
       );
       config.env.JWT_TEST_USER = jwt.sign(
         { email: 'test@user.org' },
-        process.env.JWT_SECRET,
+        process.env.AUTH_JWT_SECRET,
         {
           expiresIn: '120min',
         },
@@ -38,7 +38,7 @@ export default defineConfig({
 
       config.env.JWT_ADMIN_USER = jwt.sign(
         { email: 'admin@of.a.chapter' },
-        process.env.JWT_SECRET,
+        process.env.AUTH_JWT_SECRET,
         {
           expiresIn: '120min',
         },
@@ -46,7 +46,7 @@ export default defineConfig({
 
       config.env.JWT_BANNED_ADMIN_USER = jwt.sign(
         { email: 'banned@chapter.admin' },
-        process.env.JWT_SECRET,
+        process.env.AUTH_JWT_SECRET,
         {
           expiresIn: '120min',
         },
@@ -54,7 +54,7 @@ export default defineConfig({
 
       config.env.TOKEN_DELETED_USER = jwt.sign(
         { id: -1 },
-        process.env.JWT_SECRET,
+        process.env.AUTH_JWT_SECRET,
         {
           expiresIn: '120min',
         },
@@ -62,7 +62,7 @@ export default defineConfig({
 
       config.env.JWT_EXPIRED = jwt.sign(
         { email: 'foo@bar.com' },
-        process.env.JWT_SECRET,
+        process.env.AUTH_JWT_SECRET,
         {
           expiresIn: '1',
         },

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -20,8 +20,8 @@ if (result.error) {
 
 export interface Environment {
   NODE_ENV: 'production' | 'development' | 'test' | undefined;
-  JWT_SECRET: string;
-  UNSUBSCRIBE_SECRET: string;
+  AUTH_JWT_SECRET: string;
+  UNSUBSCRIBE_JWT_SECRET: string;
 }
 
 export const getConfig = <T extends keyof Environment>(

--- a/server/src/controllers/Auth/middleware.ts
+++ b/server/src/controllers/Auth/middleware.ts
@@ -70,7 +70,7 @@ export const userMiddleware = (
     return next(new JsonWebTokenError('Invalid auth header'));
   }
 
-  const value = verify(raw[1], getConfig('JWT_SECRET')) as { id: number };
+  const value = verify(raw[1], getConfig('AUTH_JWT_SECRET')) as { id: number };
   if (!value.id) {
     return next(new JsonWebTokenError('Missing contents'));
   }

--- a/server/src/controllers/Auth/resolver.ts
+++ b/server/src/controllers/Auth/resolver.ts
@@ -83,7 +83,7 @@ export class AuthResolver {
   async authenticate(@Arg('token') token: string): Promise<AuthenticateType> {
     let data: TokenResponseType;
     try {
-      data = verify(token, getConfig('JWT_SECRET')) as TokenResponseType;
+      data = verify(token, getConfig('AUTH_JWT_SECRET')) as TokenResponseType;
     } catch (e) {
       // TODO: Handle different parsing errors
       console.error(e);
@@ -103,7 +103,7 @@ export class AuthResolver {
       },
     });
 
-    const authToken = sign({ id: user.id }, getConfig('JWT_SECRET'), {
+    const authToken = sign({ id: user.id }, getConfig('AUTH_JWT_SECRET'), {
       expiresIn: '31d',
     });
 

--- a/server/src/controllers/Unsubscribe/resolver.ts
+++ b/server/src/controllers/Unsubscribe/resolver.ts
@@ -61,7 +61,10 @@ export class UnsubscribeResolver {
   async unsubscribe(@Arg('token') token: string): Promise<boolean> {
     let data;
     try {
-      data = verify(token, getConfig('UNSUBSCRIBE_SECRET')) as UnsubscribeToken;
+      data = verify(
+        token,
+        getConfig('UNSUBSCRIBE_JWT_SECRET'),
+      ) as UnsubscribeToken;
     } catch (e) {
       throw Error('Invalid token');
     }

--- a/server/src/services/AuthToken.ts
+++ b/server/src/services/AuthToken.ts
@@ -6,7 +6,7 @@ class AuthToken {
   private readonly secret: string;
 
   constructor() {
-    this.secret = getConfig('JWT_SECRET');
+    this.secret = getConfig('AUTH_JWT_SECRET');
   }
 
   public generateToken(email: string) {

--- a/server/src/services/UnsubscribeToken.ts
+++ b/server/src/services/UnsubscribeToken.ts
@@ -18,4 +18,4 @@ export const generateToken = (
   type: UnsubscribeType,
   id: number,
   userId: number,
-) => sign({ type, id, userId }, getConfig('UNSUBSCRIBE_SECRET'));
+) => sign({ type, id, userId }, getConfig('UNSUBSCRIBE_JWT_SECRET'));

--- a/server/tests/Auth.test.ts
+++ b/server/tests/Auth.test.ts
@@ -4,7 +4,7 @@ import { getConfig } from '../src/config';
 import { authTokenService } from '../src/services/AuthToken';
 
 // Setup
-const secret = getConfig('JWT_SECRET');
+const secret = getConfig('AUTH_JWT_SECRET');
 const email = 'joe.smith@example.com';
 const { token, code } = authTokenService.generateToken(email);
 


### PR DESCRIPTION
It's crucially important that the AUTH_JWT_SECRET is not used to create
tokens that can be accidentally shared, so this name should make it
obvious when the secret is being used in the wrong context.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #XXXXX

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
