### PR TITLE
fix: events loading inconsistency

### DIFF
--- a/client/src/modules/events/pages/eventsPage.tsx
+++ b/client/src/modules/events/pages/eventsPage.tsx
@@ -54,7 +54,7 @@ function Pagination({
 const pageSize = 5;
 export const EventsPage: NextPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
-  const [visitedPages, setVisitedPages] = useState(new Set());
+  const [visitedPages, setVisitedPages] = useState(new Set([1]));
   const { loading, error, data, fetchMore } = usePaginatedEventsWithTotalQuery({
     variables: { offset: (currentPage - 1) * pageSize, limit: pageSize },
   });

--- a/client/src/modules/events/pages/eventsPage.tsx
+++ b/client/src/modules/events/pages/eventsPage.tsx
@@ -55,17 +55,15 @@ const pageSize = 5;
 export const EventsPage: NextPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [visitedPages, setVisitedPages] = useState(new Set([1]));
+  const offset = (currentPage - 1) * pageSize;
   const { loading, error, data, fetchMore } = usePaginatedEventsWithTotalQuery({
-    variables: { offset: (currentPage - 1) * pageSize, limit: pageSize },
+    variables: { offset, limit: pageSize },
   });
 
   useEffect(() => {
     if (visitedPages.has(currentPage)) return;
     fetchMore({
-      variables: {
-        offset: data?.paginatedEventsWithTotal.events.length || 0,
-        limit: pageSize,
-      },
+      variables: { offset, limit: pageSize },
     });
     setVisitedPages(new Set(visitedPages).add(currentPage));
   }, [currentPage]);

--- a/client/src/modules/events/pages/eventsPage.tsx
+++ b/client/src/modules/events/pages/eventsPage.tsx
@@ -54,17 +54,20 @@ function Pagination({
 const pageSize = 5;
 export const EventsPage: NextPage = () => {
   const [currentPage, setCurrentPage] = useState(1);
+  const [visitedPages, setVisitedPages] = useState(new Set());
   const { loading, error, data, fetchMore } = usePaginatedEventsWithTotalQuery({
     variables: { offset: (currentPage - 1) * pageSize, limit: pageSize },
   });
 
   useEffect(() => {
+    if (visitedPages.has(currentPage)) return;
     fetchMore({
       variables: {
         offset: data?.paginatedEventsWithTotal.events.length || 0,
         limit: pageSize,
       },
     });
+    setVisitedPages(new Set(visitedPages).add(currentPage));
   }, [currentPage]);
   if (loading) {
     return <h1>Loading...</h1>;


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Fixes double load on opening `/events`, one coming from the normal query and one from `fetchMore` after `currentPage` is changed/set.
- Fetching more is now limited to not visited pages numbers. Otherwise page with events is loaded from cache (I assume it's nextjs' cache). This might be a little overkill for now, both in doing so in first place and in using set to keep track of visited pages.