### PR TITLE
test: change event venue deflaky

### DIFF
--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -153,7 +153,14 @@ describe('spec needing owner', () => {
     cy.createEvent(1, eventData).then((response) => {
       const eventId = response.body.data.createEvent.id;
       cy.visit(`/dashboard/events/${eventId}/edit`);
-      cy.findByRole('combobox', { name: 'Venue' })
+      cy.findByRole('combobox', { name: 'Venue' }).as('venuesSelect');
+
+      cy.get('@venuesSelect')
+        .find(':selected')
+        .invoke('val')
+        .should('equal', eventData.venue_id.toString());
+
+      cy.get('@venuesSelect')
         .select(newVenueId)
         .find(':checked')
         .invoke('text')
@@ -163,6 +170,7 @@ describe('spec needing owner', () => {
         .findByRole('button', {
           name: 'Save Event Changes',
         })
+        .should('be.enabled')
         .click();
 
       cy.location('pathname').should('match', /^\/dashboard\/events$/);

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -148,19 +148,15 @@ describe('spec needing owner', () => {
       ends_at: '2022-01-02T00:02',
       tags: 'Test, Event, Tag',
     };
-    const newVenueId = 2;
+    // It needs to be string to select by the value. When passing integer
+    // to the .select method, it will select option by the index.
+    const newVenueId = '2';
 
     cy.createEvent(1, eventData).then((response) => {
       const eventId = response.body.data.createEvent.id;
       cy.visit(`/dashboard/events/${eventId}/edit`);
-      cy.findByRole('combobox', { name: 'Venue' }).as('venuesSelect');
 
-      cy.get('@venuesSelect')
-        .find(':selected')
-        .invoke('val')
-        .should('equal', eventData.venue_id.toString());
-
-      cy.get('@venuesSelect')
+      cy.findByRole('combobox', { name: 'Venue' })
         .select(newVenueId)
         .find(':checked')
         .invoke('text')


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Test often failed because save button wasn't enabled when clicked. This suggests issue existing earlier, with dropdown not being recognized as dirtied.
- Change tries to ensure that dropdown is interacted with when venues are loaded, what would make save button enabled.