### PR TITLE
test: allow waiting for expected no. of emails

### DIFF
--- a/cypress/e2e/dashboard/chapters/[chapterId]/chapterId-index.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/chapterId-index.cy.ts
@@ -61,16 +61,17 @@ describe('chapter dashboard', () => {
       cy.contains(venueTitle);
     });
 
-    // check that the subscribed users have been emailed
-    cy.waitUntilMail('allMail');
-
     // TODO: select chapter during event creation and use that here (much like @venueTitle
     // ) i.e. remove the hardcoding.
     cy.getChapterMembers(1).then((members) => {
       const subscriberEmails = members
         .filter(({ subscribed }) => subscribed)
         .map(({ user: { email } }) => email);
-      cy.get('@allMail').should('have.length', subscriberEmails.length);
+
+      // check that the subscribed users have been emailed
+      cy.waitUntilMail({
+        expectedNumberOfEmails: subscriberEmails.length,
+      });
       subscriberEmails.forEach((subscriberEmail) => {
         cy.mhGetMailsByRecipient(subscriberEmail).as('currentRecipient');
         cy.get('@currentRecipient').should('have.length', 1);

--- a/cypress/e2e/dashboard/events/[eventId].cy.ts
+++ b/cypress/e2e/dashboard/events/[eventId].cy.ts
@@ -17,8 +17,7 @@ describe('event dashboard', () => {
         .findByRole('button', { name: 'Confirm' })
         .click();
 
-      cy.waitUntilMail('allMail');
-      cy.get('@allMail').mhFirst().as('email');
+      cy.waitUntilMail().mhFirst().as('email');
 
       cy.get<string>('@userName').then((userName) => {
         cy.get('@waitlist').not(`:contains(${userName})`);

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -81,12 +81,10 @@ describe('spec needing owner', () => {
     cy.findByRole('button', { name: 'Send Email' }).click();
     cy.contains('Email sent');
 
-    cy.waitUntilMail('allMail');
-
     const recipientEmails = users
       .filter(filterCallback)
       .map(({ user: { email } }) => email);
-    cy.get('@allMail').should('have.length', recipientEmails.length);
+    cy.waitUntilMail().should('have.length', recipientEmails.length);
     recipientEmails.forEach((recipientEmail) => {
       cy.mhGetMailsByRecipient(recipientEmail).as('currentRecipient');
       cy.get('@currentRecipient').should('have.length', 1);
@@ -115,8 +113,7 @@ describe('spec needing owner', () => {
       's',
     );
 
-    cy.waitUntilMail('email');
-    cy.get('@email')
+    cy.waitUntilMail()
       .mhFirst()
       .then((mail) => {
         const MIME = mail.MIME as {
@@ -168,9 +165,7 @@ describe('spec needing owner', () => {
 
       cy.location('pathname').should('match', /^\/dashboard\/events$/);
 
-      cy.waitUntilMail('allMail');
-
-      cy.get('@allMail').mhFirst().as('venueMail');
+      cy.waitUntilMail().mhFirst().as('venueMail');
 
       cy.get('@newVenueTitle').then((venueTitle) => {
         cy.get('@venueMail')
@@ -277,8 +272,7 @@ describe('spec needing owner', () => {
     cy.findByRole('button', { name: 'Cancel' }).click();
     cy.findByRole('alertdialog').findByText('Confirm').click();
 
-    cy.waitUntilMail('allMail');
-    cy.get('@allMail').mhFirst().as('emails');
+    cy.waitUntilMail().mhFirst().as('emails');
 
     cy.url()
       .then((url) => parseInt(url.match(/\d+$/)[0], 10))

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -181,16 +181,20 @@ Cypress.Commands.add('getEventUsers', getEventUsers);
  * Wait until emails are received by mailhog
  * @param alias Name of the alias to reference emails by
  */
-const waitUntilMail = (alias?: string) => {
-  cy.waitUntil(() =>
+
+function waitUntilMail(args?: {
+  alias?: string;
+  expectedNumberOfEmails: number;
+}) {
+  const { alias, expectedNumberOfEmails = 1 } = args ?? {};
+  const checkMail = (mails: mailhog.Item[]) =>
+    mails?.length >= expectedNumberOfEmails ? mails : false;
+  return cy.waitUntil(() =>
     alias
-      ? cy
-          .mhGetAllMails()
-          .as(alias)
-          .then((mails) => mails?.length > 0)
-      : cy.mhGetAllMails().then((mails) => mails?.length > 0),
+      ? cy.mhGetAllMails().as(alias).then(checkMail)
+      : cy.mhGetAllMails().then(checkMail),
   );
-};
+}
 
 Cypress.Commands.add('waitUntilMail', waitUntilMail);
 


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

This should reduce flake since it always waits for the number of emails the next command requires.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
