### PR TITLE
fix: home page layout responsive

### DIFF
--- a/client/src/components/ChapterCard.tsx
+++ b/client/src/components/ChapterCard.tsx
@@ -15,9 +15,12 @@ export const ChapterCard: React.FC<ChapterCardProps> = ({ chapter }) => {
       borderWidth="1px"
       borderRadius="lg"
       overflow="hidden"
+      width={'full'}
+      minW={'20em'}
+      gap={'2'}
     >
-      <Grid minW={'25em'} maxW={'35em'} templateColumns="repeat(2, 1fr)">
-        <GridItem colSpan={3} paddingInline={'1em'} paddingBlock={'.5em'}>
+      <Grid templateColumns="repeat(2, 1fr)" gap={'3'} marginRight={'1em'}>
+        <GridItem paddingInline={'1em'} paddingBlock={'.5em'} colSpan={3}>
           <Link href={`/chapters/${chapter?.id}`} _hover={{}}>
             <Flex justifyContent={'space-between'}>
               <Heading
@@ -41,29 +44,40 @@ export const ChapterCard: React.FC<ChapterCardProps> = ({ chapter }) => {
           marginInline={'1em'}
           marginBlock={'.5em'}
         >
-          <Text mt="2" as="p" fontWeight={400} fontSize={'md'}>
+          <Text mt="2" as="p" fontWeight={400} fontSize={['sm', 'md', 'lg']}>
             {chapter.description}
           </Text>
         </GridItem>
+        <GridItem colSpan={3}>
+          {chapter.events.map(({ id, name, start_at }) => (
+            <Link key={id} href={`/events/${id}`} _hover={{}}>
+              <Flex
+                direction={['column', 'column', 'row']}
+                paddingInline={'1em'}
+                paddingBlock={'.5em'}
+                justifyContent={'space-between'}
+              >
+                <Text
+                  mt="2"
+                  fontWeight={600}
+                  fontSize={['sm', 'md', 'lg']}
+                  width={['10em', '15em']}
+                >
+                  {name}
+                </Text>
+                <Text
+                  mt="2"
+                  fontWeight={400}
+                  fontSize={['sm', 'md', 'lg']}
+                  opacity={'.8'}
+                >
+                  {start_at}
+                </Text>
+              </Flex>
+            </Link>
+          ))}
+        </GridItem>
       </Grid>
-      <GridItem colSpan={3}>
-        {chapter.events.map(({ id, name, start_at }) => (
-          <Link key={id} href={`/events/${id}`} _hover={{}}>
-            <Flex
-              paddingInline={'1em'}
-              paddingBlock={'.5em'}
-              justifyContent={'space-between'}
-            >
-              <Text mt="2" fontWeight={600} fontSize={'md'} maxW={'10em'}>
-                {name}
-              </Text>
-              <Text mt="2" fontWeight={600} fontSize={'md'}>
-                {start_at}
-              </Text>
-            </Flex>
-          </Link>
-        ))}
-      </GridItem>
     </Grid>
   );
 };

