### PR TITLE
feat: chapters dropdown event create

### DIFF
--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -44,14 +44,21 @@ import {
 import 'react-datepicker/dist/react-datepicker.css';
 
 const EventForm: React.FC<EventFormProps> = (props) => {
-  const { onSubmit, data, loading, submitText, chapterId, loadingText } = props;
-  const isChaptersDropdownNeeded = chapterId === -1;
+  const {
+    onSubmit,
+    data,
+    loading,
+    submitText,
+    chapterId: initialChapterId,
+    loadingText,
+  } = props;
+  const isChaptersDropdownNeeded = initialChapterId === -1;
   const {
     loading: loadingChapter,
     error: errorChapter,
     data: dataChapter,
   } = useChapterQuery({
-    variables: { chapterId },
+    variables: { chapterId: initialChapterId },
   });
 
   interface Chapter {
@@ -77,7 +84,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
         start_at: new Date(),
         ends_at: new Date(),
         venue_type: VenueType.PhysicalAndOnline,
-        chapter_id: chapterId,
+        chapter_id: initialChapterId,
       };
     }
     return {
@@ -94,7 +101,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
       venue_id: data.venue_id,
       image_url: data.image_url,
       invite_only: data.invite_only,
-      chapter_id: chapterId,
+      chapter_id: initialChapterId,
     };
   }, []);
 
@@ -124,13 +131,13 @@ const EventForm: React.FC<EventFormProps> = (props) => {
   const watchSponsorsArray = watch('sponsors');
   const inviteOnly = watch('invite_only');
   const venueType = watch('venue_type');
-  const chapter = watch('chapter_id');
+  const chapterId = watch('chapter_id');
 
   const {
     loading: loadingVenues,
     error: errorVenues,
     data: dataVenues,
-  } = useChapterVenuesQuery({ variables: { chapterId: chapter } });
+  } = useChapterVenuesQuery({ variables: { chapterId } });
 
   useEffect(() => {
     resetField('chapter_id', { defaultValue: adminedChapters[0]?.id ?? -1 });
@@ -187,12 +194,11 @@ const EventForm: React.FC<EventFormProps> = (props) => {
               })}
               isDisabled={loading}
             >
-              {adminedChapters?.length &&
-                adminedChapters.map(({ id, name }) => (
-                  <option key={id} value={id}>
-                    {name}
-                  </option>
-                ))}
+              {adminedChapters.map(({ id, name }) => (
+                <option key={id} value={id}>
+                  {name}
+                </option>
+              ))}
             </Select>
           </FormControl>
         )}

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -138,7 +138,8 @@ const EventForm: React.FC<EventFormProps> = (props) => {
 
   useEffect(() => {
     resetField('venue_id', {
-      defaultValue: dataVenues?.chapterVenues[0]?.id ?? -1,
+      defaultValue:
+        defaultValues.venue_id ?? dataVenues?.chapterVenues[0]?.id ?? -1,
     });
   }, [dataVenues]);
 

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -15,7 +15,7 @@ import {
   Radio,
   Heading,
 } from '@chakra-ui/react';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm, useFieldArray } from 'react-hook-form';
 import DatePicker from 'react-datepicker';
 import { Input } from '../../../../components/Form/Input';
@@ -28,6 +28,7 @@ import {
 } from '../../../../generated/graphql';
 import styles from '../../../../styles/Form.module.css';
 import { isOnline, isPhysical } from '../../../../util/venueType';
