### PR TITLE
feat: added toast to display event edit status

### DIFF
--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
+import { useToast } from '@chakra-ui/react';
 
 import {
   useEventQuery,
@@ -26,6 +27,8 @@ export const EditEventPage: NextPage = () => {
   } = useEventQuery({
     variables: { eventId: eventId },
   });
+
+  const toast = useToast();
 
   // TODO: update the cache directly:
   // https://www.apollographql.com/docs/react/data/mutations/#updating-the-cache-directly
@@ -67,9 +70,17 @@ export const EditEventPage: NextPage = () => {
       });
 
       if (event.data) {
+        toast({
+          title: `Event "${event.data.updateEvent.name}" updated successfuly!`,
+          status: 'success',
+        });
         await router.push('/dashboard/events');
       }
     } catch (err) {
+      toast({
+        title: 'Something went wrong.',
+        status: 'error',
+      });
       console.error(err);
     } finally {
       setLoadingUpdate(false);

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -70,11 +70,11 @@ export const EditEventPage: NextPage = () => {
       });
 
       if (event.data) {
+        await router.push('/dashboard/events');
         toast({
           title: `Event "${event.data.updateEvent.name}" updated successfuly!`,
           status: 'success',
         });
-        await router.push('/dashboard/events');
       }
     } catch (err) {
       toast({


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #1274

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
**What I did:**
Added a toast message on successful and failed edit of an Event
