### PR TITLE
fix: restrict 'user ban' functionality to member with ChapterBanUser rule

### DIFF
--- a/common/permissions.ts
+++ b/common/permissions.ts
@@ -1,5 +1,6 @@
 export enum ChapterPermission {
   ChapterEdit = 'chapter-edit',
+  ChapterBanUser = 'ban-user',
   EventCreate = 'event-create',
   EventEdit = 'event-edit',
   EventDelete = 'event-delete',
@@ -20,7 +21,6 @@ export enum InstancePermission {
   ChapterUserRoleChange = 'chapter-user-role-change',
   SponsorsManage = 'sponsors-manage',
   UserInstanceRoleChange = 'user-instance-role-change',
-  ChapterBanUser = 'ban-user',
   UsersView = 'users-view',
 }
 

--- a/common/permissions.ts
+++ b/common/permissions.ts
@@ -20,6 +20,7 @@ export enum InstancePermission {
   ChapterUserRoleChange = 'chapter-user-role-change',
   SponsorsManage = 'sponsors-manage',
   UserInstanceRoleChange = 'user-instance-role-change',
+  ChapterBanUser = 'ban-user',
   UsersView = 'users-view',
 }
 

--- a/cypress/e2e/dashboard/chapters/users.cy.ts
+++ b/cypress/e2e/dashboard/chapters/users.cy.ts
@@ -141,7 +141,6 @@ describe('Chapter Users dashboard', () => {
   }
 
   it('someone whos NOT an admin of a chapter, should NOT be able to ban a chapter users', () => {
-    cy.logout();
     cy.login('admin@of.chapter.one');
     cy.visit(`/dashboard/chapters/2/users`);
 

--- a/cypress/e2e/dashboard/chapters/users.cy.ts
+++ b/cypress/e2e/dashboard/chapters/users.cy.ts
@@ -155,6 +155,7 @@ describe('Chapter Users dashboard', () => {
       .findByRole('button', { name: 'Ban' })
       .click();
     cy.findByRole('button', { name: 'Confirm' }).click();
+    cy.findByRole('status').contains('access denied', { matchCase: false });
   });
 
   it('an admin cannot ban themselves', () => {

--- a/cypress/e2e/dashboard/chapters/users.cy.ts
+++ b/cypress/e2e/dashboard/chapters/users.cy.ts
@@ -140,6 +140,23 @@ describe('Chapter Users dashboard', () => {
       .as('firstUnbannedMember');
   }
 
+  it('someone whos NOT an admin of a chapter, should NOT be able to ban a chapter users', () => {
+    cy.logout();
+    cy.login('admin@of.chapter.one');
+    cy.visit(`/dashboard/chapters/2/users`);
+
+    initializeBanVariables();
+
+    cy.get('@firstUnbannedMember')
+      .find('[data-cy=isBanned]')
+      .should('not.exist');
+
+    cy.get('@firstUnbannedMember')
+      .findByRole('button', { name: 'Ban' })
+      .click();
+    cy.findByRole('button', { name: 'Confirm' }).click();
+  });
+
   it('an admin cannot ban themselves', () => {
     cy.login('admin@of.chapter.one');
     cy.visit(`/dashboard/chapters/${chapterId}/users`);

--- a/server/prisma/generator/factories/instanceRoles.factory.ts
+++ b/server/prisma/generator/factories/instanceRoles.factory.ts
@@ -1,10 +1,6 @@
 import { prisma } from '../../../src/prisma';
 
-import {
-  ChapterPermission,
-  InstancePermission,
-  Permission,
-} from '../../../../common/permissions';
+import { InstancePermission, Permission } from '../../../../common/permissions';
 
 const allPermissions = Object.values(Permission);
 
@@ -24,7 +20,6 @@ const roles: InstanceRole[] = [
     permissions: [
       InstancePermission.ChapterJoin,
       InstancePermission.ChapterSubscriptionsManage,
-      ChapterPermission.ChapterBanUser,
     ],
   },
 ];

--- a/server/prisma/generator/factories/instanceRoles.factory.ts
+++ b/server/prisma/generator/factories/instanceRoles.factory.ts
@@ -1,6 +1,10 @@
 import { prisma } from '../../../src/prisma';
 
-import { InstancePermission, Permission } from '../../../../common/permissions';
+import {
+  ChapterPermission,
+  InstancePermission,
+  Permission,
+} from '../../../../common/permissions';
 
 const allPermissions = Object.values(Permission);
 
@@ -20,7 +24,7 @@ const roles: InstanceRole[] = [
     permissions: [
       InstancePermission.ChapterJoin,
       InstancePermission.ChapterSubscriptionsManage,
-      InstancePermission.ChapterBanUser,
+      ChapterPermission.ChapterBanUser,
     ],
   },
 ];

--- a/server/prisma/generator/factories/instanceRoles.factory.ts
+++ b/server/prisma/generator/factories/instanceRoles.factory.ts
@@ -20,6 +20,7 @@ const roles: InstanceRole[] = [
     permissions: [
       InstancePermission.ChapterJoin,
       InstancePermission.ChapterSubscriptionsManage,
+      InstancePermission.ChapterBanUser,
     ],
   },
 ];

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -182,6 +182,7 @@ export class ChapterUserResolver {
     });
   }
 
+  @Authorized(Permission.ChapterBanUser)
   @Mutation(() => UserBan)
   async banUser(
     @Arg('chapterId', () => Int) chapterId: number,


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->
Im adding here cypress test that should check - that admin of chapter1 cannot ban members of chapter2,
if he tries to do that - he should see 'access denied' notification
Closes part of #1217

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
