### PR TITLE
fix: change magic link to include client location

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,6 +12,7 @@ tasks:
   # they need setting here
   - before: |
       echo NEXT_PUBLIC_APOLLO_SERVER=$(gp url 5000) > client/.env.development.local &&
+      export CLIENT_LOCATION=$(gp url 3000) &&
       nvm install lts/gallium && nvm alias default lts/gallium
     # the rest, get persisted, so we can save time and use init:
     init: |

--- a/server/src/controllers/Auth/resolver.ts
+++ b/server/src/controllers/Auth/resolver.ts
@@ -63,12 +63,12 @@ export class AuthResolver {
     const { token, code } = authTokenService.generateToken(user.email);
     if (isDev()) {
       console.log(
-        `Code: ${code}\nhttp://localhost:3000/auth/token?token=${token}`,
+        `Code: ${code}\n${process.env.CLIENT_LOCATION}/auth/token?token=${token}`,
       );
       await new MailerService({
         emailList: [data.email],
         subject: 'Login to Chapter',
-        htmlEmail: `<a href=http://localhost:3000/auth/token?token=${token}>Click here to log in to chapter</a>`,
+        htmlEmail: `<a href=${process.env.CLIENT_LOCATION}/auth/token?token=${token}>Click here to log in to chapter</a>`,
       }).sendEmail();
     }
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Uses `CLIENT_LOCATION` env in the logging in link.
- Sets appropriate `CLIENT_LOCATION` env for gitpod.