### PR TITLE
feat: truncate website text

### DIFF
--- a/client/src/modules/dashboard/Sponsors/pages/SponsorsPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/SponsorsPage.tsx
@@ -100,9 +100,13 @@ export const SponsorsPage: NextPage = () => {
                           >
                             Edit
                           </LinkButton>
-                          {/* the slice is here to stop the overflow, ToDo not use slice */}
-                          <Text size={'sm'} wordBreak={'keep-all'}>
-                            {website.slice(7, -4)}
+                          <Text
+                            size={'sm'}
+                            wordBreak="break-all"
+                            maxWidth="sm"
+                            noOfLines={1}
+                          >
+                            {website}
                           </Text>
                         </VStack>
                       ),


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Replaces website-link slicing with truncating text.
- `noOfLines === 1` adds the ellipsis when text exceeds the `maxWidth`.
- `maxWidth` is the attribute that can adjust how long text can be before truncating. `sm` value can be considered as a placeholder, if somebody has specific idea what put there instead.
- `wordBreak === 'break-all'` can break text on every character, while ie. `break-word` will break only on full words. In here that point will be the start of truncating.