### PR TITLE
fix: stop enforcing platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   app:
     restart: unless-stopped
     env_file: .env
-    platform: "linux/amd64"
     build:
       context: .
       dockerfile: server.Dockerfile


### PR DESCRIPTION
Unfortunately GitHub actions have recently started failing, seemingly
because they *sometimes* do not support linux/amd64.

This is a hotfix to get CI working again, but we will need to come up
with something for mac users.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->


<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
