### PR TITLE
fix: let docker use google keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       context: .
       dockerfile: server.Dockerfile
     working_dir: /usr/chapter/server
+    volumes:
+      - ./server/keys/:/usr/chapter/server/keys/
     ports:
       - "5000:5000"
     image: chapter-app


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

This should make the oauth2 keys available for use in production.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
