### PR TITLE
chore: remove nullable from rsvpEvent

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -3391,9 +3391,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "EventUser",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EventUser",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -281,7 +281,7 @@ export type Mutation = {
   joinChapter: ChapterUser;
   login: LoginType;
   register: User;
-  rsvpEvent?: Maybe<EventUser>;
+  rsvpEvent: EventUser;
   sendEmail: Email;
   sendEventInvite: Scalars['Boolean'];
   subscribeToEvent: EventUser;
@@ -1306,7 +1306,7 @@ export type RsvpToEventMutationVariables = Exact<{
 
 export type RsvpToEventMutation = {
   __typename?: 'Mutation';
-  rsvpEvent?: { __typename?: 'EventUser'; updated_at: any } | null;
+  rsvpEvent: { __typename?: 'EventUser'; updated_at: any };
 };
 
 export type CancelRsvpMutationVariables = Exact<{

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -265,12 +265,12 @@ export class EventResolver {
   }
 
   @Authorized(Permission.Rsvp)
-  @Mutation(() => EventUser, { nullable: true })
+  @Mutation(() => EventUser)
   async rsvpEvent(
     @Arg('eventId', () => Int) eventId: number,
     @Arg('chapterId', () => Int) chapterId: number,
     @Ctx() ctx: Required<ResolverCtx>,
-  ): Promise<EventUser | null> {
+  ): Promise<EventUser> {
     const event = await prisma.events.findUniqueOrThrow({
       where: { id: eventId },
       include: {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- I forgot to do this when splitting it.
- `rsvpEvent` now always returns `EventUser`, so `nullable` is no longer needed.