### PR TITLE
chore: unify imports from /modules/dashboard/Sponsors

### DIFF
--- a/client/src/modules/dashboard/Sponsors/index.ts
+++ b/client/src/modules/dashboard/Sponsors/index.ts
@@ -1,3 +1,4 @@
+export { SponsorPage } from './pages/SponsorPage';
 export { SponsorsPage } from './pages/SponsorsPage';
 export { NewSponsorPage } from './pages/NewSponsorPage';
 export { EditSponsorPage } from './pages/EditSponsorPage';

--- a/client/src/pages/dashboard/sponsors/[id]/edit.tsx
+++ b/client/src/pages/dashboard/sponsors/[id]/edit.tsx
@@ -1,3 +1,3 @@
-import { EditSponsorPage } from '../../../../modules/dashboard/Sponsors/pages/EditSponsorPage';
+import { EditSponsorPage } from '../../../../modules/dashboard/Sponsors';
 
 export default EditSponsorPage;

--- a/client/src/pages/dashboard/sponsors/[id]/index.tsx
+++ b/client/src/pages/dashboard/sponsors/[id]/index.tsx
@@ -1,3 +1,3 @@
-import { SponsorPage } from '../../../../modules/dashboard/Sponsors/pages/SponsorPage';
+import { SponsorPage } from '../../../../modules/dashboard/Sponsors';
 
 export default SponsorPage;

--- a/client/src/pages/dashboard/sponsors/index.tsx
+++ b/client/src/pages/dashboard/sponsors/index.tsx
@@ -1,3 +1,3 @@
-import { SponsorsPage } from '../../../modules/dashboard/Sponsors/index';
+import { SponsorsPage } from '../../../modules/dashboard/Sponsors';
 
 export default SponsorsPage;

--- a/client/src/pages/dashboard/sponsors/new.tsx
+++ b/client/src/pages/dashboard/sponsors/new.tsx
@@ -1,2 +1,2 @@
-import { NewSponsorPage } from '../../../modules/dashboard/Sponsors/pages/NewSponsorPage';
+import { NewSponsorPage } from '../../../modules/dashboard/Sponsors';
 export default NewSponsorPage;


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- When skimming other PR I've noticed on the CodeSee map - https://app.codesee.io/maps/review/github/freeCodeCamp/chapter/pr/1481 - that one module is not like others.
- This change unifies imports for Sponsors with how it's done in other files.