### PR TITLE
fix: allow venues to be changed to online

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -83,7 +83,7 @@
             "deprecationReason": null
           },
           {
-            "name": "chatUrl",
+            "name": "chat_url",
             "description": null,
             "args": [],
             "type": {
@@ -175,7 +175,7 @@
             "deprecationReason": null
           },
           {
-            "name": "imageUrl",
+            "name": "image_url",
             "description": null,
             "args": [],
             "type": {
@@ -510,7 +510,7 @@
             "deprecationReason": null
           },
           {
-            "name": "chatUrl",
+            "name": "chat_url",
             "description": null,
             "args": [],
             "type": {
@@ -626,7 +626,7 @@
             "deprecationReason": null
           },
           {
-            "name": "imageUrl",
+            "name": "image_url",
             "description": null,
             "args": [],
             "type": {
@@ -725,7 +725,7 @@
             "deprecationReason": null
           },
           {
-            "name": "chatUrl",
+            "name": "chat_url",
             "description": null,
             "args": [],
             "type": {
@@ -841,7 +841,7 @@
             "deprecationReason": null
           },
           {
-            "name": "imageUrl",
+            "name": "image_url",
             "description": null,
             "args": [],
             "type": {
@@ -941,7 +941,7 @@
             "deprecationReason": null
           },
           {
-            "name": "chatUrl",
+            "name": "chat_url",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -1001,7 +1001,7 @@
             "deprecationReason": null
           },
           {
-            "name": "imageUrl",
+            "name": "image_url",
             "description": null,
             "type": {
               "kind": "NON_NULL",
@@ -5022,7 +5022,7 @@
             "deprecationReason": null
           },
           {
-            "name": "chatUrl",
+            "name": "chat_url",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -5070,7 +5070,7 @@
             "deprecationReason": null
           },
           {
-            "name": "imageUrl",
+            "name": "image_url",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -31,13 +31,13 @@ export type AuthenticateType = {
 export type Chapter = {
   __typename?: 'Chapter';
   category: Scalars['String'];
-  chatUrl?: Maybe<Scalars['String']>;
+  chat_url?: Maybe<Scalars['String']>;
   city: Scalars['String'];
   country: Scalars['String'];
   creator_id: Scalars['Int'];
   description: Scalars['String'];
   id: Scalars['Int'];
-  imageUrl: Scalars['String'];
+  image_url: Scalars['String'];
   name: Scalars['String'];
   region: Scalars['String'];
 };
@@ -74,14 +74,14 @@ export type ChapterUser = {
 export type ChapterWithEvents = {
   __typename?: 'ChapterWithEvents';
   category: Scalars['String'];
-  chatUrl?: Maybe<Scalars['String']>;
+  chat_url?: Maybe<Scalars['String']>;
   city: Scalars['String'];
   country: Scalars['String'];
   creator_id: Scalars['Int'];
   description: Scalars['String'];
   events: Array<Event>;
   id: Scalars['Int'];
-  imageUrl: Scalars['String'];
+  image_url: Scalars['String'];
   name: Scalars['String'];
   region: Scalars['String'];
 };
@@ -90,14 +90,14 @@ export type ChapterWithRelations = {
   __typename?: 'ChapterWithRelations';
   category: Scalars['String'];
   chapter_users: Array<ChapterUser>;
-  chatUrl?: Maybe<Scalars['String']>;
+  chat_url?: Maybe<Scalars['String']>;
   city: Scalars['String'];
   country: Scalars['String'];
   creator_id: Scalars['Int'];
   description: Scalars['String'];
   events: Array<Event>;
   id: Scalars['Int'];
-  imageUrl: Scalars['String'];
+  image_url: Scalars['String'];
   name: Scalars['String'];
   region: Scalars['String'];
   user_bans: Array<UserBan>;
@@ -105,11 +105,11 @@ export type ChapterWithRelations = {
 
 export type CreateChapterInputs = {
   category: Scalars['String'];
-  chatUrl?: InputMaybe<Scalars['String']>;
+  chat_url?: InputMaybe<Scalars['String']>;
   city: Scalars['String'];
   country: Scalars['String'];
   description: Scalars['String'];
-  imageUrl: Scalars['String'];
+  image_url: Scalars['String'];
   name: Scalars['String'];
   region: Scalars['String'];
 };
@@ -553,11 +553,11 @@ export type Tag = {
 
 export type UpdateChapterInputs = {
   category?: InputMaybe<Scalars['String']>;
-  chatUrl?: InputMaybe<Scalars['String']>;
+  chat_url?: InputMaybe<Scalars['String']>;
   city?: InputMaybe<Scalars['String']>;
   country?: InputMaybe<Scalars['String']>;
   description?: InputMaybe<Scalars['String']>;
-  imageUrl?: InputMaybe<Scalars['String']>;
+  image_url?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
   region?: InputMaybe<Scalars['String']>;
 };
@@ -757,8 +757,8 @@ export type ChapterQuery = {
     city: string;
     region: string;
     country: string;
-    imageUrl: string;
-    chatUrl?: string | null;
+    image_url: string;
+    chat_url?: string | null;
     events: Array<{
       __typename?: 'Event';
       id: number;
@@ -822,7 +822,7 @@ export type ChaptersQuery = {
     name: string;
     description: string;
     category: string;
-    imageUrl: string;
+    image_url: string;
     events: Array<{
       __typename?: 'Event';
       id: number;
@@ -846,7 +846,7 @@ export type CreateChapterMutation = {
     city: string;
     region: string;
     country: string;
-    chatUrl?: string | null;
+    chat_url?: string | null;
   };
 };
 
@@ -865,7 +865,7 @@ export type UpdateChapterMutation = {
     city: string;
     region: string;
     country: string;
-    chatUrl?: string | null;
+    chat_url?: string | null;
   };
 };
 
@@ -1452,7 +1452,7 @@ export type HomeQuery = {
     name: string;
     description: string;
     category: string;
-    imageUrl: string;
+    image_url: string;
     events: Array<{
       __typename?: 'Event';
       id: number;
@@ -1794,8 +1794,8 @@ export const ChapterDocument = gql`
       city
       region
       country
-      imageUrl
-      chatUrl
+      image_url
+      chat_url
       events {
         id
         name
@@ -2004,7 +2004,7 @@ export const ChaptersDocument = gql`
       name
       description
       category
-      imageUrl
+      image_url
       events {
         id
         name
@@ -2067,7 +2067,7 @@ export const CreateChapterDocument = gql`
       city
       region
       country
-      chatUrl
+      chat_url
     }
   }
 `;
@@ -2123,7 +2123,7 @@ export const UpdateChapterDocument = gql`
       city
       region
       country
-      chatUrl
+      chat_url
     }
   }
 `;
@@ -4138,7 +4138,7 @@ export const HomeDocument = gql`
       name
       description
       category
-      imageUrl
+      image_url
       events {
         id
         name

--- a/client/src/modules/chapters/graphql/queries.ts
+++ b/client/src/modules/chapters/graphql/queries.ts
@@ -10,8 +10,8 @@ export const CHAPTER = gql`
       city
       region
       country
-      imageUrl
-      chatUrl
+      image_url
+      chat_url
       events {
         id
         name
@@ -79,7 +79,7 @@ export const CHAPTERS = gql`
       name
       description
       category
-      imageUrl
+      image_url
       events {
         id
         name

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -110,7 +110,7 @@ export const ChapterPage: NextPage = () => {
         <Image
           boxSize="100%"
           maxH="300px"
-          src={data.chapter.imageUrl}
+          src={data.chapter.image_url}
           alt=""
           borderRadius="md"
           objectFit="cover"
@@ -162,12 +162,12 @@ export const ChapterPage: NextPage = () => {
               Join chapter
             </Button>
           ))}
-        {data.chapter.chatUrl && (
+        {data.chapter.chat_url && (
           <div>
             <Heading size="md" color={'gray.700'}>
               Chat Link:
             </Heading>
-            <Link>{data.chapter.chatUrl}</Link>
+            <Link>{data.chapter.chat_url}</Link>
           </div>
         )}
         <Heading size="md" color={'gray.700'}>

--- a/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
+++ b/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
@@ -72,14 +72,14 @@ const fields: Fields[] = [
     type: 'text',
   },
   {
-    key: 'imageUrl',
+    key: 'image_url',
     label: 'Image Url',
     placeholder: 'https://www.freecodecamp.org',
     required: true,
     type: 'url',
   },
   {
-    key: 'chatUrl',
+    key: 'chat_url',
     label: 'Chat link',
     placeholder: 'https://discord.gg/KVUmVXA',
     required: false,
@@ -98,8 +98,8 @@ const ChapterForm: React.FC<ChapterFormProps> = (props) => {
     region: chapter?.region ?? '',
     country: chapter?.country ?? '',
     category: chapter?.category ?? '',
-    imageUrl: chapter?.imageUrl ?? '',
-    chatUrl: chapter?.chatUrl ?? '',
+    image_url: chapter?.image_url ?? '',
+    chat_url: chapter?.chat_url ?? '',
   };
   const {
     handleSubmit,

--- a/client/src/modules/dashboard/Chapters/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Chapters/graphql/mutations.ts
@@ -9,7 +9,7 @@ export const createChapter = gql`
       city
       region
       country
-      chatUrl
+      chat_url
     }
   }
 `;
@@ -23,7 +23,7 @@ export const updateChapter = gql`
       city
       region
       country
-      chatUrl
+      chat_url
     }
   }
 `;

--- a/client/src/modules/home/graphql/queries.ts
+++ b/client/src/modules/home/graphql/queries.ts
@@ -27,7 +27,7 @@ export const HOME_PAGE_QUERY = gql`
       name
       description
       category
-      imageUrl
+      image_url
       events {
         id
         name

--- a/cypress/e2e/dashboard/chapters/[chapterId]/chapterId-index.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/chapterId-index.cy.ts
@@ -10,7 +10,7 @@ const testEvent = {
   startAt: '2022-01-01T00:01',
   endAt: '2022-01-02T00:02',
   venueId: '1',
-  imageUrl: 'https://test.event.org/image',
+  image_url: 'https://test.event.org/image',
 };
 
 // TODO: Consolidate fixtures.
@@ -116,7 +116,7 @@ describe('chapter dashboard', () => {
       testEvent.description,
     );
     cy.findByRole('textbox', { name: 'Event Image Url' }).type(
-      testEvent.imageUrl,
+      testEvent.image_url,
     );
     cy.findByRole('textbox', { name: 'Url' }).type(testEvent.url);
     cy.findByRole('spinbutton', { name: 'Capacity' }).type(testEvent.capacity);

--- a/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
@@ -7,7 +7,7 @@ const chapterData = {
   region: 'New Region',
   country: 'New Country',
   category: 'New Category',
-  imageUrl: 'https://example.com/new-image.jpg',
+  image_url: 'https://example.com/new-image.jpg',
 };
 
 describe('chapter edit dashboard', () => {
@@ -36,7 +36,7 @@ describe('chapter edit dashboard', () => {
       .type(chapterData.category);
     cy.findByRole('textbox', { name: 'Image Url' })
       .clear()
-      .type(chapterData.imageUrl);
+      .type(chapterData.image_url);
 
     cy.findByRole('form', { name: 'Save Chapter Changes' })
       .findByRole('button', { name: 'Save Chapter Changes' })

--- a/cypress/e2e/dashboard/chapters/chapters-index.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapters-index.cy.ts
@@ -7,7 +7,7 @@ const chapterData = {
   region: 'Location in the world',
   country: 'Home country',
   category: 'Type of chapter',
-  imageUrl: 'https://example.com/image.jpg',
+  image_url: 'https://example.com/image.jpg',
 };
 
 describe('chapters dashboard', () => {
@@ -47,7 +47,7 @@ describe('chapters dashboard', () => {
     cy.findByRole('textbox', { name: 'Region' }).type(chapterData.region);
     cy.findByRole('textbox', { name: 'Country' }).type(chapterData.country);
     cy.findByRole('textbox', { name: 'Category' }).type(chapterData.category);
-    cy.findByRole('textbox', { name: 'Image Url' }).type(chapterData.imageUrl);
+    cy.findByRole('textbox', { name: 'Image Url' }).type(chapterData.image_url);
 
     cy.findByRole('form', { name: 'Add chapter' })
       .findByRole('button', {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -234,7 +234,7 @@ const createChapter = (data) => {
         city
         region
         country
-        chatUrl
+        chat_url
       }
     }
   `,

--- a/server/prisma/generator/factories/chapters.factory.ts
+++ b/server/prisma/generator/factories/chapters.factory.ts
@@ -23,7 +23,7 @@ const createChapters = async (userId: number): Promise<number[]> => {
       country: address.country(),
       city: address.city(),
       region: address.state(),
-      imageUrl: image.imageUrl(640, 480, 'tech', true),
+      image_url: image.imageUrl(640, 480, 'tech', true),
     };
 
     // TODO: batch this once createMany returns the records.

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -21,8 +21,8 @@ model chapters {
   city          String
   region        String
   country       String
-  imageUrl      String
-  chatUrl       String?
+  image_url      String
+  chat_url       String?
   creator_id    Int
   events        events[]
   user_bans     user_bans[]

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -120,7 +120,7 @@ model events {
   venue_id      Int?
   chapter_id    Int
   chapter       chapters               @relation(fields: [chapter_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  venue         venues?                @relation(fields: [venue_id, chapter_id], references: [id, chapter_id], onDelete: NoAction, onUpdate: NoAction)
+  venue         venues?                @relation(fields: [venue_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   sponsors      event_sponsors[]
   tags          event_tags[]
   event_users   event_users[]
@@ -277,10 +277,8 @@ model venues {
   latitude       Float?
   longitude      Float?
   events         events[]
-  chapter        chapters @relation(fields: [chapter_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   chapter_id     Int
-
-  @@unique([id, chapter_id])
+  chapter        chapters @relation(fields: [chapter_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 }
 
 enum events_venue_type_enum {

--- a/server/src/controllers/Chapter/inputs.ts
+++ b/server/src/controllers/Chapter/inputs.ts
@@ -23,10 +23,10 @@ export class CreateChapterInputs implements Omit<Chapter, 'id' | 'creator_id'> {
   country: string;
 
   @Field(() => String)
-  imageUrl: string;
+  image_url: string;
 
   @Field(() => String, { nullable: true })
-  chatUrl?: string | null;
+  chat_url?: string | null;
 }
 
 @InputType()
@@ -50,8 +50,8 @@ export class UpdateChapterInputs implements Omit<Chapter, 'id' | 'creator_id'> {
   country: string;
 
   @Field(() => String, { nullable: true })
-  imageUrl: string;
+  image_url: string;
 
   @Field(() => String, { nullable: true })
-  chatUrl?: string | null;
+  chat_url?: string | null;
 }

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -54,12 +54,12 @@ export class VenueResolver {
   @Mutation(() => Venue)
   updateVenue(
     @Arg('venueId', () => Int) id: number,
-    @Arg('chapterId', () => Int) chapter_id: number,
+    @Arg('chapterId', () => Int) _onlyUsedForAuth: number,
     @Arg('data') data: UpdateVenueInputs,
   ): Promise<Venue | null> {
     const venueData: Prisma.venuesUpdateInput = data;
     return prisma.venues.update({
-      where: { id_chapter_id: { id, chapter_id } },
+      where: { id },
       data: venueData,
     });
   }
@@ -68,11 +68,11 @@ export class VenueResolver {
   @Mutation(() => Venue)
   async deleteVenue(
     @Arg('venueId', () => Int) id: number,
-    @Arg('chapterId', () => Int) chapter_id: number,
+    @Arg('chapterId', () => Int) _onlyUsedForAuth: number,
   ): Promise<{ id: number }> {
     // TODO: handle deletion of non-existent venue
     return await prisma.venues.delete({
-      where: { id_chapter_id: { id, chapter_id } },
+      where: { id },
     });
   }
 }

--- a/server/src/graphql-types/Chapter.ts
+++ b/server/src/graphql-types/Chapter.ts
@@ -11,7 +11,7 @@ export class Chapter extends BaseObject {
   description: string;
 
   @Field(() => String, { nullable: true })
-  chatUrl?: string | null;
+  chat_url?: string | null;
 
   @Field(() => String)
   category: string;
@@ -26,7 +26,7 @@ export class Chapter extends BaseObject {
   country: string;
 
   @Field(() => String)
-  imageUrl!: string;
+  image_url!: string;
 
   @Field(() => Int)
   creator_id: number;


### PR DESCRIPTION
Having event's fk for venue be composite meant that the query to remove
that reference would try and null both keys (chapter_id and venue_id),
but chapter_id is not nullable.

This was a bit of a hack to require chapterId to be sent as a
GraphQL variable (so that authChecker could see it), this just opts for
the lesser of two hacks. Namely, passing, but not using, chapterId.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Related to https://github.com/freeCodeCamp/chapter/issues/1316, but it would be best to close that after adding some tests to prevent regressions.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
