### PR TITLE
refactor: split rsvpEvent resolver

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -2735,6 +2735,35 @@
             "deprecationReason": null
           },
           {
+            "name": "cancelRsvp",
+            "description": null,
+            "args": [
+              {
+                "name": "eventId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EventUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "changeChapterUserRole",
             "description": null,
             "args": [
@@ -3219,39 +3248,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Venue",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "initUserInterestForChapter",
-            "description": null,
-            "args": [
-              {
-                "name": "id",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
                 "ofType": null
               }
             },

--- a/client/src/components/LoginRegisterModal.tsx
+++ b/client/src/components/LoginRegisterModal.tsx
@@ -32,9 +32,9 @@ interface RegisterData extends LoginData {
 
 export const LoginRegisterModal: React.FC<{
   modalProps: UseDisclosureReturn;
-  onRsvp: (add: boolean) => void;
+  action: (condition: boolean) => void;
   userIds: number[];
-}> = ({ modalProps, onRsvp, userIds }) => {
+}> = ({ modalProps, action, userIds }) => {
   const client = useApolloClient();
   const [login] = useLoginMutation();
   const [registerMutation] = useRegisterMutation();
@@ -80,7 +80,7 @@ export const LoginRegisterModal: React.FC<{
             if (me) {
               clearInterval(interval);
               modalProps.onClose();
-              onRsvp(!userIds.includes(me.id));
+              action(!userIds.includes(me.id));
             }
           })
           .catch((err) => {

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -266,6 +266,7 @@ export type Mutation = {
   authenticate: AuthenticateType;
   banUser: UserBan;
   cancelEvent: Event;
+  cancelRsvp?: Maybe<EventUser>;
   changeChapterUserRole: ChapterUser;
   changeInstanceUserRole: UserWithInstanceRole;
   confirmRsvp: EventUser;
@@ -277,7 +278,6 @@ export type Mutation = {
   deleteEvent: Event;
   deleteRsvp: Scalars['Boolean'];
   deleteVenue: Venue;
-  initUserInterestForChapter: Scalars['Boolean'];
   joinChapter: ChapterUser;
   login: LoginType;
   register: User;
@@ -306,6 +306,10 @@ export type MutationBanUserArgs = {
 
 export type MutationCancelEventArgs = {
   id: Scalars['Int'];
+};
+
+export type MutationCancelRsvpArgs = {
+  eventId: Scalars['Int'];
 };
 
 export type MutationChangeChapterUserRoleArgs = {
@@ -358,10 +362,6 @@ export type MutationDeleteRsvpArgs = {
 export type MutationDeleteVenueArgs = {
   chapterId: Scalars['Int'];
   venueId: Scalars['Int'];
-};
-
-export type MutationInitUserInterestForChapterArgs = {
-  id: Scalars['Int'];
 };
 
 export type MutationJoinChapterArgs = {
@@ -989,15 +989,6 @@ export type SendEventInviteMutation = {
   sendEventInvite: boolean;
 };
 
-export type InitUserInterestForChapterMutationVariables = Exact<{
-  eventId: Scalars['Int'];
-}>;
-
-export type InitUserInterestForChapterMutation = {
-  __typename?: 'Mutation';
-  initUserInterestForChapter: boolean;
-};
-
 export type EventsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type EventsQuery = {
@@ -1316,6 +1307,15 @@ export type RsvpToEventMutationVariables = Exact<{
 export type RsvpToEventMutation = {
   __typename?: 'Mutation';
   rsvpEvent?: { __typename?: 'EventUser'; updated_at: any } | null;
+};
+
+export type CancelRsvpMutationVariables = Exact<{
+  eventId: Scalars['Int'];
+}>;
+
+export type CancelRsvpMutation = {
+  __typename?: 'Mutation';
+  cancelRsvp?: { __typename?: 'EventUser'; updated_at: any } | null;
 };
 
 export type SubscribeToEventMutationVariables = Exact<{
@@ -2738,55 +2738,6 @@ export type SendEventInviteMutationOptions = Apollo.BaseMutationOptions<
   SendEventInviteMutation,
   SendEventInviteMutationVariables
 >;
-export const InitUserInterestForChapterDocument = gql`
-  mutation initUserInterestForChapter($eventId: Int!) {
-    initUserInterestForChapter(id: $eventId)
-  }
-`;
-export type InitUserInterestForChapterMutationFn = Apollo.MutationFunction<
-  InitUserInterestForChapterMutation,
-  InitUserInterestForChapterMutationVariables
->;
-
-/**
- * __useInitUserInterestForChapterMutation__
- *
- * To run a mutation, you first call `useInitUserInterestForChapterMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useInitUserInterestForChapterMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [initUserInterestForChapterMutation, { data, loading, error }] = useInitUserInterestForChapterMutation({
- *   variables: {
- *      eventId: // value for 'eventId'
- *   },
- * });
- */
-export function useInitUserInterestForChapterMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    InitUserInterestForChapterMutation,
-    InitUserInterestForChapterMutationVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    InitUserInterestForChapterMutation,
-    InitUserInterestForChapterMutationVariables
-  >(InitUserInterestForChapterDocument, options);
-}
-export type InitUserInterestForChapterMutationHookResult = ReturnType<
-  typeof useInitUserInterestForChapterMutation
->;
-export type InitUserInterestForChapterMutationResult =
-  Apollo.MutationResult<InitUserInterestForChapterMutation>;
-export type InitUserInterestForChapterMutationOptions =
-  Apollo.BaseMutationOptions<
-    InitUserInterestForChapterMutation,
-    InitUserInterestForChapterMutationVariables
-  >;
 export const EventsDocument = gql`
   query events {
     events(showAll: true) {
@@ -3824,6 +3775,56 @@ export type RsvpToEventMutationResult =
 export type RsvpToEventMutationOptions = Apollo.BaseMutationOptions<
   RsvpToEventMutation,
   RsvpToEventMutationVariables
+>;
+export const CancelRsvpDocument = gql`
+  mutation cancelRsvp($eventId: Int!) {
+    cancelRsvp(eventId: $eventId) {
+      updated_at
+    }
+  }
+`;
+export type CancelRsvpMutationFn = Apollo.MutationFunction<
+  CancelRsvpMutation,
+  CancelRsvpMutationVariables
+>;
+
+/**
+ * __useCancelRsvpMutation__
+ *
+ * To run a mutation, you first call `useCancelRsvpMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCancelRsvpMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [cancelRsvpMutation, { data, loading, error }] = useCancelRsvpMutation({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *   },
+ * });
+ */
+export function useCancelRsvpMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    CancelRsvpMutation,
+    CancelRsvpMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<CancelRsvpMutation, CancelRsvpMutationVariables>(
+    CancelRsvpDocument,
+    options,
+  );
+}
+export type CancelRsvpMutationHookResult = ReturnType<
+  typeof useCancelRsvpMutation
+>;
+export type CancelRsvpMutationResult =
+  Apollo.MutationResult<CancelRsvpMutation>;
+export type CancelRsvpMutationOptions = Apollo.BaseMutationOptions<
+  CancelRsvpMutation,
+  CancelRsvpMutationVariables
 >;
 export const SubscribeToEventDocument = gql`
   mutation subscribeToEvent($eventId: Int!) {

--- a/client/src/modules/dashboard/Events/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Events/graphql/mutations.ts
@@ -79,9 +79,3 @@ export const sendEventInvite = gql`
     sendEventInvite(id: $eventId, emailGroups: $emailGroups)
   }
 `;
-
-export const initUserInterestForChapter = gql`
-  mutation initUserInterestForChapter($eventId: Int!) {
-    initUserInterestForChapter(id: $eventId)
-  }
-`;

--- a/client/src/modules/events/graphql/mutations.ts
+++ b/client/src/modules/events/graphql/mutations.ts
@@ -10,6 +10,14 @@ export const rsvpToEvent = gql`
   }
 `;
 
+export const cancelRsvp = gql`
+  mutation cancelRsvp($eventId: Int!) {
+    cancelRsvp(eventId: $eventId) {
+      updated_at
+    }
+  }
+`;
+
 export const subscribeToEvent = gql`
   mutation subscribeToEvent($eventId: Int!) {
     subscribeToEvent(eventId: $eventId) {

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -67,7 +67,7 @@ export const EventPage: NextPage = () => {
   const allDataLoaded = !loading && user;
   const canCheckRsvp = router.query?.emaillink && !userRsvped;
   useEffect(() => {
-    if (allDataLoaded && canCheckRsvp) onRsvp();
+    if (allDataLoaded && canCheckRsvp) checkOnRsvp();
   }, [allDataLoaded, canCheckRsvp]);
 
   if (loading) {
@@ -125,9 +125,6 @@ export const EventPage: NextPage = () => {
   };
 
   const onRsvp = async () => {
-    if (!user) {
-      return handleLoginUserFirst();
-    }
     const ok = await confirm({ title: 'You want to join this?' });
 
     if (ok) {
@@ -167,6 +164,11 @@ export const EventPage: NextPage = () => {
     }
   };
 
+  const checkOnRsvp = async () => {
+    if (!user) return handleLoginUserFirst();
+    await onRsvp();
+  };
+
   const rsvps = data.event.event_users.filter(
     ({ rsvp }) => rsvp.name === 'yes',
   );
@@ -177,7 +179,7 @@ export const EventPage: NextPage = () => {
   return (
     <VStack align="flex-start">
       <LoginRegisterModal
-        onRsvp={onRsvp}
+        action={(notRsvped) => (notRsvped ? onRsvp() : onCancelRsvp())}
         userIds={data?.event?.event_users.map(({ user }) => user.id) || []}
         modalProps={modalProps}
       />
@@ -223,7 +225,7 @@ export const EventPage: NextPage = () => {
           </Button>
         </HStack>
       ) : (
-        <Button data-cy="rsvp-button" colorScheme="blue" onClick={onRsvp}>
+        <Button data-cy="rsvp-button" colorScheme="blue" onClick={checkOnRsvp}>
           {data.event.invite_only ? 'Request' : 'RSVP'}
         </Button>
       )}

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -25,6 +25,7 @@ import { EVENT } from '../../dashboard/Events/graphql/queries';
 import {
   useCancelRsvpMutation,
   useEventQuery,
+  useJoinChapterMutation,
   useRsvpToEventMutation,
   useSubscribeToEventMutation,
   useUnsubscribeFromEventMutation,
@@ -42,6 +43,7 @@ export const EventPage: NextPage = () => {
 
   const [rsvpToEvent] = useRsvpToEventMutation(refetch);
   const [cancelRsvp] = useCancelRsvpMutation(refetch);
+  const [joinChapter] = useJoinChapterMutation(refetch);
   const [subscribeToEvent] = useSubscribeToEventMutation(refetch);
   const [unsubscribeFromEvent] = useUnsubscribeFromEventMutation(refetch);
   // TODO: check if we need to default to -1 here
@@ -130,6 +132,7 @@ export const EventPage: NextPage = () => {
 
     if (ok) {
       try {
+        await joinChapter({ variables: { chapterId } });
         await rsvpToEvent({
           variables: { eventId, chapterId },
         });

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -23,11 +23,11 @@ import { useAuth } from '../../auth/store';
 import SponsorsCard from '../../../components/SponsorsCard';
 import { EVENT } from '../../dashboard/Events/graphql/queries';
 import {
+  useCancelRsvpMutation,
   useEventQuery,
   useRsvpToEventMutation,
   useSubscribeToEventMutation,
   useUnsubscribeFromEventMutation,
-  useInitUserInterestForChapterMutation,
 } from '../../../generated/graphql';
 import { useParam } from 'hooks/useParam';
 
@@ -41,7 +41,7 @@ export const EventPage: NextPage = () => {
   };
 
   const [rsvpToEvent] = useRsvpToEventMutation(refetch);
-  const [initUserInterestForChapter] = useInitUserInterestForChapterMutation();
+  const [cancelRsvp] = useCancelRsvpMutation(refetch);
   const [subscribeToEvent] = useSubscribeToEventMutation(refetch);
   const [unsubscribeFromEvent] = useUnsubscribeFromEventMutation(refetch);
   // TODO: check if we need to default to -1 here
@@ -65,7 +65,7 @@ export const EventPage: NextPage = () => {
   const allDataLoaded = !loading && user;
   const canCheckRsvp = router.query?.emaillink && !userRsvped;
   useEffect(() => {
-    if (allDataLoaded && canCheckRsvp) checkOnRsvp(true);
+    if (allDataLoaded && canCheckRsvp) onRsvp();
   }, [allDataLoaded, canCheckRsvp]);
 
   if (loading) {
@@ -122,34 +122,22 @@ export const EventPage: NextPage = () => {
     }
   };
 
-  const onRsvp = async (add: boolean) => {
-    const ok = await confirm(
-      add
-        ? { title: 'You want to join this?' }
-        : { title: 'Are you sure you want to cancel your RSVP' },
-    );
+  const onRsvp = async () => {
+    if (!user) {
+      return handleLoginUserFirst();
+    }
+    const ok = await confirm({ title: 'You want to join this?' });
 
     if (ok) {
       try {
-        // this has to happen before trying to RSVP, since the user needs to be
-        // added to the chapter first.
-        if (add) {
-          await initUserInterestForChapter({
-            variables: { eventId },
-          });
-        }
         await rsvpToEvent({
           variables: { eventId, chapterId },
         });
 
-        toast(
-          add
-            ? {
-                title: 'You successfully RSVPed to this event',
-                status: 'success',
-              }
-            : { title: 'You canceled your RSVP 👋', status: 'error' },
-        );
+        toast({
+          title: 'You successfully RSVPed to this event',
+          status: 'success',
+        });
       } catch (err) {
         toast({ title: 'Something went wrong', status: 'error' });
         console.error(err);
@@ -157,12 +145,23 @@ export const EventPage: NextPage = () => {
     }
   };
 
-  const checkOnRsvp = async (add: boolean) => {
-    if (!user) {
-      return handleLoginUserFirst();
-    }
+  const onCancelRsvp = async () => {
+    const ok = await confirm({
+      title: 'Are you sure you want to cancel your RSVP',
+    });
 
-    await onRsvp(add);
+    if (ok) {
+      try {
+        await cancelRsvp({
+          variables: { eventId },
+        });
+
+        toast({ title: 'You canceled your RSVP 👋', status: 'info' });
+      } catch (err) {
+        toast({ title: 'Something went wrong', status: 'error' });
+        console.error(err);
+      }
+    }
   };
 
   const rsvps = data.event.event_users.filter(
@@ -205,7 +204,7 @@ export const EventPage: NextPage = () => {
       {userRsvped === 'yes' ? (
         <HStack>
           <Heading>You&lsquo;ve RSVPed to this event</Heading>
-          <Button colorScheme="red" onClick={() => checkOnRsvp(false)}>
+          <Button colorScheme="red" onClick={onCancelRsvp}>
             Cancel
           </Button>
         </HStack>
@@ -216,16 +215,12 @@ export const EventPage: NextPage = () => {
           ) : (
             <Heading>You&lsquo;re on waitlist for this event</Heading>
           )}
-          <Button colorScheme="red" onClick={() => checkOnRsvp(false)}>
+          <Button colorScheme="red" onClick={onCancelRsvp}>
             Cancel
           </Button>
         </HStack>
       ) : (
-        <Button
-          data-cy="rsvp-button"
-          colorScheme="blue"
-          onClick={() => checkOnRsvp(true)}
-        >
+        <Button data-cy="rsvp-button" colorScheme="blue" onClick={onRsvp}>
           {data.event.invite_only ? 'Request' : 'RSVP'}
         </Button>
       )}

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -294,28 +294,6 @@ export class EventResolver {
       (user_chapter) => user_chapter.chapter_id === chapterId,
     );
 
-    if (!userChapter) {
-      await prisma.chapter_users.create({
-        data: {
-          user: { connect: { id: ctx.user.id } },
-          chapter: { connect: { id: chapterId } },
-          chapter_role: { connect: { name: 'member' } },
-          subscribed: true, // TODO add user setting option override
-          joined_date: new Date(),
-        },
-        include: {
-          user: true,
-          chapter_role: {
-            include: {
-              chapter_role_permissions: {
-                include: { chapter_permission: true },
-              },
-            },
-          },
-        },
-      });
-    }
-
     const oldEventUser = await prisma.event_users.findUnique({
       include: { rsvp: true },
       where: {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Splits rsvping into rsvpEvent and cancelRsvp mutations.
- Removes `initUserInterestForChapter` mutation, in favor of using slightly modified `joinChapter` mutation.