### PR TITLE
fix: add label to invite only icon

### DIFF
--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -31,7 +31,7 @@ export const EventCard: React.FC<EventCardProps> = ({ event }) => {
       )}
       {event.invite_only && (
         <Tag borderRadius="full" pl="2" px="2" colorScheme="gray">
-          <LockIcon />
+          <LockIcon /> Invite Only
         </Tag>
       )}
     </>

--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -31,7 +31,8 @@ export const EventCard: React.FC<EventCardProps> = ({ event }) => {
       )}
       {event.invite_only && (
         <Tag borderRadius="full" pl="2" px="2" colorScheme="gray">
-          <LockIcon /> Invite Only
+          <LockIcon />
+          Invite Only
         </Tag>
       )}
     </>

--- a/client/tests/__snapshots__/EventCard.test.tsx.snap
+++ b/client/tests/__snapshots__/EventCard.test.tsx.snap
@@ -98,6 +98,7 @@ exports[`EventCard should render with tags 1`] = `
               fill="currentColor"
             />
           </svg>
+          Invite Only
         </span>
       </h4>
       <div

--- a/client/tests/__snapshots__/EventCard.test.tsx.snap
+++ b/client/tests/__snapshots__/EventCard.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`EventCard should render 1`] = `
               fill="currentColor"
             />
           </svg>
+          Invite Only
         </span>
       </h4>
       <div


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.



Closes #1243
Have added the text "Invite Only" next to the lock icon.
<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

![image](https://user-images.githubusercontent.com/97171261/183478183-c4977ec6-b8ea-406e-9e58-a44493a01dbf.png)