--- a/client/src/components/EventCard.tsx
+++ b/client/src/components/EventCard.tsx
@@ -77,15 +77,12 @@ export const EventCard: React.FC<EventCardProps> = ({ event }) => {
           as="h4"
           lineHeight="tight"
           gridTemplateColumns={'repeat(3, 1fr)'}
-          templateAreas={[
-            `"eventname eventname eventname"
+          templateAreas={`
+          "eventname eventname eventname"
           "chaptername chaptername chaptername"
           "eventstart eventstart eventstart"
-          "metatag metatag metatag"`,
-            `"eventname eventname metatag"
-          "chaptername chaptername chaptername"
-          "eventstart eventstart eventstart"`,
-          ]}
+          "metatag metatag metatag"
+          `}
         >
           <GridItem area={'eventname'}>
             <Link data-cy="event-link" href={`/events/${event.id}`}>

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -135,18 +135,21 @@ export const ChapterPage: NextPage = () => {
             <Spinner />
           ) : dataChapterUser ? (
             <HStack>
-              <CheckIcon />
-              <Text>
-                {dataChapterUser.chapterUser.chapter_role.name} of the chapter
-              </Text>
               {dataChapterUser.chapterUser.subscribed ? (
-                <Button
-                  colorScheme="orange"
-                  onClick={() => chapterSubscribe(false)}
-                  size="md"
-                >
-                  Unsubscribe
-                </Button>
+                <HStack>
+                  <CheckIcon />
+                  <Text>
+                    {dataChapterUser.chapterUser.chapter_role.name} of the
+                    chapter
+                  </Text>
+                  <Button
+                    colorScheme="orange"
+                    onClick={() => chapterSubscribe(false)}
+                    size="md"
+                  >
+                    Unsubscribe
+                  </Button>
+                </HStack>
               ) : (
                 <Button
                   colorScheme="green"

--- a/client/src/modules/chapters/pages/chaptersPage.tsx
+++ b/client/src/modules/chapters/pages/chaptersPage.tsx
@@ -1,4 +1,4 @@
-import { Heading, VStack, Stack } from '@chakra-ui/layout';
+import { Heading, Stack } from '@chakra-ui/layout';
 import { NextPage } from 'next';
 import React from 'react';
 import { Grid, GridItem } from '@chakra-ui/react';
@@ -21,19 +21,17 @@ export const ChaptersPage: NextPage = () => {
     );
   }
   return (
-    <VStack>
-      <Stack w={['90%', '90%', '60%']} maxW="600px" spacing={3} mt={10} mb={5}>
-        <Heading>Chapters: </Heading>
-        <Grid mt="5%" templateColumns="repeat(2, 1fr)" columnGap="5%">
-          {data.chapters.map((chapter) => (
-            <GridItem key={chapter.id}>
-              <Heading size="md">
-                <ChapterCard chapter={chapter} />
-              </Heading>
-            </GridItem>
-          ))}
-        </Grid>
-      </Stack>
-    </VStack>
+    <Stack mt={10} mb={5} display={'block'}>
+      <Heading>Chapters: </Heading>
+      <Grid templateColumns="[repeat(2, 1fr), none]" gap="1em">
+        {data.chapters.map((chapter) => (
+          <GridItem key={chapter.id}>
+            <Heading size="md">
+              <ChapterCard chapter={chapter} />
+            </Heading>
+          </GridItem>
+        ))}
+      </Grid>
+    </Stack>
   );
 };

--- a/client/src/modules/home/index.tsx
+++ b/client/src/modules/home/index.tsx
@@ -38,8 +38,8 @@ const Home = () => {
   };
 
   return (
-    <Grid templateColumns="repeat(3, 1fr)" columnGap={10} mt="5">
-      <GridItem colSpan={{ base: 3, md: 2 }}>
+    <Grid templateColumns="repeat(2, 1fr)" gap={10} mt="5">
+      <GridItem colSpan={{ base: 2, xl: 1 }}>
         <VStack align="flex-start">
           <Heading>Upcoming events</Heading>
           {loading ? (
@@ -64,7 +64,7 @@ const Home = () => {
           )}
         </VStack>
       </GridItem>
-      <GridItem colSpan={{ base: 3, md: 1 }}>
+      <GridItem colSpan={{ base: 2, xl: 1 }}>
         <VStack align="flex-start">
           <Heading>Chapters</Heading>
           {loading ? (

--- a/client/src/styles/themes.ts
+++ b/client/src/styles/themes.ts
@@ -21,11 +21,4 @@ const chapterStyleVaribles = {
   },
 };
 
-const breakpoints = {
-  sm: '20em',
-  md: '35em',
-  lg: '45em',
-  xl: '62em',
-};
-
-export const chapterTheme = extendTheme(chapterStyleVaribles, { breakpoints });
+export const chapterTheme = extendTheme(chapterStyleVaribles);

--- a/client/src/styles/themes.ts
+++ b/client/src/styles/themes.ts
@@ -21,4 +21,11 @@ const chapterStyleVaribles = {
   },
 };
 
-export const chapterTheme = extendTheme(chapterStyleVaribles);
+const breakpoints = {
+  sm: '20em',
+  md: '35em',
+  lg: '45em',
+  xl: '62em',
+};
+
+export const chapterTheme = extendTheme(chapterStyleVaribles, { breakpoints });


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

In tablet 768px, it wasn't responsive. This is a lazy way to make it responsive by making them a column when they are in 768px wide screens.

With slight polishing to the font. 
