### PR TITLE
feat: added validation for form data edited or not

### DIFF
--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -38,6 +38,7 @@ import {
   getAllowedSponsors,
   getAllowedSponsorTypes,
   getAllowedSponsorsForType,
+  isFormEdited,
 } from './EventFormUtils';
 
 import 'react-datepicker/dist/react-datepicker.css';
@@ -125,6 +126,8 @@ const EventForm: React.FC<EventFormProps> = (props) => {
     },
     [setValue, setStartDate],
   );
+
+  const isSaveBtnDisabled = !isFormEdited(defaultValues, watch()) || loading;
   return (
     <>
       {loadingChapter ? (
@@ -366,7 +369,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
               width="full"
               colorScheme="blue"
               type="submit"
-              isDisabled={loading}
+              isDisabled={isSaveBtnDisabled}
             >
               {submitText}
             </Button>

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -210,3 +210,20 @@ const isSponsorSelectedElsewhere = (
     (sponsorFieldId === undefined || selectedFieldId !== sponsorFieldId)
   );
 };
+
+const replaceStringNumbersToNumbers = (_key: unknown, value: unknown) => {
+  if (typeof value === 'string' && value.match(/^\d+$/)) {
+    return Number(value);
+  }
+  return value;
+};
+
+export const isFormEdited = (
+  defaultValues: Record<string, unknown>,
+  currentValues: EventFormData,
+) => {
+  return (
+    JSON.stringify(defaultValues) !==
+    JSON.stringify(currentValues, replaceStringNumbersToNumbers)
+  );
+};


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #1272

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
**What I did**
- Added form utility function that compares default(initial) form values and current(updated) values of form and returns true if the from is edited.