### PR TITLE
feat: add Authorized decorator to updateEvent resolver

### DIFF
--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -1,3 +1,21 @@
+import { expectToBeRejected } from '../../../support/util';
+
+const eventData = {
+  name: 'Homer Simpson3',
+  description: 'i will show you damn!',
+  url: 'http://wooden-swing.com',
+  streaming_url: null,
+  capacity: 149,
+  start_at: '2022-08-03T18:45:00.000Z',
+  ends_at: '2022-08-03T18:45:00.000Z',
+  venue_type: 'Physical',
+  venue_id: 2,
+  image_url: 'http://loremflickr.com/640/480/nature?79359',
+  invite_only: false,
+  tags: ['aut'],
+  sponsor_ids: [],
+  chapter_id: 1,
+};
 describe('events dashboard', () => {
   beforeEach(() => {
     cy.exec('npm run db:seed');
@@ -275,5 +293,27 @@ describe('events dashboard', () => {
     });
 
     cy.mhDeleteAll();
+  });
+
+  it('chapter admin should be allowed to edit event, but nobody else', () => {
+    const eventId = 1;
+    // admin of chapter 1
+    cy.login(Cypress.env('JWT_ADMIN_USER'));
+    cy.reload();
+    cy.updateEvent(eventId, eventData).then((response) => {
+      expect(response.body.errors).not.to.exist;
+    });
+    cy.logout();
+    // newly registered user (without a chapter_users record)
+    cy.register();
+
+    cy.login(Cypress.env('JWT_TEST_USER'));
+    cy.reload();
+    cy.updateEvent(eventId, eventData).then(expectToBeRejected);
+    cy.logout();
+    // banned admin should be rejected
+    cy.login(Cypress.env('JWT_BANNED_ADMIN_USER'));
+    cy.reload();
+    cy.updateEvent(eventId, eventData).then(expectToBeRejected);
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -260,6 +260,26 @@ Cypress.Commands.add('updateChapter', (chapterId, data) => {
   };
   return cy.authedRequest(gqlOptions(chapterMutation));
 });
+/**
+ * Update event using GQL mutation
+ * @param eventId Id of the event
+ * @param data Data of the event. Equivalent of CreateEventInputs for the Events resolver.
+ */
+Cypress.Commands.add('updateEvent', (eventId, data) => {
+  const eventMutation = {
+    operationName: 'updateEvent',
+    variables: {
+      eventId,
+      data,
+    },
+    query: `mutation updateEvent($eventId: Int!, $data: UpdateEventInputs!) {
+      updateEvent(id: $eventId, data: $data) {
+        id
+      }
+    }`,
+  };
+  return cy.authedRequest(gqlOptions(eventMutation));
+});
 
 /**
  * Delete event using GQL mutation

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -48,6 +48,13 @@ declare global {
       deleteRsvp(eventId: number, userId: number): Chainable<any>;
 
       /**
+       * Delete rsvp of user with userId for the event with eventId
+       * @param eventId Id of the event
+       * @param data data object of the event
+       */
+      updateEvent(eventId: number, data): Chainable<any>;
+
+      /**
        * Rsvp to event with eventId and chapterId
        * @param eventId Id of the event
        * @param chapterId Id of the chapter

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -542,6 +542,7 @@ ${unsubscribeOptions}`,
     });
   }
 
+  @Authorized(Permission.EventEdit)
   @Mutation(() => Event)
   async updateEvent(
     @Arg('id', () => Int) id: number,


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes one part of  #1217
Idea behind this PR - to make several endpoints protected at server side
Basically - the main change is here:
![image](https://user-images.githubusercontent.com/1336862/182013919-9e741a9b-5d84-4100-902b-c1745afee484.png)

