### PR TITLE
feat: display toast after sending email

### DIFF
--- a/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
+++ b/client/src/modules/dashboard/Events/components/SendEmailModal.tsx
@@ -1,6 +1,12 @@
-import { Button } from '@chakra-ui/button';
-import { Checkbox } from '@chakra-ui/checkbox';
-import { Stack } from '@chakra-ui/layout';
+import {
+  Alert,
+  AlertIcon,
+  AlertDescription,
+  Button,
+  Checkbox,
+  Stack,
+  useToast,
+} from '@chakra-ui/react';
 import {
   Modal,
   ModalBody,
@@ -10,8 +16,7 @@ import {
   ModalFooter,
   ModalOverlay,
 } from '@chakra-ui/modal';
-import { Alert, AlertIcon, AlertDescription } from '@chakra-ui/react';
-import React from 'react';
+import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSendEventInviteMutation } from 'generated/graphql';
 interface SendEmailModalProps {
@@ -29,6 +34,7 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
   isOpen,
   eventId,
 }) => {
+  const [isLoading, setLoading] = useState(false);
   const {
     register,
     getValues,
@@ -45,7 +51,9 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
   };
 
   const [publish] = useSendEventInviteMutation();
-  const onSubmit = (data: FormInputs) => {
+  const toast = useToast();
+
+  const onSubmit = async (data: FormInputs) => {
     const emailGroups = [];
     if (data.confirmed) {
       emailGroups.push('confirmed');
@@ -56,7 +64,10 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
     if (data.on_waitlist) {
       emailGroups.push('on_waitlist');
     }
-    publish({ variables: { eventId, emailGroups } });
+    setLoading(true);
+    await publish({ variables: { eventId, emailGroups } });
+    setLoading(false);
+    toast({ title: 'Email sent', status: 'success' });
     onClose();
   };
   return (
@@ -107,6 +118,8 @@ const SendEmailModal: React.FC<SendEmailModalProps> = ({
             colorScheme={'blue'}
             variant="solid"
             form="sendemail"
+            isLoading={isLoading}
+            loadingText="Sending"
           >
             Send Email
           </Button>

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -79,6 +79,7 @@ describe('spec needing owner', () => {
   function sendAndCheckEmails(filterCallback, users) {
     cy.mhDeleteAll();
     cy.findByRole('button', { name: 'Send Email' }).click();
+    cy.contains('Email sent');
 
     cy.waitUntilMail('allMail');
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Adds toast after email(s) are send. This also changes to `await` for emails in client.
- Tries to lower flakiness of the relevant test.
- Changes test to check sent emails only after toast is displayed. Test was often failing with incorrect number of emails - `cy.waitUntilMail` was too fast and was getting lower number of emails than expected.
- Some alternative could be changing `cy.waitUntilMail` to keep waiting when number of emails caught by mailhog changes. Or more explicitly wait for a specific number of emails.
- Slightly unrelated, disables button when emails are being sent.