### PR TITLE
feat: display add new venue button only for users with chapter admin permission

### DIFF
--- a/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuesPage.tsx
@@ -7,18 +7,24 @@ import React from 'react';
 import { useVenuesQuery } from '../../../../generated/graphql';
 import { Layout } from '../../shared/components/Layout';
 import getLocationString from '../../../../util/getLocationString';
+import { useAuth } from '../../../auth/store';
 
 export const VenuesPage: NextPage = () => {
   const { loading, error, data } = useVenuesQuery();
+
+  const { user } = useAuth();
+  const adminedChapters = user?.admined_chapters ?? [];
 
   return (
     <Layout>
       <VStack>
         <Flex w="full" justify="space-between">
           <Heading id="page-heading">Venues</Heading>
-          <LinkButton data-cy="new-venue" href="/dashboard/venues/new">
-            Add new
-          </LinkButton>
+          {adminedChapters.length > 0 && (
+            <LinkButton data-cy="new-venue" href="/dashboard/venues/new">
+              Add new
+            </LinkButton>
+          )}
         </Flex>
         {loading ? (
           <Heading>Loading...</Heading>


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Displays the general `Add new` button in venues dashboard only for users who have chapter admin permissions.