### PR TITLE
fix: ensure event start is not after end

### DIFF
--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -93,8 +93,8 @@ const EventForm: React.FC<EventFormProps> = (props) => {
       url: data.url,
       streaming_url: data.streaming_url,
       capacity: data.capacity,
-      start_at: data.start_at,
-      ends_at: data.ends_at,
+      start_at: new Date(data.start_at),
+      ends_at: new Date(data.ends_at),
       sponsors: data.sponsors,
       tags: (data.tags || []).map(({ tag }) => tag.name).join(', '),
       venue_type: data.venue_type,
@@ -157,10 +157,12 @@ const EventForm: React.FC<EventFormProps> = (props) => {
   const onDatePickerChange = useCallback(
     (key: string) => {
       return (date: Date | null) => {
-        if (key === 'start_at' && date) {
+        if (!date) return;
+        if (key === 'start_at' || date < getValues('start_at')) {
           setValue('start_at', date, { shouldDirty: true });
           setStartDate(date);
-        } else if (key === 'ends_at' && date) {
+        }
+        if (key === 'ends_at' || date > getValues('ends_at')) {
           setValue('ends_at', date, { shouldDirty: true });
           setEndDate(date);
         }


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #1508

---
- Prevents event start and end times mismatch.
  - When _Start at_ is changed to be after _End at_, the _End at_ is set to _Start at_ as well.
  - When _End at_ is changed to be before _Start at_, the _Start at_ is set to _End at_ as well.