### PR TITLE
chore: add custom error message

### DIFF
--- a/cypress/support/util.ts
+++ b/cypress/support/util.ts
@@ -1,7 +1,7 @@
 export function expectToBeRejected(response) {
   expect(response.status).to.eq(200);
   const errors = response.body?.errors;
-  expect(errors).to.have.length(1);
+  expect(errors, 'Expected response to contain one error').to.have.length(1);
   expect(errors[0].message).to.eq(
     "Access denied! You don't have permission for this action!",
   );


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Adds custom error message for when (rejected) response doesn't contain one error. It gives a bit of context when test fails, without the need to digging deeper into test. Goal is to improve over the default message:
>Target cannot be null or undefined.