### PR TITLE
fix: use correct loading to display loading message

### DIFF
--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -90,7 +90,7 @@ export const EditEventPage: NextPage = () => {
   if (eventLoading || error || !data?.event) {
     return (
       <Layout>
-        <h1>{loadingUpdate ? 'Loading...' : 'Error...'}</h1>
+        <h1>{eventLoading ? 'Loading...' : 'Error...'}</h1>
         {error && <div>{error.message}</div>}
       </Layout>
     );


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Due to usage of wrong loading variable, when loading event page was displaying `Error...`.