### PR TITLE
fix: Popper console warning on Menu click

### DIFF
--- a/client/src/components/PageLayout/Header.tsx
+++ b/client/src/components/PageLayout/Header.tsx
@@ -1,6 +1,7 @@
 import { HStack } from '@chakra-ui/layout';
 import {
   Avatar,
+  Box,
   Button,
   Flex,
   Image,
@@ -98,45 +99,47 @@ export const Header: React.FC = () => {
           />
         </Link>
         <HStack as="nav">
-          <Menu>
-            <MenuButton
-              as={Button}
-              aria-label="Options"
-              variant="outline"
-              background={'gray.10'}
-              px={[2, 4]}
-              py={[1, 2]}
-            >
-              Menu
-            </MenuButton>
-            <MenuList>
-              <Flex className={styles.header} flexDirection={'column'}>
-                <NextLink passHref href="/chapters">
-                  <MenuItem as="a">Chapters</MenuItem>
-                </NextLink>
+          <Box>
+            <Menu>
+              <MenuButton
+                as={Button}
+                aria-label="Options"
+                variant="outline"
+                background={'gray.10'}
+                px={[2, 4]}
+                py={[1, 2]}
+              >
+                Menu
+              </MenuButton>
+              <MenuList>
+                <Flex className={styles.header} flexDirection={'column'}>
+                  <NextLink passHref href="/chapters">
+                    <MenuItem as="a">Chapters</MenuItem>
+                  </NextLink>
 
-                <NextLink passHref href="/events">
-                  <MenuItem as="a">Events</MenuItem>
-                </NextLink>
+                  <NextLink passHref href="/events">
+                    <MenuItem as="a">Events</MenuItem>
+                  </NextLink>
 
-                {user ? (
-                  <>
-                    <NextLink passHref href="/dashboard/chapters">
-                      <MenuItem as="a">Dashboard</MenuItem>
-                    </NextLink>
+                  {user ? (
+                    <>
+                      <NextLink passHref href="/dashboard/chapters">
+                        <MenuItem as="a">Dashboard</MenuItem>
+                      </NextLink>
 
-                    <MenuItem data-cy="logout-button" onClick={logout}>
-                      Logout
-                    </MenuItem>
-                  </>
-                ) : process.env.NEXT_PUBLIC_ENVIRONMENT === 'development' ? (
-                  <DevLoginButton />
-                ) : (
-                  <LoginButton />
-                )}
-              </Flex>
-            </MenuList>
-          </Menu>
+                      <MenuItem data-cy="logout-button" onClick={logout}>
+                        Logout
+                      </MenuItem>
+                    </>
+                  ) : process.env.NEXT_PUBLIC_ENVIRONMENT === 'development' ? (
+                    <DevLoginButton />
+                  ) : (
+                    <LoginButton />
+                  )}
+                </Flex>
+              </MenuList>
+            </Menu>
+          </Box>
 
           {user ? (
             <>


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Workarounds console warning when clicking Menu per https://github.com/chakra-ui/chakra-ui/issues/3440#issuecomment-851707911

<details>
<summary>Popper: CSS "margin" styles cannot be used to apply padding between the popper and its reference element or boundary.</summary>

```
Popper: CSS "margin" styles cannot be used to apply padding between the popper and its reference element or boundary. To replicate margin, use the `offset` modifier, as well as the `padding` option in the `preventOverflow` and `flip` modifiers. 
div
withEmotionCache/<@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66
MenuList<@webpack-internal:///../node_modules/@chakra-ui/menu/dist/index.esm.js:859:34
Menu@webpack-internal:///../node_modules/@chakra-ui/menu/dist/index.esm.js:626:24
nav
withEmotionCache/<@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66
Stack<@webpack-internal:///../node_modules/@chakra-ui/layout/dist/index.esm.js:725:7
HStack
header
withEmotionCache/<@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66
Flex2@webpack-internal:///../node_modules/@chakra-ui/layout/dist/index.esm.js:273:77
Header@webpack-internal:///./src/components/PageLayout/Header.tsx:801:97
PageLayout@webpack-internal:///./src/components/PageLayout/index.tsx:103:18
ConfirmContextProvider@webpack-internal:///../node_modules/chakra-confirm/dist/chakra-confirm.esm.js:223:18
AuthContextProvider@webpack-internal:///./src/modules/auth/store/index.tsx:666:18
ConditionalWrap@webpack-internal:///./src/pages/_app.tsx:772:14
EnvironmentProvider@webpack-internal:///../node_modules/@chakra-ui/react-env/dist/index.esm.js:121:54
ColorModeProvider@webpack-internal:///../node_modules/@chakra-ui/provider/node_modules/@chakra-ui/color-mode/dist/index.esm.js:166:7
ThemeProvider@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:96:64
ThemeProvider@webpack-internal:///../node_modules/@chakra-ui/provider/node_modules/@chakra-ui/system/dist/index.esm.js:112:44
ChakraProvider@webpack-internal:///../node_modules/@chakra-ui/provider/dist/index.esm.js:28:7
ChakraProvider@webpack-internal:///../node_modules/@chakra-ui/react/dist/index.esm.js:244:24
ApolloProvider@webpack-internal:///../node_modules/@apollo/client/react/context/ApolloProvider.js:12:18
CustomApp@webpack-internal:///./src/pages/_app.tsx:812:19
ErrorBoundary@webpack-internal:///../node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:20740
ReactDevOverlay@webpack-internal:///../node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:23630
Container@webpack-internal:///../node_modules/next/dist/client/index.js:111:20
AppContainer@webpack-internal:///../node_modules/next/dist/client/index.js:721:18
Root@webpack-internal:///../node_modules/next/dist/client/index.js:858:19
```

</details>