### PR TITLE
fix: infer chapterId from events, not user_events

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import { GQLCtx, Request } from './common-types/gql';
 import { resolvers } from './controllers';
 import {
   userMiddleware,
+  events,
   handleAuthenticationError,
 } from './controllers/Auth/middleware';
 
@@ -28,6 +29,7 @@ const PORT = process.env.PORT || 5000;
 export const main = async (app: Express) => {
   app.use(cors({ credentials: true, origin: true }));
   app.use(userMiddleware);
+  app.use(events);
   app.use(handleAuthenticationError);
 
   const schema = await buildSchema({
@@ -40,6 +42,7 @@ export const main = async (app: Express) => {
       req,
       res,
       user: req.user,
+      events: req.events,
     }),
   });
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,7 +6,7 @@ import express, { Express, Response } from 'express';
 import { buildSchema } from 'type-graphql';
 
 import { authorizationChecker } from './authorization';
-import { GQLCtx, Request } from './common-types/gql';
+import { ResolverCtx, Request } from './common-types/gql';
 import { resolvers } from './controllers';
 import {
   user,
@@ -38,7 +38,7 @@ export const main = async (app: Express) => {
   });
   const server = new ApolloServer({
     schema,
-    context: ({ req, res }: { req: Request; res: Response }): GQLCtx => ({
+    context: ({ req, res }: { req: Request; res: Response }): ResolverCtx => ({
       req,
       res,
       user: req.user,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -9,7 +9,7 @@ import { authorizationChecker } from './authorization';
 import { GQLCtx, Request } from './common-types/gql';
 import { resolvers } from './controllers';
 import {
-  userMiddleware,
+  user,
   events,
   handleAuthenticationError,
 } from './controllers/Auth/middleware';
@@ -28,7 +28,7 @@ const PORT = process.env.PORT || 5000;
 
 export const main = async (app: Express) => {
   app.use(cors({ credentials: true, origin: true }));
-  app.use(userMiddleware);
+  app.use(user);
   app.use(events);
   app.use(handleAuthenticationError);
 

--- a/server/src/authorization/index.ts
+++ b/server/src/authorization/index.ts
@@ -16,7 +16,7 @@ export const authorizationChecker: AuthChecker<GQLCtx | Required<GQLCtx>> = (
   { context, info: { variableValues } },
   requiredPermissions,
 ): boolean => {
-  if (!hasUser(context)) return false;
+  if (!hasUserAndEvents(context)) return false;
 
   if (requiredPermissions.length !== 1) return false;
   const requiredPermission = requiredPermissions[0];
@@ -31,8 +31,10 @@ export const authorizationChecker: AuthChecker<GQLCtx | Required<GQLCtx>> = (
   return false;
 };
 
-function hasUser(ctx: GQLCtx | Required<GQLCtx>): ctx is Required<GQLCtx> {
-  return 'user' in ctx;
+function hasUserAndEvents(
+  ctx: GQLCtx | Required<GQLCtx>,
+): ctx is Required<GQLCtx> {
+  return 'user' in ctx && 'events' in ctx;
 }
 
 function isAllowedByChapterRole(

--- a/server/src/authorization/index.ts
+++ b/server/src/authorization/index.ts
@@ -83,8 +83,6 @@ function isAllowedByEventRole(
 }
 
 function getUserPermissionsForInstance(user: User): string[] {
-  console.log('checking instance permissions');
-  console.log('user', user);
   return user.instance_role.instance_role_permissions.map(
     (x) => x.instance_permission.name,
   );

--- a/server/src/authorization/index.ts
+++ b/server/src/authorization/index.ts
@@ -1,7 +1,7 @@
 import { GraphQLResolveInfo } from 'graphql';
 import { AuthChecker } from 'type-graphql';
 
-import { GQLCtx } from '../common-types/gql';
+import { ResolverCtx } from '../common-types/gql';
 import type { Events, User } from '../controllers/Auth/middleware';
 
 // This is a *very* broad type, but unfortunately variableValues is only
@@ -12,10 +12,9 @@ type VariableValues = GraphQLResolveInfo['variableValues'];
  * on a user's role. It cannot affect what is returned by a resolver, it just
  * determines if the resolver is called or not. For fine-grained control, the
  * resolver itself must modify the response based on the user's roles */
-export const authorizationChecker: AuthChecker<GQLCtx | Required<GQLCtx>> = (
-  { context, info: { variableValues } },
-  requiredPermissions,
-): boolean => {
+export const authorizationChecker: AuthChecker<
+  ResolverCtx | Required<ResolverCtx>
+> = ({ context, info: { variableValues } }, requiredPermissions): boolean => {
   if (!hasUserAndEvents(context)) return false;
 
   if (requiredPermissions.length !== 1) return false;
@@ -32,13 +31,13 @@ export const authorizationChecker: AuthChecker<GQLCtx | Required<GQLCtx>> = (
 };
 
 function hasUserAndEvents(
-  ctx: GQLCtx | Required<GQLCtx>,
-): ctx is Required<GQLCtx> {
+  ctx: ResolverCtx | Required<ResolverCtx>,
+): ctx is Required<ResolverCtx> {
   return typeof ctx.user !== 'undefined' && typeof ctx.events !== 'undefined';
 }
 
 function isAllowedByChapterRole(
-  { user, events }: Required<GQLCtx>,
+  { user, events }: Required<ResolverCtx>,
   requiredPermission: string,
   variableValues: VariableValues,
 ): boolean {
@@ -49,7 +48,7 @@ function isAllowedByChapterRole(
 }
 
 function isAllowedByInstanceRole(
-  { user }: Required<GQLCtx>,
+  { user }: Required<ResolverCtx>,
   requiredPermission: string,
 ): boolean {
   const userInstancePermissions = getUserPermissionsForInstance(user);
@@ -75,7 +74,7 @@ function getRelatedChapterId(
 }
 
 function isAllowedByEventRole(
-  { user }: Required<GQLCtx>,
+  { user }: Required<ResolverCtx>,
   requiredPermission: string,
   info: VariableValues,
 ): boolean {
@@ -113,7 +112,7 @@ function getUserPermissionsForEvent(
 }
 
 function isBannedFromChapter(
-  { user, events }: Required<GQLCtx>,
+  { user, events }: Required<ResolverCtx>,
   variableValues: VariableValues,
 ): boolean {
   const chapterId = getRelatedChapterId(events, variableValues);

--- a/server/src/authorization/index.ts
+++ b/server/src/authorization/index.ts
@@ -34,7 +34,7 @@ export const authorizationChecker: AuthChecker<GQLCtx | Required<GQLCtx>> = (
 function hasUserAndEvents(
   ctx: GQLCtx | Required<GQLCtx>,
 ): ctx is Required<GQLCtx> {
-  return 'user' in ctx && 'events' in ctx;
+  return typeof ctx.user !== 'undefined' && typeof ctx.events !== 'undefined';
 }
 
 function isAllowedByChapterRole(
@@ -84,6 +84,8 @@ function isAllowedByEventRole(
 }
 
 function getUserPermissionsForInstance(user: User): string[] {
+  console.log('checking instance permissions');
+  console.log('user', user);
   return user.instance_role.instance_role_permissions.map(
     (x) => x.instance_permission.name,
   );

--- a/server/src/common-types/gql.ts
+++ b/server/src/common-types/gql.ts
@@ -1,9 +1,10 @@
 import { Request as ExpressRequest, Response } from 'express';
 
-import type { User } from '../controllers/Auth/middleware';
+import type { User, Events } from '../controllers/Auth/middleware';
 
 export interface GQLCtx {
   user?: User;
+  events?: Events;
   res: Response;
   req: ExpressRequest;
 }

--- a/server/src/common-types/gql.ts
+++ b/server/src/common-types/gql.ts
@@ -4,7 +4,7 @@ import type { User, Events } from '../controllers/Auth/middleware';
 
 export interface GQLCtx {
   user?: User;
-  events?: Events;
+  events: Events;
   res: Response;
   req: ExpressRequest;
 }

--- a/server/src/common-types/gql.ts
+++ b/server/src/common-types/gql.ts
@@ -4,11 +4,12 @@ import type { User, Events } from '../controllers/Auth/middleware';
 
 export interface GQLCtx {
   user?: User;
-  events: Events;
+  events?: Events;
   res: Response;
   req: ExpressRequest;
 }
 
 export interface Request extends ExpressRequest {
   user?: User;
+  events?: Events;
 }

--- a/server/src/common-types/gql.ts
+++ b/server/src/common-types/gql.ts
@@ -2,7 +2,7 @@ import { Request as ExpressRequest, Response } from 'express';
 
 import type { User, Events } from '../controllers/Auth/middleware';
 
-export interface GQLCtx {
+export interface ResolverCtx {
   user?: User;
   events?: Events;
   res: Response;

--- a/server/src/controllers/Auth/middleware.ts
+++ b/server/src/controllers/Auth/middleware.ts
@@ -52,6 +52,9 @@ type Merge<T> = {
 };
 
 export type User = Merge<Prisma.usersGetPayload<typeof userInclude>>;
+export type Events = Merge<
+  Prisma.eventsGetPayload<{ select: { id: true; chapter_id: true } }>[]
+>;
 
 export const userMiddleware = (
   req: Request,

--- a/server/src/controllers/Auth/middleware.ts
+++ b/server/src/controllers/Auth/middleware.ts
@@ -78,11 +78,7 @@ export const events = (req: Request, _res: Response, next: NextFunction) => {
     });
 };
 
-export const userMiddleware = (
-  req: Request,
-  _res: Response,
-  next: NextFunction,
-) => {
+export const user = (req: Request, _res: Response, next: NextFunction) => {
   const { authorization } = req.headers;
   if (!authorization) {
     return next();

--- a/server/src/controllers/Auth/resolver.ts
+++ b/server/src/controllers/Auth/resolver.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client';
 import { verify, sign } from 'jsonwebtoken';
 import { Resolver, Arg, Mutation, Query, Ctx } from 'type-graphql';
 
-import { GQLCtx } from '../../common-types/gql';
+import { ResolverCtx } from '../../common-types/gql';
 import { getConfig, isDev } from '../../config';
 import { User, UserWithInstanceRole } from '../../graphql-types';
 import { prisma } from '../../prisma';
@@ -25,7 +25,7 @@ type TokenResponseType = {
 @Resolver()
 export class AuthResolver {
   @Query(() => UserWithInstanceRole, { nullable: true })
-  async me(@Ctx() ctx: GQLCtx): Promise<UserWithInstanceRole | null> {
+  async me(@Ctx() ctx: ResolverCtx): Promise<UserWithInstanceRole | null> {
     return ctx.user ?? null;
   }
 

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -10,7 +10,7 @@ import {
 } from 'type-graphql';
 import { Permission } from '../../../../common/permissions';
 
-import { GQLCtx } from '../../common-types/gql';
+import { ResolverCtx } from '../../common-types/gql';
 import { Chapter, ChapterWithRelations } from '../../graphql-types';
 import { prisma } from '../../prisma';
 import { CreateChapterInputs, UpdateChapterInputs } from './inputs';
@@ -52,7 +52,7 @@ export class ChapterResolver {
   @Mutation(() => Chapter)
   async createChapter(
     @Arg('data') data: CreateChapterInputs,
-    @Ctx() ctx: Required<GQLCtx>,
+    @Ctx() ctx: Required<ResolverCtx>,
   ): Promise<Chapter> {
     // An instance owner may not want or need to join a chapter they've created
     // so they are not made a member by default.

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -10,7 +10,7 @@ import {
   Resolver,
 } from 'type-graphql';
 
-import { GQLCtx } from '../../common-types/gql';
+import { ResolverCtx } from '../../common-types/gql';
 import { prisma } from '../../prisma';
 import { ChapterUser, UserBan } from '../../graphql-types';
 import { Permission } from '../../../../common/permissions';
@@ -22,7 +22,7 @@ export class ChapterUserResolver {
   @Query(() => ChapterUser)
   async chapterUser(
     @Arg('chapterId', () => Int) chapterId: number,
-    @Ctx() ctx: GQLCtx,
+    @Ctx() ctx: ResolverCtx,
   ): Promise<ChapterUser | null> {
     if (!ctx.user) {
       return null;
@@ -46,7 +46,7 @@ export class ChapterUserResolver {
   @Mutation(() => ChapterUser)
   async joinChapter(
     @Arg('chapterId', () => Int) chapterId: number,
-    @Ctx() ctx: GQLCtx,
+    @Ctx() ctx: ResolverCtx,
   ): Promise<ChapterUser> {
     if (!ctx.user) {
       throw Error('User must be logged in to join chapter');
@@ -74,7 +74,7 @@ export class ChapterUserResolver {
   @Mutation(() => ChapterUser)
   async toggleChapterSubscription(
     @Arg('chapterId', () => Int) chapterId: number,
-    @Ctx() ctx: GQLCtx,
+    @Ctx() ctx: ResolverCtx,
   ): Promise<ChapterUser> {
     if (!ctx.user) {
       throw Error('User must be logged in to change subscription');
@@ -131,7 +131,7 @@ export class ChapterUserResolver {
   @Mutation(() => Boolean)
   async initUserInterestForChapter(
     @Arg('id', () => Int) id: number,
-    @Ctx() ctx: GQLCtx,
+    @Ctx() ctx: ResolverCtx,
   ): Promise<boolean> {
     if (!ctx.user) {
       throw Error('User must be logged in to update role ');
@@ -211,7 +211,7 @@ export class ChapterUserResolver {
   async banUser(
     @Arg('chapterId', () => Int) chapterId: number,
     @Arg('userId', () => Int) userId: number,
-    @Ctx() ctx: GQLCtx,
+    @Ctx() ctx: ResolverCtx,
   ): Promise<UserBan> {
     if (!ctx.user) {
       throw Error('User must be logged to ban');
@@ -233,7 +233,7 @@ export class ChapterUserResolver {
   async unbanUser(
     @Arg('chapterId', () => Int) chapterId: number,
     @Arg('userId', () => Int) userId: number,
-    @Ctx() ctx: GQLCtx,
+    @Ctx() ctx: ResolverCtx,
   ): Promise<UserBan> {
     if (!ctx.user) {
       throw Error('User must be logged in to unban');
@@ -253,7 +253,7 @@ export class ChapterUserResolver {
 
   // TODO: control this with an Authorization decorator
   @FieldResolver()
-  canBeBanned(@Ctx() ctx: GQLCtx): boolean {
+  canBeBanned(@Ctx() ctx: ResolverCtx): boolean {
     if (!ctx.user) {
       return false;
     }

--- a/server/src/controllers/EventUser/resolver.ts
+++ b/server/src/controllers/EventUser/resolver.ts
@@ -5,7 +5,7 @@ import { sub } from 'date-fns';
 import { prisma } from '../../prisma';
 
 import { EventUser } from '../../graphql-types/EventUser';
-import { GQLCtx } from '../../common-types/gql';
+import { ResolverCtx } from '../../common-types/gql';
 import { Permission } from '../../../../common/permissions';
 
 @Resolver()
@@ -14,7 +14,7 @@ export class EventUserResolver {
   @Mutation(() => EventUser)
   async subscribeToEvent(
     @Arg('eventId', () => Int) eventId: number,
-    @Ctx() ctx: Required<GQLCtx>,
+    @Ctx() ctx: Required<ResolverCtx>,
   ): Promise<EventUser> {
     const whereCondition = {
       user_id_event_id: { event_id: eventId, user_id: ctx.user.id },
@@ -53,7 +53,7 @@ export class EventUserResolver {
   @Mutation(() => EventUser)
   async unsubscribeFromEvent(
     @Arg('eventId', () => Int) eventId: number,
-    @Ctx() ctx: Required<GQLCtx>,
+    @Ctx() ctx: Required<ResolverCtx>,
   ): Promise<EventUser> {
     const whereCondition = {
       user_id_event_id: { event_id: eventId, user_id: ctx.user.id },

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -21,7 +21,7 @@ import { isEqual, sub } from 'date-fns';
 import ical from 'ical-generator';
 
 import { Permission } from '../../../../common/permissions';
-import { GQLCtx } from '../../common-types/gql';
+import { ResolverCtx } from '../../common-types/gql';
 import {
   Event,
   EventUser,
@@ -260,7 +260,7 @@ export class EventResolver {
   async rsvpEvent(
     @Arg('eventId', () => Int) eventId: number,
     @Arg('chapterId', () => Int) chapterId: number,
-    @Ctx() ctx: Required<GQLCtx>,
+    @Ctx() ctx: Required<ResolverCtx>,
   ): Promise<EventUser | null> {
     const event = await prisma.events.findUniqueOrThrow({
       where: { id: eventId },
@@ -409,7 +409,7 @@ export class EventResolver {
   async confirmRsvp(
     @Arg('eventId', () => Int) eventId: number,
     @Arg('userId', () => Int) userId: number,
-    @Ctx() ctx: GQLCtx,
+    @Ctx() ctx: ResolverCtx,
   ): Promise<EventUser> {
     if (!ctx.user) throw Error('User must be logged in to confirm RSVPs');
     const eventUser = await prisma.event_users.findUniqueOrThrow({
@@ -472,7 +472,7 @@ ${unsubscribeOptions}`,
   async createEvent(
     @Arg('chapterId', () => Int) chapterId: number,
     @Arg('data') data: CreateEventInputs,
-    @Ctx() ctx: Required<GQLCtx>,
+    @Ctx() ctx: Required<ResolverCtx>,
   ): Promise<Event | null> {
     let venue;
     if (data.venue_id) {

--- a/server/tests/authorization.test.ts
+++ b/server/tests/authorization.test.ts
@@ -20,7 +20,7 @@ const mockRes = {} as Response;
 const mockInfo = { variableValues: {} } as GraphQLResolveInfo;
 
 const baseResolverData = {
-  context: { req: mockReq, res: mockRes },
+  context: { req: mockReq, res: mockRes, user: undefined, events: undefined },
   info: mockInfo,
   root: {},
   args: {},
@@ -32,7 +32,7 @@ const resolverDataWithEvents = merge(baseResolverData, {
 
 describe('authorizationChecker', () => {
   describe('when user is NOT banned', () => {
-    it('should return false if there is no user', () => {
+    it('should return false if user is undefined', () => {
       const result = authorizationChecker(resolverDataWithEvents, [
         'some-permission',
       ]);
@@ -40,7 +40,7 @@ describe('authorizationChecker', () => {
       expect(result).toBe(false);
     });
 
-    it('should return false if there is a user, but no events property', () => {
+    it('should return false if user is defined, but events is not', () => {
       const resolverData = merge(baseResolverData, {
         context: { user: userWithInstanceRole },
       });

--- a/server/tests/authorization.test.ts
+++ b/server/tests/authorization.test.ts
@@ -6,10 +6,10 @@ import { authorizationChecker } from '../src/authorization';
 
 import {
   userWithRoleForChapterOne,
-  chapterTwoUserEvent,
+  chapterTwoEventUser,
   userWithRoleForEventOne,
   userWithInstanceRole,
-  chapterOneUserEvent,
+  chapterOneEventUser,
   userBansChapterOne,
   userBansChapterTwo,
 } from './fixtures/users';
@@ -108,7 +108,7 @@ describe('authorizationChecker', () => {
 
     it('should return false if the event is in a chapter for which the user has no role', () => {
       const user = merge(userWithRoleForChapterOne, {
-        user_events: chapterTwoUserEvent,
+        user_events: chapterTwoEventUser,
       });
       const resolverData = merge(baseResolverData, {
         context: { user },
@@ -122,7 +122,7 @@ describe('authorizationChecker', () => {
 
     it('should return true if a user has a chapter role, even if they do not have an event role', () => {
       const user = merge(userWithRoleForChapterOne, {
-        user_events: chapterOneUserEvent,
+        user_events: chapterOneEventUser,
       });
       const resolverData = merge(baseResolverData, {
         context: { user },

--- a/server/tests/fixtures/events.ts
+++ b/server/tests/fixtures/events.ts
@@ -18,3 +18,23 @@ export const mockEvent = {
   venue_id: 1,
   chapter_id: 1,
 };
+
+// All the authChecker needs to know is which chapter a given event belongs to:
+export const events = [
+  {
+    id: 1,
+    chapter_id: 1,
+  },
+  {
+    id: 2,
+    chapter_id: 1,
+  },
+  {
+    id: 3,
+    chapter_id: 2,
+  },
+  {
+    id: 4,
+    chapter_id: 3,
+  },
+];

--- a/server/tests/fixtures/users.ts
+++ b/server/tests/fixtures/users.ts
@@ -85,26 +85,7 @@ export const chapterTwoEventUser: EventUser[] = [
         },
       ],
     },
-    event_id: 2,
-  },
-];
-
-export const chapterOneEventUser: EventUser[] = [
-  {
-    event: {
-      chapter_id: 1,
-    },
-    event_role: {
-      name: 'some-role',
-      event_role_permissions: [
-        {
-          event_permission: {
-            name: 'some-permission-for-events',
-          },
-        },
-      ],
-    },
-    event_id: 2,
+    event_id: 3,
   },
 ];
 

--- a/server/tests/fixtures/users.ts
+++ b/server/tests/fixtures/users.ts
@@ -70,7 +70,7 @@ type EventUser = Pick<event_users, 'event_id'> & {
   };
 };
 
-export const chapterTwoUserEvent: EventUser[] = [
+export const chapterTwoEventUser: EventUser[] = [
   {
     event: {
       chapter_id: 2,
@@ -89,7 +89,7 @@ export const chapterTwoUserEvent: EventUser[] = [
   },
 ];
 
-export const chapterOneUserEvent: EventUser[] = [
+export const chapterOneEventUser: EventUser[] = [
   {
     event: {
       chapter_id: 1,


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

The authChecker would incorrectly reject requests from chapter administrators when the requests only have `eventId` as the variable. This changes the logic from looking for the `chapter_id` in the user's _user_events_ record (which may not exist) to looking in the _events_ table (which will).


Credit to @shootermv for letting me know about this issue.
<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
