### PR TITLE
test: use deletable venue for deletion

### DIFF
--- a/cypress/e2e/dashboard/venues.cy.ts
+++ b/cypress/e2e/dashboard/venues.cy.ts
@@ -89,50 +89,66 @@ describe('venues dashboard', () => {
     const venueCreateVariables = {
       chapterId: 1,
     };
-    const venueUpdateDeleteVariables = {
+    const venueUpdateVariables = {
       chapterId: 1,
       venueId: 1,
     };
 
-    // logged out user
-    cy.logout();
+    // Create new venue, which is not used in any event
+    cy.createVenue(venueCreateVariables, venueData, { withAuth: true }).then(
+      (response) => {
+        const venueDeleteVariables = {
+          chapterId: 1,
+          venueId: response.body.data.createVenue.id,
+        };
 
-    cy.createVenue(venueCreateVariables, venueData, { withAuth: false }).then(
-      expectToBeRejected,
+        // logged out user
+        cy.logout();
+
+        cy.createVenue(venueCreateVariables, venueData, {
+          withAuth: false,
+        }).then(expectToBeRejected);
+        cy.updateVenue(venueUpdateVariables, venueData, {
+          withAuth: false,
+        }).then(expectToBeRejected);
+        cy.deleteVenue(venueDeleteVariables, { withAuth: false }).then(
+          expectToBeRejected,
+        );
+
+        // newly registered user (without a chapter_users record)
+        cy.login('test@user.org');
+
+        cy.createVenue(venueCreateVariables, venueData).then(
+          expectToBeRejected,
+        );
+        cy.updateVenue(venueUpdateVariables, venueData).then(
+          expectToBeRejected,
+        );
+        cy.deleteVenue(venueDeleteVariables).then(expectToBeRejected);
+
+        // banned user
+        cy.login('banned@chapter.admin');
+
+        cy.createVenue(venueCreateVariables, venueData).then(
+          expectToBeRejected,
+        );
+        cy.updateVenue(venueUpdateVariables, venueData).then(
+          expectToBeRejected,
+        );
+        cy.deleteVenue(venueDeleteVariables).then(expectToBeRejected);
+
+        // Admin of different chapter
+        cy.login('admin@of.chapter.two');
+
+        cy.createVenue(venueCreateVariables, venueData).then(
+          expectToBeRejected,
+        );
+        cy.updateVenue(venueUpdateVariables, venueData).then(
+          expectToBeRejected,
+        );
+        cy.deleteVenue(venueDeleteVariables).then(expectToBeRejected);
+      },
     );
-    cy.updateVenue(venueUpdateDeleteVariables, venueData, {
-      withAuth: false,
-    }).then(expectToBeRejected);
-    cy.deleteVenue(venueUpdateDeleteVariables, { withAuth: false }).then(
-      expectToBeRejected,
-    );
-
-    // newly registered user (without a chapter_users record)
-    cy.login('test@user.org');
-
-    cy.createVenue(venueCreateVariables, venueData).then(expectToBeRejected);
-    cy.updateVenue(venueUpdateDeleteVariables, venueData).then(
-      expectToBeRejected,
-    );
-    cy.deleteVenue(venueUpdateDeleteVariables).then(expectToBeRejected);
-
-    // banned user
-    cy.login('banned@chapter.admin');
-
-    cy.createVenue(venueCreateVariables, venueData).then(expectToBeRejected);
-    cy.updateVenue(venueUpdateDeleteVariables, venueData).then(
-      expectToBeRejected,
-    );
-    cy.deleteVenue(venueUpdateDeleteVariables).then(expectToBeRejected);
-
-    // Admin of different chapter
-    cy.login('admin@of.chapter.two');
-
-    cy.createVenue(venueCreateVariables, venueData).then(expectToBeRejected);
-    cy.updateVenue(venueUpdateDeleteVariables, venueData).then(
-      expectToBeRejected,
-    );
-    cy.deleteVenue(venueUpdateDeleteVariables).then(expectToBeRejected);
   });
 
   describe('adding venue with chapter selected in form', () => {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Changes venue used in test to one that can be deleted (not used in any event).
- Technically the venue shouldn't matter, as test should be stopped at the authorization. When that doesn't happen though, test can result with confusing error (see below), if the venue is still used in some event. This is to reduce that confusion when things don't work.
- Relevant test still can fail until #1548 makes logout more consistent.

```
Invalid prisma_1.prisma.venues.delete() invocation in
/usr/chapter/server/src/controllers/Venue/resolver.js:61:51
return await prisma_1.prisma.venues.delete(
Foreign key constraint failed on the field: events_venue_id_fkey (index) to equal **Access denied! You don't have permission for this action!**
```