+import { useAuth } from '../../../auth/store';
 import EventCancelButton from './EventCancelButton';
 import {
   EventFormProps,
@@ -44,6 +45,7 @@ import 'react-datepicker/dist/react-datepicker.css';
 
 const EventForm: React.FC<EventFormProps> = (props) => {
   const { onSubmit, data, loading, submitText, chapterId, loadingText } = props;
+  const isChaptersDropdownNeeded = chapterId === -1;
   const {
     loading: loadingChapter,
     error: errorChapter,
@@ -51,11 +53,17 @@ const EventForm: React.FC<EventFormProps> = (props) => {
   } = useChapterQuery({
     variables: { chapterId },
   });
-  const {
-    loading: loadingVenues,
-    error: errorVenues,
-    data: dataVenues,
-  } = useChapterVenuesQuery({ variables: { chapterId } });
+
+  interface Chapter {
+    id: number;
+    name: string;
+  }
+
+  let adminedChapters: Chapter[] = [];
+  if (isChaptersDropdownNeeded) {
+    const { user } = useAuth();
+    adminedChapters = user?.admined_chapters ?? [];
+  }
 
   const {
     loading: loadingSponsors,
@@ -69,6 +77,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
         start_at: new Date(),
         ends_at: new Date(),
         venue_type: VenueType.PhysicalAndOnline,
+        chapter_id: chapterId,
       };
     }
     return {
@@ -85,17 +94,19 @@ const EventForm: React.FC<EventFormProps> = (props) => {
       venue_id: data.venue_id,
       image_url: data.image_url,
       invite_only: data.invite_only,
+      chapter_id: chapterId,
     };
   }, []);
 
   const {
-    register,
     control,
-    handleSubmit,
-    watch,
-    setValue,
-    getValues,
     formState: { isDirty },
+    getValues,
+    handleSubmit,
+    register,
+    resetField,
+    setValue,
+    watch,
   } = useForm<EventFormData>({
     defaultValues,
   });
@@ -113,6 +124,23 @@ const EventForm: React.FC<EventFormProps> = (props) => {
   const watchSponsorsArray = watch('sponsors');
   const inviteOnly = watch('invite_only');
   const venueType = watch('venue_type');
+  const chapter = watch('chapter_id');
+
+  const {
+    loading: loadingVenues,
+    error: errorVenues,
+    data: dataVenues,
+  } = useChapterVenuesQuery({ variables: { chapterId: chapter } });
+
+  useEffect(() => {
+    resetField('chapter_id', { defaultValue: adminedChapters[0]?.id ?? -1 });
+  }, [adminedChapters]);
+
+  useEffect(() => {
+    resetField('venue_id', {
+      defaultValue: dataVenues?.chapterVenues[0]?.id ?? -1,
+    });
+  }, [dataVenues]);
 
   const [startDate, setStartDate] = useState<Date>(
     new Date(defaultValues.start_at),
@@ -134,274 +162,288 @@ const EventForm: React.FC<EventFormProps> = (props) => {
   );
 
   return (
-    <>
-      {loadingChapter ? (
-        <Text>Loading Chapter</Text>
-      ) : errorChapter || !dataChapter?.chapter ? (
-        <Text>Error loading chapter</Text>
-      ) : (
-        <Heading>{dataChapter.chapter.name}</Heading>
-      )}
-      <form
-        aria-label={submitText}
-        onSubmit={handleSubmit((data) => onSubmit(data, chapterId))}
-        className={styles.form}
-      >
-        <VStack align="flex-start">
-          {fields.map((field) =>
-            field.type === 'datetime' ? (
-              <FormControl key={field.key} isRequired>
-                <DatePicker
-                  selected={field.key === 'start_at' ? startDate : endDate}
-                  showTimeSelect
-                  timeIntervals={5}
-                  onChange={onDatePickerChange(field.key)}
-                  disabled={loading}
-                  dateFormat="MMMM d, yyyy h:mm aa"
-                  customInput={
-                    <Input
-                      id={`${field.key}_trigger`}
-                      name={`${field.key}`}
-                      label={field.label}
-                      isDisabled={loading}
-                      value={
-                        field.key === 'start_at'
-                          ? startDate.toDateString()
-                          : endDate.toDateString()
-                      }
-                    />
-                  }
-                />
+    <form
+      aria-label={submitText}
+      onSubmit={handleSubmit(onSubmit)}
+      className={styles.form}
+    >
+      <VStack align="flex-start">
+        {!isChaptersDropdownNeeded || data ? (
+          loadingChapter ? (
+            <Text>Loading Chapter</Text>
+          ) : errorChapter || !dataChapter?.chapter ? (
+            <Text>Error loading chapter</Text>
+          ) : (
+            <Heading>{dataChapter.chapter.name}</Heading>
+          )
+        ) : (
+          <FormControl isRequired>
+            <FormLabel>Chapter</FormLabel>
+            <Select
+              {...register('chapter_id' as const, {
+                required: true,
+                valueAsNumber: true,
+              })}
+              isDisabled={loading}
+            >
+              {adminedChapters?.length &&
+                adminedChapters.map(({ id, name }) => (
+                  <option key={id} value={id}>
+                    {name}
+                  </option>
+                ))}
+            </Select>
+          </FormControl>
+        )}
+        {fields.map((field) =>
+          field.type === 'datetime' ? (
+            <FormControl key={field.key} isRequired>
+              <DatePicker
+                selected={field.key === 'start_at' ? startDate : endDate}
+                showTimeSelect
+                timeIntervals={5}
+                onChange={onDatePickerChange(field.key)}
+                disabled={loading}
+                dateFormat="MMMM d, yyyy h:mm aa"
+                customInput={
+                  <Input
+                    id={`${field.key}_trigger`}
+                    name={`${field.key}`}
+                    label={field.label}
+                    isDisabled={loading}
+                    value={
+                      field.key === 'start_at'
+                        ? startDate.toDateString()
+                        : endDate.toDateString()
+                    }
+                  />
+                }
+              />
+            </FormControl>
+          ) : field.type === 'textarea' ? (
+            <TextArea
+              key={field.key}
+              label={field.label}
+              placeholder={field.placeholder}
+              isRequired={field.isRequired}
+              isDisabled={loading}
+              {...register(field.key)}
+            />
+          ) : (
+            <Input
+              key={field.key}
+              type={field.type}
+              label={field.label}
+              placeholder={field.placeholder}
+              isRequired={field.isRequired}
+              isDisabled={loading}
+              {...register(field.key)}
+            />
+          ),
+        )}
+
+        <Checkbox
+          data-cy="invite-only-checkbox"
+          isChecked={inviteOnly}
+          disabled={loading}
+          onChange={(e) => setValue('invite_only', e.target.checked)}
+        >
+          Invite only
+        </Checkbox>
+
+        <FormControl isRequired>
+          <FormLabel>Venue Type</FormLabel>
+          <RadioGroup defaultValue={venueType}>
+            <HStack>
+              {venueTypes.map((venueType) => (
+                <Radio
+                  key={venueType.value}
+                  value={venueType.value}
+                  isDisabled={loading}
+                  {...register('venue_type')}
+                >
+                  {venueType.name}
+                </Radio>
+              ))}
+            </HStack>
+          </RadioGroup>
+
+          {loadingVenues ? (
+            <h1>Loading venues...</h1>
+          ) : errorVenues || !dataVenues ? (
+            <h1>Error loading venues</h1>
+          ) : (
+            isPhysical(getValues('venue_type')) && (
+              <FormControl isRequired>
+                <FormLabel>Venue</FormLabel>
+                <Select {...register('venue_id')} isDisabled={loading}>
+                  {dataVenues.chapterVenues.map((v) => (
+                    <option key={v.id} value={v.id}>
+                      {v.name}
+                    </option>
+                  ))}
+                </Select>
               </FormControl>
-            ) : field.type === 'textarea' ? (
-              <TextArea
-                key={field.key}
-                label={field.label}
-                placeholder={field.placeholder}
-                isRequired={field.isRequired}
-                isDisabled={loading}
-                {...register(field.key)}
-              />
-            ) : (
-              <Input
-                key={field.key}
-                type={field.type}
-                label={field.label}
-                placeholder={field.placeholder}
-                isRequired={field.isRequired}
-                isDisabled={loading}
-                {...register(field.key)}
-              />
-            ),
+            )
           )}
 
-          <Checkbox
-            data-cy="invite-only-checkbox"
-            isChecked={inviteOnly}
-            disabled={loading}
-            onChange={(e) => setValue('invite_only', e.target.checked)}
-          >
-            Invite only
-          </Checkbox>
+          {isOnline(getValues('venue_type')) && (
+            <Input
+              key="streaming url"
+              type="url"
+              label="Streaming URL"
+              placeholder=""
+              isDisabled={loading}
+              isRequired
+              {...register('streaming_url')}
+            />
+          )}
+        </FormControl>
 
-          <FormControl isRequired>
-            <FormLabel>Venue Type</FormLabel>
-            <RadioGroup defaultValue={venueType}>
-              <HStack>
-                {venueTypes.map((venueType) => (
-                  <Radio
-                    key={venueType.value}
-                    value={venueType.value}
-                    isDisabled={loading}
-                    {...register('venue_type')}
-                  >
-                    {venueType.name}
-                  </Radio>
-                ))}
-              </HStack>
-            </RadioGroup>
-
-            {loadingVenues ? (
-              <h1>Loading venues...</h1>
-            ) : errorVenues || !dataVenues ? (
-              <h1>Error loading venues</h1>
-            ) : (
-              isPhysical(getValues('venue_type')) && (
-                <FormControl isRequired>
-                  <FormLabel>Venue</FormLabel>
-                  <Select {...register('venue_id')} isDisabled={loading}>
-                    {dataVenues.chapterVenues.map((v) => (
-                      <option key={v.id} value={v.id}>
-                        {v.name}
-                      </option>
-                    ))}
-                  </Select>
-                </FormControl>
-              )
-            )}
-
-            {isOnline(getValues('venue_type')) && (
-              <Input
-                key="streaming url"
-                type="url"
-                label="Streaming URL"
-                placeholder=""
-                isDisabled={loading}
-                isRequired
-                {...register('streaming_url')}
-              />
-            )}
-          </FormControl>
-
-          <FormControl id="first-name" isRequired>
-            <Box display="flex" alignItems="end" m="1">
-              <FormLabel> Sponsors</FormLabel>
-              <Spacer />
-              <Button
-                onClick={() => {
-                  if (sponsorData) {
-                    const allowedSponsors = getAllowedSponsors(
-                      sponsorData,
-                      watchSponsorsArray,
-                    );
-                    append({
-                      type: allowedSponsors[0]?.type,
-                      id: allowedSponsors[0]?.id,
-                    });
-                  }
-                }}
-                isDisabled={
-                  loading ||
-                  loadingSponsors ||
-                  errorSponsor ||
-                  !sponsorData ||
-                  sponsorFields.length < sponsorData.sponsors.length
-                    ? false
-                    : true
-                }
-              >
-                Add
-              </Button>
-            </Box>
-            {sponsorFields.map((sponsorField, sponsorFieldId) => {
-              const registeredSponsor = register(
-                `sponsors.${sponsorFieldId}.type` as const,
-                {
-                  required: true,
-                },
-              );
-
-              return (
-                <Flex key={sponsorField.key} borderWidth="1px" p="5" mb="5">
-                  <Box display="flex" flexGrow={1}>
-                    <FormControl m="1">
-                      <FormLabel>Sponsor Type</FormLabel>
-                      {loadingSponsors ? (
-                        <h5>loading sponsors</h5>
-                      ) : errorSponsor || !sponsorData ? (
-                        <h5> Error loading sponsors</h5>
-                      ) : (
-                        <Select
-                          defaultValue={getValues(
-                            `sponsors.${sponsorFieldId}.type`,
-                          )}
-                          {...registeredSponsor}
-                          onChange={(e) => {
-                            registeredSponsor.onChange(e);
-                            const sponsorsForThisType =
-                              getAllowedSponsorsForType(
-                                sponsorData,
-                                e.target.value,
-                                watchSponsorsArray,
-                                sponsorFieldId,
-                              );
-                            setValue(
-                              `sponsors.${sponsorFieldId}.id`,
-                              sponsorsForThisType[0]?.id,
-                            );
-                          }}
-                          isDisabled={loading}
-                        >
-                          {getAllowedSponsorTypes(
-                            sponsorData,
-                            sponsorTypes,
-                            watchSponsorsArray,
-                            sponsorFieldId,
-                          ).map((sponsorType) => (
-                            <option
-                              key={sponsorType.type}
-                              value={sponsorType.type}
-                            >
-                              {sponsorType.name}
-                            </option>
-                          ))}
-                        </Select>
-                      )}
-                    </FormControl>
-
-                    <FormControl m="1">
-                      <FormLabel> Sponsor Name</FormLabel>
-                      {loadingSponsors ? (
-                        <h5>loading sponsors</h5>
-                      ) : errorSponsor || !sponsorData ? (
-                        <h5> Error loading sponsors</h5>
-                      ) : (
-                        <Select
-                          defaultValue={getValues(
-                            `sponsors.${sponsorFieldId}.id`,
-                          )}
-                          {...register(
-                            `sponsors.${sponsorFieldId}.id` as const,
-                            {
-                              required: true,
-                              valueAsNumber: true,
-                            },
-                          )}
-                          isDisabled={loading}
-                        >
-                          {getAllowedSponsorsForType(
-                            sponsorData,
-                            watchSponsorsArray[sponsorFieldId].type,
-                            watchSponsorsArray,
-                            sponsorFieldId,
-                          ).map((s) => (
-                            <option key={s.id} value={s.id}>
-                              {s.name}
-                            </option>
-                          ))}
-                        </Select>
-                      )}
-                    </FormControl>
-                  </Box>
-                  <CloseButton onClick={() => remove(sponsorFieldId)} />
-                </Flex>
-              );
-            })}
-          </FormControl>
-          {data?.canceled && <Text color="red.500">Event canceled</Text>}
-          <HStack width="100%" mb="10 !important">
+        <FormControl id="first-name" isRequired>
+          <Box display="flex" alignItems="end" m="1">
+            <FormLabel> Sponsors</FormLabel>
+            <Spacer />
             <Button
-              width="full"
-              colorScheme="blue"
-              type="submit"
-              isDisabled={!isDirty || loading}
-              isLoading={loading}
-              loadingText={loadingText}
+              onClick={() => {
+                if (sponsorData) {
+                  const allowedSponsors = getAllowedSponsors(
+                    sponsorData,
+                    watchSponsorsArray,
+                  );
+                  append({
+                    type: allowedSponsors[0]?.type,
+                    id: allowedSponsors[0]?.id,
+                  });
+                }
+              }}
+              isDisabled={
+                loading ||
+                loadingSponsors ||
+                errorSponsor ||
+                !sponsorData ||
+                sponsorFields.length < sponsorData.sponsors.length
+                  ? false
+                  : true
+              }
             >
-              {submitText}
+              Add
             </Button>
-            {data && !data.canceled && (
-              <EventCancelButton
-                isFullWidth={true}
-                event={data}
-                isDisabled={loading}
-                buttonText="Cancel this Event"
-              />
-            )}
-          </HStack>
-        </VStack>
-      </form>
-    </>
+          </Box>
+          {sponsorFields.map((sponsorField, sponsorFieldId) => {
+            const registeredSponsor = register(
+              `sponsors.${sponsorFieldId}.type` as const,
+              {
+                required: true,
+              },
+            );
+
+            return (
+              <Flex key={sponsorField.key} borderWidth="1px" p="5" mb="5">
+                <Box display="flex" flexGrow={1}>
+                  <FormControl m="1">
+                    <FormLabel>Sponsor Type</FormLabel>
+                    {loadingSponsors ? (
+                      <h5>loading sponsors</h5>
+                    ) : errorSponsor || !sponsorData ? (
+                      <h5> Error loading sponsors</h5>
+                    ) : (
+                      <Select
+                        defaultValue={getValues(
+                          `sponsors.${sponsorFieldId}.type`,
+                        )}
+                        {...registeredSponsor}
+                        onChange={(e) => {
+                          registeredSponsor.onChange(e);
+                          const sponsorsForThisType = getAllowedSponsorsForType(
+                            sponsorData,
+                            e.target.value,
+                            watchSponsorsArray,
+                            sponsorFieldId,
+                          );
+                          setValue(
+                            `sponsors.${sponsorFieldId}.id`,
+                            sponsorsForThisType[0]?.id,
+                          );
+                        }}
+                        isDisabled={loading}
+                      >
+                        {getAllowedSponsorTypes(
+                          sponsorData,
+                          sponsorTypes,
+                          watchSponsorsArray,
+                          sponsorFieldId,
+                        ).map((sponsorType) => (
+                          <option
+                            key={sponsorType.type}
+                            value={sponsorType.type}
+                          >
+                            {sponsorType.name}
+                          </option>
+                        ))}
+                      </Select>
+                    )}
+                  </FormControl>
+
+                  <FormControl m="1">
+                    <FormLabel> Sponsor Name</FormLabel>
+                    {loadingSponsors ? (
+                      <h5>loading sponsors</h5>
+                    ) : errorSponsor || !sponsorData ? (
+                      <h5> Error loading sponsors</h5>
+                    ) : (
+                      <Select
+                        defaultValue={getValues(
+                          `sponsors.${sponsorFieldId}.id`,
+                        )}
+                        {...register(`sponsors.${sponsorFieldId}.id` as const, {
+                          required: true,
+                          valueAsNumber: true,
+                        })}
+                        isDisabled={loading}
+                      >
+                        {getAllowedSponsorsForType(
+                          sponsorData,
+                          watchSponsorsArray[sponsorFieldId].type,
+                          watchSponsorsArray,
+                          sponsorFieldId,
+                        ).map((s) => (
+                          <option key={s.id} value={s.id}>
+                            {s.name}
+                          </option>
+                        ))}
+                      </Select>
+                    )}
+                  </FormControl>
+                </Box>
+                <CloseButton onClick={() => remove(sponsorFieldId)} />
+              </Flex>
+            );
+          })}
+        </FormControl>
+        {data?.canceled && <Text color="red.500">Event canceled</Text>}
+        <HStack width="100%" mb="10 !important">
+          <Button
+            width="full"
+            colorScheme="blue"
+            type="submit"
+            isDisabled={!isDirty || loading}
+            isLoading={loading}
+            loadingText={loadingText}
+          >
+            {submitText}
+          </Button>
+          {data && !data.canceled && (
+            <EventCancelButton
+              isFullWidth={true}
+              event={data}
+              isDisabled={loading}
+              buttonText="Cancel this Event"
+            />
+          )}
+        </HStack>
+      </VStack>
+    </form>
   );
 };
 

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -130,11 +130,13 @@ export interface EventFormData {
   invite_only?: boolean;
   sponsors: Array<EventSponsorInput>;
   canceled: boolean;
+  chapter_id: number;
 }
 
 export type IEventData = Pick<
   Event,
-  keyof Omit<EventFormData, 'venue_id' | 'tags' | 'sponsors'> | 'id'
+  | keyof Omit<EventFormData, 'venue_id' | 'tags' | 'sponsors' | 'chapter_id'>
+  | 'id'
 > & {
   venue_id?: number;
   tags: EventTag[];
@@ -143,7 +145,7 @@ export type IEventData = Pick<
 };
 
 export interface EventFormProps {
-  onSubmit: (data: EventFormData, chapterId: number) => void;
+  onSubmit: (data: EventFormData) => void;
   loading: boolean;
   data?: IEventData;
   submitText: string;

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -40,7 +40,7 @@ export const EditEventPage: NextPage = () => {
     ],
   });
 
-  const onSubmit = async (data: EventFormData, chapterId: number) => {
+  const onSubmit = async (data: EventFormData) => {
     setLoadingUpdate(true);
 
     try {
@@ -62,7 +62,6 @@ export const EditEventPage: NextPage = () => {
         streaming_url: isOnline(data.venue_type) ? data.streaming_url : null,
         tags: tagsArray,
         sponsor_ids: sponsorArray,
-        chapter_id: chapterId,
       };
 
       const event = await updateEvent({

--- a/client/src/modules/dashboard/Events/pages/EventsPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventsPage.tsx
@@ -7,16 +7,24 @@ import React from 'react';
 import { formatDate } from '../../../../util/date';
 import { Layout } from '../../shared/components/Layout';
 import { isOnline, isPhysical } from '../../../../util/venueType';
+import { useAuth } from '../../../auth/store';
 import { useEventsQuery } from 'generated/graphql';
 
 export const EventsPage: NextPage = () => {
   const { error, loading, data } = useEventsQuery();
+
+  const { user } = useAuth();
 
   return (
     <Layout>
       <VStack>
         <Flex w="full" justify="space-between">
           <Heading id="page-heading">Events</Heading>
+          {!!user?.admined_chapters.length && (
+            <LinkButton data-cy="new-event" href="/dashboard/events/new">
+              Add new
+            </LinkButton>
+          )}
         </Flex>
 
         {loading ? (

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -14,7 +14,7 @@ import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 import { useParam } from '../../../../hooks/useParam';
 
 export const NewEventPage: NextPage = () => {
-  const { param: chapterId } = useParam('id');
+  const { param: chapterId, isReady } = useParam('id');
   const router = useRouter();
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -27,11 +27,11 @@ export const NewEventPage: NextPage = () => {
 
   const [publish] = useSendEventInviteMutation();
 
-  const onSubmit = async (data: EventFormData, chapterId: number) => {
+  const onSubmit = async (data: EventFormData) => {
     setLoading(true);
 
     try {
-      const { sponsors, tags, ...rest } = data;
+      const { chapter_id, sponsors, tags, ...rest } = data;
       const sponsorArray = sponsors.map((s) => parseInt(String(s.id)));
       const tagsArray = tags
         .split(',')
@@ -51,7 +51,7 @@ export const NewEventPage: NextPage = () => {
         sponsor_ids: sponsorArray,
       };
       const event = await createEvent({
-        variables: { chapterId, data: { ...eventData } },
+        variables: { chapterId: chapter_id, data: { ...eventData } },
       });
 
       if (event.data) {
@@ -70,13 +70,15 @@ export const NewEventPage: NextPage = () => {
 
   return (
     <Layout>
-      <EventForm
-        loading={loading}
-        onSubmit={onSubmit}
-        submitText={'Add event'}
-        loadingText={'Adding Event'}
-        chapterId={chapterId}
-      />
+      {isReady && (
+        <EventForm
+          loading={loading}
+          onSubmit={onSubmit}
+          submitText={'Add event'}
+          loadingText={'Adding Event'}
+          chapterId={chapterId}
+        />
+      )}
     </Layout>
   );
 };

--- a/client/src/pages/dashboard/events/new.tsx
+++ b/client/src/pages/dashboard/events/new.tsx
@@ -1,0 +1,2 @@
+import { NewEventPage } from '../../../modules/dashboard/Events/';
+export default NewEventPage;


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #1215 

---
- Adds general `Add new` button on the events dashboard, leading to `/dashboard/events/new` route, with add event form including chapters dropdown.
- Dropdown uses user `admined_chapters` array. This can be a bit weird, as permission required for _admining chapter_ - `ChapterEdit` is not the permission required for adding new events - `EventCreate`.
- `Add new` Button is visible only to those with permission to admin chapter.
- The bulk of the changed lines in `components/EventForm.tsx` is due to removal of blank dummy parent element and dedenting the whole form.