### PR TITLE
fix: defer loading until the router is ready

### DIFF
--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -12,15 +12,15 @@ import {
 } from '@chakra-ui/react';
 import { CheckIcon } from '@chakra-ui/icons';
 import { NextPage } from 'next';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { useConfirm } from 'chakra-confirm';
 import { CHAPTER_USER } from '../graphql/queries';
 import { useAuth } from '../../auth/store';
 import { EventCard } from 'components/EventCard';
 import {
-  useChapterQuery,
-  useChapterUserQuery,
+  useChapterLazyQuery,
+  useChapterUserLazyQuery,
   useJoinChapterMutation,
   useToggleChapterSubscriptionMutation,
 } from 'generated/graphql';
@@ -30,17 +30,26 @@ export const ChapterPage: NextPage = () => {
   const { param: chapterId, isReady } = useParam('chapterId');
   const { user } = useAuth();
 
-  const { loading, error, data } = useChapterQuery({
+  const [getChapter, { loading, error, data }] = useChapterLazyQuery({
     variables: { chapterId },
   });
 
   const confirm = useConfirm();
   const toast = useToast();
 
-  const { loading: loadingChapterUser, data: dataChapterUser } =
-    useChapterUserQuery({
-      variables: { chapterId },
-    });
+  const [
+    getChapterUsers,
+    { loading: loadingChapterUser, data: dataChapterUser },
+  ] = useChapterUserLazyQuery({
+    variables: { chapterId },
+  });
+
+  useEffect(() => {
+    if (isReady) {
+      getChapter();
+      getChapterUsers();
+    }
+  }, [isReady]);
 
   const refetch = {
     refetchQueries: [{ query: CHAPTER_USER, variables: { chapterId } }],

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -12,12 +12,12 @@ import {
 } from '@chakra-ui/react';
 import { DataTable } from 'chakra-data-table';
 import { NextPage } from 'next';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { useConfirm } from 'chakra-confirm';
 import {
   useBanUserMutation,
-  useChapterUsersQuery,
+  useChapterUsersLazyQuery,
   useChapterRolesQuery,
   useChangeChapterUserRoleMutation,
   useUnbanUserMutation,
@@ -33,9 +33,14 @@ import { CHAPTER_USERS } from '../../../../chapters/graphql/queries';
 export const ChapterUsersPage: NextPage = () => {
   const { param: chapterId, isReady } = useParam('id');
 
-  const { loading, error, data } = useChapterUsersQuery({
+  const [getChapterUsers, { loading, error, data }] = useChapterUsersLazyQuery({
     variables: { chapterId },
   });
+
+  useEffect(() => {
+    if (isReady) getChapterUsers();
+  }, [isReady]);
+
   const { data: chapterRoles } = useChapterRolesQuery();
   const modalProps = useDisclosure();
 

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -1,10 +1,10 @@
 import { Heading, Link, Box, HStack } from '@chakra-ui/layout';
 import { LinkButton } from 'chakra-next-link';
 import { NextPage } from 'next';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Card } from '../../../../components/Card';
 import ProgressCardContent from '../../../../components/ProgressCardContent';
-import { useChapterQuery } from '../../../../generated/graphql';
+import { useChapterLazyQuery } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
 import styles from '../../../../styles/Page.module.css';
 import { Layout } from '../../shared/components/Layout';
@@ -12,9 +12,13 @@ import { Layout } from '../../shared/components/Layout';
 export const ChapterPage: NextPage = () => {
   const { param: chapterId, isReady } = useParam('id');
 
-  const { loading, error, data } = useChapterQuery({
+  const [getChapter, { loading, error, data }] = useChapterLazyQuery({
     variables: { chapterId },
   });
+
+  useEffect(() => {
+    if (isReady) getChapter();
+  }, [isReady]);
 
   if (loading || !isReady || error || !data?.chapter) {
     return (

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -1,9 +1,9 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
-  useChapterQuery,
+  useChapterLazyQuery,
   useUpdateChapterMutation,
 } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
@@ -18,9 +18,14 @@ export const EditChapterPage: NextPage = () => {
 
   const { param: chapterId, isReady } = useParam('id');
 
-  const { loading, error, data } = useChapterQuery({
+  const [getChapter, { loading, error, data }] = useChapterLazyQuery({
     variables: { chapterId },
   });
+
+  useEffect(() => {
+    if (isReady) getChapter();
+  }, [isReady]);
+
   const [updateChapter] = useUpdateChapterMutation({
     refetchQueries: [{ query: CHAPTERS }],
   });

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -1,10 +1,10 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useToast } from '@chakra-ui/react';
 
 import {
-  useEventQuery,
+  useEventLazyQuery,
   useUpdateEventMutation,
 } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
@@ -20,13 +20,13 @@ export const EditEventPage: NextPage = () => {
   const [loadingUpdate, setLoadingUpdate] = useState<boolean>(false);
   const { param: eventId, isReady } = useParam();
 
-  const {
-    loading: eventLoading,
-    error,
-    data,
-  } = useEventQuery({
+  const [getEvent, { loading, error, data }] = useEventLazyQuery({
     variables: { eventId: eventId },
   });
+
+  useEffect(() => {
+    if (isReady) getEvent();
+  }, [isReady]);
 
   const toast = useToast();
 
@@ -86,10 +86,10 @@ export const EditEventPage: NextPage = () => {
     }
   };
 
-  if (eventLoading || !isReady || error || !data?.event) {
+  if (loading || !isReady || error || !data?.event) {
     return (
       <Layout>
-        <h1>{eventLoading || !isReady ? 'Loading...' : 'Error...'}</h1>
+        <h1>{loading || !isReady ? 'Loading...' : 'Error...'}</h1>
         {error && <div>{error.message}</div>}
       </Layout>
     );

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -11,12 +11,12 @@ import { useConfirm, useConfirmDelete } from 'chakra-confirm';
 import { DataTable } from 'chakra-data-table';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import {
   useConfirmRsvpMutation,
   useDeleteRsvpMutation,
-  useEventQuery,
+  useEventLazyQuery,
   MutationConfirmRsvpArgs,
   MutationDeleteRsvpArgs,
 } from '../../../../generated/graphql';
@@ -35,9 +35,14 @@ const args = (eventId: number) => ({
 export const EventPage: NextPage = () => {
   const router = useRouter();
   const { param: eventId, isReady } = useParam('id');
-  const { loading, error, data } = useEventQuery({
+
+  const [getEvent, { loading, error, data }] = useEventLazyQuery({
     variables: { eventId },
   });
+
+  useEffect(() => {
+    if (isReady) getEvent();
+  }, [isReady]);
 
   const [confirmRsvpFn] = useConfirmRsvpMutation(args(eventId));
   const [kickRsvpFn] = useDeleteRsvpMutation(args(eventId));

--- a/client/src/modules/dashboard/Sponsors/pages/SponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/SponsorPage.tsx
@@ -1,18 +1,24 @@
 import { Flex, Heading, Link, Text } from '@chakra-ui/layout';
 import { NextPage } from 'next';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Card } from '../../../../components/Card';
 import ProgressCardContent from '../../../../components/ProgressCardContent';
-import { useSponsorQuery } from '../../../../generated/graphql';
+import { useSponsorLazyQuery } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
 import styles from '../../../../styles/Page.module.css';
 import { Layout } from '../../shared/components/Layout';
 
 export const SponsorPage: NextPage = () => {
   const { param: sponsorId, isReady } = useParam('id');
-  const { loading, error, data } = useSponsorQuery({
+  const [getSponsor, { loading, error, data }] = useSponsorLazyQuery({
     variables: { sponsorId },
   });
+
+  useEffect(() => {
+    if (isReady) {
+      getSponsor();
+    }
+  }, [isReady]);
 
   if (loading || !isReady) {
     return <h1>Loading the sponsor details</h1>;

--- a/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
@@ -1,9 +1,9 @@
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
-  useVenueQuery,
+  useVenueLazyQuery,
   useUpdateVenueMutation,
 } from '../../../../generated/graphql';
 
@@ -22,9 +22,14 @@ export const EditVenuePage: NextPage = () => {
 
   const isReady = isVenueIdReady && isChapterIdReady;
 
-  const { loading, error, data } = useVenueQuery({
+  const [getVenue, { loading, error, data }] = useVenueLazyQuery({
     variables: { id: venueId },
   });
+
+  useEffect(() => {
+    if (isReady) getVenue();
+  }, [isReady]);
+
   const [updateVenue] = useUpdateVenueMutation({
     refetchQueries: [{ query: VENUES }],
   });

--- a/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
@@ -1,9 +1,9 @@
 import { Heading, Text } from '@chakra-ui/layout';
 import { NextPage } from 'next';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Card } from '../../../../components/Card';
 import ProgressCardContent from '../../../../components/ProgressCardContent';
-import { useVenueQuery } from '../../../../generated/graphql';
+import { useVenueLazyQuery } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
 import getLocationString from '../../../../util/getLocationString';
 import styles from '../../../../styles/Page.module.css';
@@ -12,9 +12,13 @@ import { Layout } from '../../shared/components/Layout';
 export const VenuePage: NextPage = () => {
   const { param: venueId, isReady } = useParam('id');
 
-  const { loading, error, data } = useVenueQuery({
+  const [getVenue, { loading, error, data }] = useVenueLazyQuery({
     variables: { id: venueId },
   });
+
+  useEffect(() => {
+    if (isReady) getVenue();
+  }, [isReady]);
 
   if (loading || !isReady || error || !data?.venue) {
     return (

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -23,7 +23,7 @@ import SponsorsCard from '../../../components/SponsorsCard';
 import { EVENT } from '../../dashboard/Events/graphql/queries';
 import {
   useCancelRsvpMutation,
-  useEventQuery,
+  useEventLazyQuery,
   useJoinChapterMutation,
   useRsvpToEventMutation,
   useSubscribeToEventMutation,
@@ -45,10 +45,14 @@ export const EventPage: NextPage = () => {
   const [joinChapter] = useJoinChapterMutation(refetch);
   const [subscribeToEvent] = useSubscribeToEventMutation(refetch);
   const [unsubscribeFromEvent] = useUnsubscribeFromEventMutation(refetch);
-  // TODO: check if we need to default to -1 here
-  const { loading, error, data } = useEventQuery({
+
+  const [getEvent, { loading, error, data }] = useEventLazyQuery({
     variables: { eventId },
   });
+
+  useEffect(() => {
+    if (isReady) getEvent();
+  }, [isReady]);
 
   const toast = useToast();
   const confirm = useConfirm();


### PR DESCRIPTION
Without this the Apollo client makes an invalid request before the
router is ready.  This request can get canceled abruptly when the page
re-renders causing an InternalServerError: stream is not readable on
the server.


<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes https://github.com/freeCodeCamp/chapter/issues/1420

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
