### PR TITLE
fix: delay rendering until url param is loaded

### DIFF
--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -27,7 +27,7 @@ import {
 import { useParam } from 'hooks/useParam';
 
 export const ChapterPage: NextPage = () => {
-  const { param: chapterId } = useParam('chapterId');
+  const { param: chapterId, isReady } = useParam('chapterId');
   const { user } = useAuth();
 
   const { loading, error, data } = useChapterQuery({
@@ -91,7 +91,7 @@ export const ChapterPage: NextPage = () => {
     }
   };
 
-  if (loading) {
+  if (loading || !isReady) {
     return <Spinner />;
   }
 

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -30,7 +30,7 @@ import { useParam } from '../../../../../hooks/useParam';
 import { CHAPTER_USERS } from '../../../../chapters/graphql/queries';
 
 export const ChapterUsersPage: NextPage = () => {
-  const { param: chapterId } = useParam('id');
+  const { param: chapterId, isReady } = useParam('id');
 
   const { loading, error, data } = useChapterUsersQuery({
     variables: { chapterId },
@@ -135,7 +135,7 @@ export const ChapterUsersPage: NextPage = () => {
         <Flex w="full" justify="space-between">
           <Heading id="page-heading">Chapter Users</Heading>
         </Flex>
-        {loading ? (
+        {loading || !isReady ? (
           <Heading>Loading...</Heading>
         ) : error || !data?.chapter?.chapter_users ? (
           <>

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -10,16 +10,16 @@ import styles from '../../../../styles/Page.module.css';
 import { Layout } from '../../shared/components/Layout';
 
 export const ChapterPage: NextPage = () => {
-  const { param: chapterId } = useParam('id');
+  const { param: chapterId, isReady } = useParam('id');
 
   const { loading, error, data } = useChapterQuery({
     variables: { chapterId },
   });
 
-  if (loading || error || !data?.chapter) {
+  if (loading || !isReady || error || !data?.chapter) {
     return (
       <Layout>
-        <h1>{loading ? 'Loading...' : 'Error...'}</h1>
+        <h1>{loading || !isReady ? 'Loading...' : 'Error...'}</h1>
         {error && <div className={styles.error}>{error.message}</div>}
       </Layout>
     );

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -16,7 +16,7 @@ export const EditChapterPage: NextPage = () => {
   const router = useRouter();
   const [loadingUpdate, setLoadingUpdate] = useState(false);
 
-  const { param: chapterId } = useParam('id');
+  const { param: chapterId, isReady } = useParam('id');
 
   const { loading, error, data } = useChapterQuery({
     variables: { chapterId },
@@ -39,10 +39,10 @@ export const EditChapterPage: NextPage = () => {
     }
   };
 
-  if (loading || error || !data?.chapter) {
+  if (loading || !isReady || error || !data?.chapter) {
     return (
       <Layout>
-        <h1>{loading ? 'Loading...' : 'Error...'}</h1>
+        <h1>{loading || !isReady ? 'Loading...' : 'Error...'}</h1>
         {error && <div className={styles.error}>{error.message}</div>}
       </Layout>
     );

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -18,7 +18,7 @@ import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 export const EditEventPage: NextPage = () => {
   const router = useRouter();
   const [loadingUpdate, setLoadingUpdate] = useState<boolean>(false);
-  const { param: eventId } = useParam();
+  const { param: eventId, isReady } = useParam();
 
   const {
     loading: eventLoading,
@@ -86,10 +86,10 @@ export const EditEventPage: NextPage = () => {
     }
   };
 
-  if (eventLoading || error || !data?.event) {
+  if (eventLoading || !isReady || error || !data?.event) {
     return (
       <Layout>
-        <h1>{eventLoading ? 'Loading...' : 'Error...'}</h1>
+        <h1>{eventLoading || !isReady ? 'Loading...' : 'Error...'}</h1>
         {error && <div>{error.message}</div>}
       </Layout>
     );

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -26,7 +26,7 @@ const args = (eventId: number) => ({
 
 export const EventPage: NextPage = () => {
   const router = useRouter();
-  const { param: eventId } = useParam('id');
+  const { param: eventId, isReady } = useParam('id');
   const { loading, error, data } = useEventQuery({
     variables: { eventId },
   });
@@ -51,11 +51,15 @@ export const EventPage: NextPage = () => {
       if (ok) kickRsvpFn({ variables: { eventId, userId } });
     };
 
-  if (loading || error || !data || !data.event) {
+  if (loading || !isReady || error || !data || !data.event) {
     return (
       <Layout>
         <h1>
-          {loading ? 'Loading...' : !error ? "Can't find event :(" : 'Error...'}
+          {loading || !isReady
+            ? 'Loading...'
+            : !error
+            ? "Can't find event :("
+            : 'Error...'}
         </h1>
       </Layout>
     );

--- a/client/src/modules/dashboard/Sponsors/pages/EditSponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/EditSponsorPage.tsx
@@ -10,7 +10,7 @@ import { useSponsorQuery, useUpdateSponsorMutation } from 'generated/graphql';
 const EditSponsorPage: NextPage = () => {
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const { param: sponsorId } = useParam('id');
+  const { param: sponsorId, isReady } = useParam('id');
   const {
     loading: sponsorLoading,
     error,
@@ -41,10 +41,10 @@ const EditSponsorPage: NextPage = () => {
     }
   };
 
-  if (sponsorLoading || error || !data?.sponsor) {
+  if (sponsorLoading || !isReady || error || !data?.sponsor) {
     return (
       <Layout>
-        <h1>{sponsorLoading ? 'Loading...' : 'Error...'}</h1>
+        <h1>{sponsorLoading || !isReady ? 'Loading...' : 'Error...'}</h1>
         {error && <div>{error.message}</div>}
       </Layout>
     );

--- a/client/src/modules/dashboard/Sponsors/pages/SponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/SponsorPage.tsx
@@ -9,12 +9,12 @@ import styles from '../../../../styles/Page.module.css';
 import { Layout } from '../../shared/components/Layout';
 
 export const SponsorPage: NextPage = () => {
-  const { param: sponsorId } = useParam('id');
+  const { param: sponsorId, isReady } = useParam('id');
   const { loading, error, data } = useSponsorQuery({
     variables: { sponsorId },
   });
 
-  if (loading) {
+  if (loading || !isReady) {
     return <h1>Loading the sponsor details</h1>;
   }
 

--- a/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
@@ -17,8 +17,10 @@ export const EditVenuePage: NextPage = () => {
   const [loadingUpdate, setLoadingUpdate] = useState(false);
 
   const router = useRouter();
-  const { param: venueId } = useParam('venueId');
-  const { param: chapterId } = useParam('id');
+  const { param: venueId, isReady: isVenueIdReady } = useParam('venueId');
+  const { param: chapterId, isReady: isChapterIdReady } = useParam('id');
+
+  const isReady = isVenueIdReady && isChapterIdReady;
 
   const { loading, error, data } = useVenueQuery({
     variables: { id: venueId },
@@ -50,10 +52,10 @@ export const EditVenuePage: NextPage = () => {
     }
   };
 
-  if (loading || error || !data?.venue) {
+  if (loading || !isReady || error || !data?.venue) {
     return (
       <Layout>
-        <h1>{loading ? 'Loading...' : 'Error...'}</h1>
+        <h1>{loading || !isReady ? 'Loading...' : 'Error...'}</h1>
         {error && <div className={styles.error}>{error.message}</div>}
       </Layout>
     );

--- a/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
@@ -10,16 +10,16 @@ import styles from '../../../../styles/Page.module.css';
 import { Layout } from '../../shared/components/Layout';
 
 export const VenuePage: NextPage = () => {
-  const { param: venueId } = useParam('id');
+  const { param: venueId, isReady } = useParam('id');
 
   const { loading, error, data } = useVenueQuery({
     variables: { id: venueId },
   });
 
-  if (loading || error || !data?.venue) {
+  if (loading || !isReady || error || !data?.venue) {
     return (
       <Layout>
-        <h1>{loading ? 'Loading...' : 'Error...'}</h1>
+        <h1>{loading || !isReady ? 'Loading...' : 'Error...'}</h1>
         {error && <div className={styles.error}>{error.message}</div>}
       </Layout>
     );

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -34,7 +34,7 @@ import {
 import { useParam } from 'hooks/useParam';
 
 export const EventPage: NextPage = () => {
-  const { param: eventId } = useParam('eventId');
+  const { param: eventId, isReady } = useParam('eventId');
   const router = useRouter();
   const { user } = useAuth();
 
@@ -71,7 +71,7 @@ export const EventPage: NextPage = () => {
     if (allDataLoaded && canCheckRsvp) checkOnRsvp();
   }, [allDataLoaded, canCheckRsvp]);
 
-  if (loading) {
+  if (loading || !isReady) {
     return <h1>Loading...</h1>;
   }
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- When page with url param is opened, url param isn't loaded instantly, but at least one render happens when param is `-1`. Query for something with `-1` usually ends up with error (or error-like state, when `!loading`, but also no proper `data` - `!data`). That change `loading -> !data/error` is usually reflected on page with some kind of _error_, which quickly disappears, when url param is finally loaded. Query goes back to the `loading`, and after getting the correct data rendering it.
- Change uses the previously added `isReady`, to render after url param is loaded, what limits the irrelevant quick state changes visible on the page.
- I hope I changed it in all relevant files.
- Unifying when and how `loading`, `error`, etc. are rendered could be a good idea, also on other pages. Currently almost every page does it in own, slightly different, way.