### PR TITLE
feat: hide dashboards

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -4180,6 +4180,35 @@
             "deprecationReason": null
           },
           {
+            "name": "dashboardEvent",
+            "description": null,
+            "args": [
+              {
+                "name": "eventId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EventWithRelations",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "event",
             "description": null,
             "args": [

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -4555,7 +4555,7 @@
             "description": null,
             "args": [
               {
-                "name": "id",
+                "name": "venueId",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -4009,9 +4009,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "ChapterWithRelations",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ChapterWithRelations",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4174,6 +4178,39 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dashboardChapter",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ChapterWithRelations",
+                "ofType": null
               }
             },
             "isDeprecated": false,

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -328,22 +328,6 @@
         "description": null,
         "fields": [
           {
-            "name": "canBeBanned",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "chapter_id",
             "description": null,
             "args": [],
@@ -369,6 +353,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "ChapterRole",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "is_bannable",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -56,9 +56,9 @@ export type ChapterRolePermission = {
 
 export type ChapterUser = {
   __typename?: 'ChapterUser';
-  canBeBanned: Scalars['Boolean'];
   chapter_id: Scalars['Int'];
   chapter_role: ChapterRole;
+  is_bannable: Scalars['Boolean'];
   joined_date: Scalars['DateTime'];
   subscribed: Scalars['Boolean'];
   user: User;
@@ -727,7 +727,7 @@ export type ChapterUsersQuery = {
     chapter_users: Array<{
       __typename?: 'ChapterUser';
       subscribed: boolean;
-      canBeBanned: boolean;
+      is_bannable: boolean;
       user: { __typename?: 'User'; id: number; name: string; email: string };
       chapter_role: { __typename?: 'ChapterRole'; id: number; name: string };
     }>;
@@ -1769,7 +1769,7 @@ export const ChapterUsersDocument = gql`
           name
         }
         subscribed
-        canBeBanned
+        is_bannable
       }
       user_bans {
         user {

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -431,12 +431,13 @@ export type PaginatedEventsWithTotal = {
 
 export type Query = {
   __typename?: 'Query';
-  chapter?: Maybe<ChapterWithRelations>;
+  chapter: ChapterWithRelations;
   chapterRoles: Array<ChapterRole>;
   chapterUser: ChapterUser;
   chapterUsers: Array<ChapterUser>;
   chapterVenues: Array<Venue>;
   chapters: Array<ChapterWithEvents>;
+  dashboardChapter: ChapterWithRelations;
   dashboardEvent?: Maybe<EventWithRelations>;
   event?: Maybe<EventWithRelations>;
   eventRoles: Array<EventRole>;
@@ -466,6 +467,10 @@ export type QueryChapterUsersArgs = {
 
 export type QueryChapterVenuesArgs = {
   chapterId: Scalars['Int'];
+};
+
+export type QueryDashboardChapterArgs = {
+  id: Scalars['Int'];
 };
 
 export type QueryDashboardEventArgs = {
@@ -693,7 +698,7 @@ export type ChapterQueryVariables = Exact<{
 
 export type ChapterQuery = {
   __typename?: 'Query';
-  chapter?: {
+  chapter: {
     __typename?: 'ChapterWithRelations';
     id: number;
     name: string;
@@ -718,7 +723,7 @@ export type ChapterQuery = {
         tag: { __typename?: 'Tag'; id: number; name: string };
       }>;
     }>;
-  } | null;
+  };
 };
 
 export type ChapterUsersQueryVariables = Exact<{
@@ -727,7 +732,7 @@ export type ChapterUsersQueryVariables = Exact<{
 
 export type ChapterUsersQuery = {
   __typename?: 'Query';
-  chapter?: {
+  chapter: {
     __typename?: 'ChapterWithRelations';
     chapter_users: Array<{
       __typename?: 'ChapterUser';
@@ -740,7 +745,7 @@ export type ChapterUsersQuery = {
       __typename?: 'UserBan';
       user: { __typename?: 'User'; id: number };
     }>;
-  } | null;
+  };
 };
 
 export type ChapterUserQueryVariables = Exact<{
@@ -868,6 +873,40 @@ export type ChapterRolesQueryVariables = Exact<{ [key: string]: never }>;
 export type ChapterRolesQuery = {
   __typename?: 'Query';
   chapterRoles: Array<{ __typename?: 'ChapterRole'; id: number; name: string }>;
+};
+
+export type DashboardChapterQueryVariables = Exact<{
+  chapterId: Scalars['Int'];
+}>;
+
+export type DashboardChapterQuery = {
+  __typename?: 'Query';
+  dashboardChapter: {
+    __typename?: 'ChapterWithRelations';
+    id: number;
+    name: string;
+    description: string;
+    category: string;
+    city: string;
+    region: string;
+    country: string;
+    image_url: string;
+    chat_url?: string | null;
+    events: Array<{
+      __typename?: 'Event';
+      id: number;
+      name: string;
+      description: string;
+      start_at: any;
+      invite_only: boolean;
+      canceled: boolean;
+      image_url: string;
+      tags: Array<{
+        __typename?: 'EventTag';
+        tag: { __typename?: 'Tag'; id: number; name: string };
+      }>;
+    }>;
+  };
 };
 
 export type CreateEventMutationVariables = Exact<{
@@ -2348,6 +2387,89 @@ export type ChapterRolesLazyQueryHookResult = ReturnType<
 export type ChapterRolesQueryResult = Apollo.QueryResult<
   ChapterRolesQuery,
   ChapterRolesQueryVariables
+>;
+export const DashboardChapterDocument = gql`
+  query dashboardChapter($chapterId: Int!) {
+    dashboardChapter(id: $chapterId) {
+      id
+      name
+      description
+      category
+      city
+      region
+      country
+      image_url
+      chat_url
+      events {
+        id
+        name
+        description
+        start_at
+        invite_only
+        canceled
+        image_url
+        tags {
+          tag {
+            id
+            name
+          }
+        }
+        invite_only
+        canceled
+      }
+    }
+  }
+`;
+
+/**
+ * __useDashboardChapterQuery__
+ *
+ * To run a query within a React component, call `useDashboardChapterQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDashboardChapterQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useDashboardChapterQuery({
+ *   variables: {
+ *      chapterId: // value for 'chapterId'
+ *   },
+ * });
+ */
+export function useDashboardChapterQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    DashboardChapterQuery,
+    DashboardChapterQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<DashboardChapterQuery, DashboardChapterQueryVariables>(
+    DashboardChapterDocument,
+    options,
+  );
+}
+export function useDashboardChapterLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    DashboardChapterQuery,
+    DashboardChapterQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    DashboardChapterQuery,
+    DashboardChapterQueryVariables
+  >(DashboardChapterDocument, options);
+}
+export type DashboardChapterQueryHookResult = ReturnType<
+  typeof useDashboardChapterQuery
+>;
+export type DashboardChapterLazyQueryHookResult = ReturnType<
+  typeof useDashboardChapterLazyQuery
+>;
+export type DashboardChapterQueryResult = Apollo.QueryResult<
+  DashboardChapterQuery,
+  DashboardChapterQueryVariables
 >;
 export const CreateEventDocument = gql`
   mutation createEvent($chapterId: Int!, $data: CreateEventInputs!) {

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -2414,8 +2414,6 @@ export const DashboardChapterDocument = gql`
             name
           }
         }
-        invite_only
-        canceled
       }
     }
   }

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -726,13 +726,13 @@ export type ChapterQuery = {
   };
 };
 
-export type ChapterUsersQueryVariables = Exact<{
+export type DashboardChapterUsersQueryVariables = Exact<{
   chapterId: Scalars['Int'];
 }>;
 
-export type ChapterUsersQuery = {
+export type DashboardChapterUsersQuery = {
   __typename?: 'Query';
-  chapter: {
+  dashboardChapter: {
     __typename?: 'ChapterWithRelations';
     chapter_users: Array<{
       __typename?: 'ChapterUser';
@@ -1805,9 +1805,9 @@ export type ChapterQueryResult = Apollo.QueryResult<
   ChapterQuery,
   ChapterQueryVariables
 >;
-export const ChapterUsersDocument = gql`
-  query chapterUsers($chapterId: Int!) {
-    chapter(id: $chapterId) {
+export const DashboardChapterUsersDocument = gql`
+  query dashboardChapterUsers($chapterId: Int!) {
+    dashboardChapter(id: $chapterId) {
       chapter_users {
         user {
           id
@@ -1831,54 +1831,54 @@ export const ChapterUsersDocument = gql`
 `;
 
 /**
- * __useChapterUsersQuery__
+ * __useDashboardChapterUsersQuery__
  *
- * To run a query within a React component, call `useChapterUsersQuery` and pass it any options that fit your needs.
- * When your component renders, `useChapterUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useDashboardChapterUsersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDashboardChapterUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useChapterUsersQuery({
+ * const { data, loading, error } = useDashboardChapterUsersQuery({
  *   variables: {
  *      chapterId: // value for 'chapterId'
  *   },
  * });
  */
-export function useChapterUsersQuery(
+export function useDashboardChapterUsersQuery(
   baseOptions: Apollo.QueryHookOptions<
-    ChapterUsersQuery,
-    ChapterUsersQueryVariables
+    DashboardChapterUsersQuery,
+    DashboardChapterUsersQueryVariables
   >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<ChapterUsersQuery, ChapterUsersQueryVariables>(
-    ChapterUsersDocument,
-    options,
-  );
+  return Apollo.useQuery<
+    DashboardChapterUsersQuery,
+    DashboardChapterUsersQueryVariables
+  >(DashboardChapterUsersDocument, options);
 }
-export function useChapterUsersLazyQuery(
+export function useDashboardChapterUsersLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    ChapterUsersQuery,
-    ChapterUsersQueryVariables
+    DashboardChapterUsersQuery,
+    DashboardChapterUsersQueryVariables
   >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<ChapterUsersQuery, ChapterUsersQueryVariables>(
-    ChapterUsersDocument,
-    options,
-  );
+  return Apollo.useLazyQuery<
+    DashboardChapterUsersQuery,
+    DashboardChapterUsersQueryVariables
+  >(DashboardChapterUsersDocument, options);
 }
-export type ChapterUsersQueryHookResult = ReturnType<
-  typeof useChapterUsersQuery
+export type DashboardChapterUsersQueryHookResult = ReturnType<
+  typeof useDashboardChapterUsersQuery
 >;
-export type ChapterUsersLazyQueryHookResult = ReturnType<
-  typeof useChapterUsersLazyQuery
+export type DashboardChapterUsersLazyQueryHookResult = ReturnType<
+  typeof useDashboardChapterUsersLazyQuery
 >;
-export type ChapterUsersQueryResult = Apollo.QueryResult<
-  ChapterUsersQuery,
-  ChapterUsersQueryVariables
+export type DashboardChapterUsersQueryResult = Apollo.QueryResult<
+  DashboardChapterUsersQuery,
+  DashboardChapterUsersQueryVariables
 >;
 export const ChapterUserDocument = gql`
   query chapterUser($chapterId: Int!) {

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -1051,31 +1051,6 @@ export type EventQuery = {
   } | null;
 };
 
-export type EventVenuesQueryVariables = Exact<{
-  eventId: Scalars['Int'];
-}>;
-
-export type EventVenuesQuery = {
-  __typename?: 'Query';
-  event?: {
-    __typename?: 'EventWithRelations';
-    id: number;
-    name: string;
-    description: string;
-    url?: string | null;
-    streaming_url?: string | null;
-    capacity: number;
-    start_at: any;
-    ends_at: any;
-    tags: Array<{
-      __typename?: 'EventTag';
-      tag: { __typename?: 'Tag'; id: number; name: string };
-    }>;
-    venue?: { __typename?: 'Venue'; id: number } | null;
-  } | null;
-  venues: Array<{ __typename?: 'Venue'; id: number; name: string }>;
-};
-
 export type SponsorsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type SponsorsQuery = {
@@ -1088,13 +1063,6 @@ export type SponsorsQuery = {
     logo_path: string;
     type: string;
   }>;
-};
-
-export type EventRolesQueryVariables = Exact<{ [key: string]: never }>;
-
-export type EventRolesQuery = {
-  __typename?: 'Query';
-  eventRoles: Array<{ __typename?: 'EventRole'; id: number; name: string }>;
 };
 
 export type ChapterVenuesQueryVariables = Exact<{
@@ -1352,32 +1320,6 @@ export type PaginatedEventsWithTotalQuery = {
       };
     }>;
   };
-};
-
-export type MinEventsQueryVariables = Exact<{ [key: string]: never }>;
-
-export type MinEventsQuery = {
-  __typename?: 'Query';
-  events: Array<{
-    __typename?: 'EventWithRelations';
-    id: number;
-    name: string;
-    description: string;
-    start_at: any;
-    invite_only: boolean;
-    canceled: boolean;
-    image_url: string;
-    tags: Array<{
-      __typename?: 'EventTag';
-      tag: { __typename?: 'Tag'; id: number; name: string };
-    }>;
-    chapter: {
-      __typename?: 'Chapter';
-      id: number;
-      name: string;
-      category: string;
-    };
-  }>;
 };
 
 export type HomeQueryVariables = Exact<{
@@ -2890,82 +2832,6 @@ export type EventQueryResult = Apollo.QueryResult<
   EventQuery,
   EventQueryVariables
 >;
-export const EventVenuesDocument = gql`
-  query eventVenues($eventId: Int!) {
-    event(eventId: $eventId) {
-      id
-      name
-      description
-      url
-      streaming_url
-      capacity
-      start_at
-      ends_at
-      tags {
-        tag {
-          id
-          name
-        }
-      }
-      venue {
-        id
-      }
-    }
-    venues {
-      id
-      name
-    }
-  }
-`;
-
-/**
- * __useEventVenuesQuery__
- *
- * To run a query within a React component, call `useEventVenuesQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventVenuesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useEventVenuesQuery({
- *   variables: {
- *      eventId: // value for 'eventId'
- *   },
- * });
- */
-export function useEventVenuesQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    EventVenuesQuery,
-    EventVenuesQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<EventVenuesQuery, EventVenuesQueryVariables>(
-    EventVenuesDocument,
-    options,
-  );
-}
-export function useEventVenuesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    EventVenuesQuery,
-    EventVenuesQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<EventVenuesQuery, EventVenuesQueryVariables>(
-    EventVenuesDocument,
-    options,
-  );
-}
-export type EventVenuesQueryHookResult = ReturnType<typeof useEventVenuesQuery>;
-export type EventVenuesLazyQueryHookResult = ReturnType<
-  typeof useEventVenuesLazyQuery
->;
-export type EventVenuesQueryResult = Apollo.QueryResult<
-  EventVenuesQuery,
-  EventVenuesQueryVariables
->;
 export const SponsorsDocument = gql`
   query sponsors {
     sponsors {
@@ -3021,62 +2887,6 @@ export type SponsorsLazyQueryHookResult = ReturnType<
 export type SponsorsQueryResult = Apollo.QueryResult<
   SponsorsQuery,
   SponsorsQueryVariables
->;
-export const EventRolesDocument = gql`
-  query eventRoles {
-    eventRoles {
-      id
-      name
-    }
-  }
-`;
-
-/**
- * __useEventRolesQuery__
- *
- * To run a query within a React component, call `useEventRolesQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventRolesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useEventRolesQuery({
- *   variables: {
- *   },
- * });
- */
-export function useEventRolesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    EventRolesQuery,
-    EventRolesQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<EventRolesQuery, EventRolesQueryVariables>(
-    EventRolesDocument,
-    options,
-  );
-}
-export function useEventRolesLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    EventRolesQuery,
-    EventRolesQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<EventRolesQuery, EventRolesQueryVariables>(
-    EventRolesDocument,
-    options,
-  );
-}
-export type EventRolesQueryHookResult = ReturnType<typeof useEventRolesQuery>;
-export type EventRolesLazyQueryHookResult = ReturnType<
-  typeof useEventRolesLazyQuery
->;
-export type EventRolesQueryResult = Apollo.QueryResult<
-  EventRolesQuery,
-  EventRolesQueryVariables
 >;
 export const ChapterVenuesDocument = gql`
   query chapterVenues($chapterId: Int!) {
@@ -3990,78 +3800,6 @@ export type PaginatedEventsWithTotalLazyQueryHookResult = ReturnType<
 export type PaginatedEventsWithTotalQueryResult = Apollo.QueryResult<
   PaginatedEventsWithTotalQuery,
   PaginatedEventsWithTotalQueryVariables
->;
-export const MinEventsDocument = gql`
-  query minEvents {
-    events {
-      id
-      name
-      description
-      start_at
-      invite_only
-      canceled
-      image_url
-      tags {
-        tag {
-          id
-          name
-        }
-      }
-      chapter {
-        id
-        name
-        category
-      }
-    }
-  }
-`;
-
-/**
- * __useMinEventsQuery__
- *
- * To run a query within a React component, call `useMinEventsQuery` and pass it any options that fit your needs.
- * When your component renders, `useMinEventsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useMinEventsQuery({
- *   variables: {
- *   },
- * });
- */
-export function useMinEventsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    MinEventsQuery,
-    MinEventsQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<MinEventsQuery, MinEventsQueryVariables>(
-    MinEventsDocument,
-    options,
-  );
-}
-export function useMinEventsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    MinEventsQuery,
-    MinEventsQueryVariables
-  >,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<MinEventsQuery, MinEventsQueryVariables>(
-    MinEventsDocument,
-    options,
-  );
-}
-export type MinEventsQueryHookResult = ReturnType<typeof useMinEventsQuery>;
-export type MinEventsLazyQueryHookResult = ReturnType<
-  typeof useMinEventsLazyQuery
->;
-export type MinEventsQueryResult = Apollo.QueryResult<
-  MinEventsQuery,
-  MinEventsQueryVariables
 >;
 export const HomeDocument = gql`
   query home($limit: Int, $offset: Int) {

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -501,7 +501,7 @@ export type QuerySponsorArgs = {
 };
 
 export type QueryVenueArgs = {
-  id: Scalars['Int'];
+  venueId: Scalars['Int'];
 };
 
 export type Rsvp = {
@@ -1265,7 +1265,7 @@ export type VenuesQuery = {
 };
 
 export type VenueQueryVariables = Exact<{
-  id: Scalars['Int'];
+  venueId: Scalars['Int'];
 }>;
 
 export type VenueQuery = {
@@ -3657,8 +3657,8 @@ export type VenuesQueryResult = Apollo.QueryResult<
   VenuesQueryVariables
 >;
 export const VenueDocument = gql`
-  query venue($id: Int!) {
-    venue(id: $id) {
+  query venue($venueId: Int!) {
+    venue(venueId: $venueId) {
       id
       name
       street_address
@@ -3694,7 +3694,7 @@ export const VenueDocument = gql`
  * @example
  * const { data, loading, error } = useVenueQuery({
  *   variables: {
- *      id: // value for 'id'
+ *      venueId: // value for 'venueId'
  *   },
  * });
  */

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -437,6 +437,7 @@ export type Query = {
   chapterUsers: Array<ChapterUser>;
   chapterVenues: Array<Venue>;
   chapters: Array<ChapterWithEvents>;
+  dashboardEvent?: Maybe<EventWithRelations>;
   event?: Maybe<EventWithRelations>;
   eventRoles: Array<EventRole>;
   events: Array<EventWithRelations>;
@@ -465,6 +466,10 @@ export type QueryChapterUsersArgs = {
 
 export type QueryChapterVenuesArgs = {
   chapterId: Scalars['Int'];
+};
+
+export type QueryDashboardEventArgs = {
+  eventId: Scalars['Int'];
 };
 
 export type QueryEventArgs = {
@@ -987,13 +992,13 @@ export type EventsQuery = {
   }>;
 };
 
-export type EventQueryVariables = Exact<{
+export type DashboardEventQueryVariables = Exact<{
   eventId: Scalars['Int'];
 }>;
 
-export type EventQuery = {
+export type DashboardEventQuery = {
   __typename?: 'Query';
-  event?: {
+  dashboardEvent?: {
     __typename?: 'EventWithRelations';
     id: number;
     name: string;
@@ -1320,6 +1325,70 @@ export type PaginatedEventsWithTotalQuery = {
       };
     }>;
   };
+};
+
+export type EventQueryVariables = Exact<{
+  eventId: Scalars['Int'];
+}>;
+
+export type EventQuery = {
+  __typename?: 'Query';
+  event?: {
+    __typename?: 'EventWithRelations';
+    id: number;
+    name: string;
+    description: string;
+    url?: string | null;
+    invite_only: boolean;
+    streaming_url?: string | null;
+    canceled: boolean;
+    capacity: number;
+    start_at: any;
+    ends_at: any;
+    image_url: string;
+    venue_type: VenueType;
+    chapter: { __typename?: 'Chapter'; id: number; name: string };
+    tags: Array<{
+      __typename?: 'EventTag';
+      tag: { __typename?: 'Tag'; id: number; name: string };
+    }>;
+    sponsors: Array<{
+      __typename?: 'EventSponsor';
+      sponsor: {
+        __typename?: 'Sponsor';
+        name: string;
+        website: string;
+        logo_path: string;
+        type: string;
+        id: number;
+      };
+    }>;
+    venue?: {
+      __typename?: 'Venue';
+      id: number;
+      name: string;
+      street_address?: string | null;
+      city: string;
+      postal_code: string;
+      region: string;
+      country: string;
+    } | null;
+    event_users: Array<{
+      __typename?: 'EventUser';
+      subscribed: boolean;
+      rsvp: { __typename?: 'Rsvp'; name: string };
+      user: { __typename?: 'User'; id: number; name: string };
+      event_role: {
+        __typename?: 'EventRole';
+        id: number;
+        name: string;
+        event_role_permissions: Array<{
+          __typename?: 'EventRolePermission';
+          event_permission: { __typename?: 'EventPermission'; name: string };
+        }>;
+      };
+    }>;
+  } | null;
 };
 
 export type HomeQueryVariables = Exact<{
@@ -2726,9 +2795,9 @@ export type EventsQueryResult = Apollo.QueryResult<
   EventsQuery,
   EventsQueryVariables
 >;
-export const EventDocument = gql`
-  query event($eventId: Int!) {
-    event(eventId: $eventId) {
+export const DashboardEventDocument = gql`
+  query dashboardEvent($eventId: Int!) {
+    dashboardEvent(eventId: $eventId) {
       id
       name
       description
@@ -2793,44 +2862,54 @@ export const EventDocument = gql`
 `;
 
 /**
- * __useEventQuery__
+ * __useDashboardEventQuery__
  *
- * To run a query within a React component, call `useEventQuery` and pass it any options that fit your needs.
- * When your component renders, `useEventQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useDashboardEventQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDashboardEventQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useEventQuery({
+ * const { data, loading, error } = useDashboardEventQuery({
  *   variables: {
  *      eventId: // value for 'eventId'
  *   },
  * });
  */
-export function useEventQuery(
-  baseOptions: Apollo.QueryHookOptions<EventQuery, EventQueryVariables>,
+export function useDashboardEventQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    DashboardEventQuery,
+    DashboardEventQueryVariables
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<EventQuery, EventQueryVariables>(
-    EventDocument,
+  return Apollo.useQuery<DashboardEventQuery, DashboardEventQueryVariables>(
+    DashboardEventDocument,
     options,
   );
 }
-export function useEventLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<EventQuery, EventQueryVariables>,
+export function useDashboardEventLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    DashboardEventQuery,
+    DashboardEventQueryVariables
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<EventQuery, EventQueryVariables>(
-    EventDocument,
+  return Apollo.useLazyQuery<DashboardEventQuery, DashboardEventQueryVariables>(
+    DashboardEventDocument,
     options,
   );
 }
-export type EventQueryHookResult = ReturnType<typeof useEventQuery>;
-export type EventLazyQueryHookResult = ReturnType<typeof useEventLazyQuery>;
-export type EventQueryResult = Apollo.QueryResult<
-  EventQuery,
-  EventQueryVariables
+export type DashboardEventQueryHookResult = ReturnType<
+  typeof useDashboardEventQuery
+>;
+export type DashboardEventLazyQueryHookResult = ReturnType<
+  typeof useDashboardEventLazyQuery
+>;
+export type DashboardEventQueryResult = Apollo.QueryResult<
+  DashboardEventQuery,
+  DashboardEventQueryVariables
 >;
 export const SponsorsDocument = gql`
   query sponsors {
@@ -3800,6 +3879,112 @@ export type PaginatedEventsWithTotalLazyQueryHookResult = ReturnType<
 export type PaginatedEventsWithTotalQueryResult = Apollo.QueryResult<
   PaginatedEventsWithTotalQuery,
   PaginatedEventsWithTotalQueryVariables
+>;
+export const EventDocument = gql`
+  query event($eventId: Int!) {
+    event(eventId: $eventId) {
+      id
+      name
+      description
+      url
+      invite_only
+      streaming_url
+      canceled
+      capacity
+      start_at
+      ends_at
+      image_url
+      chapter {
+        id
+        name
+      }
+      tags {
+        tag {
+          id
+          name
+        }
+      }
+      sponsors {
+        sponsor {
+          name
+          website
+          logo_path
+          type
+          id
+        }
+      }
+      venue_type
+      venue {
+        id
+        name
+        street_address
+        city
+        postal_code
+        region
+        country
+      }
+      event_users {
+        rsvp {
+          name
+        }
+        user {
+          id
+          name
+        }
+        event_role {
+          id
+          name
+          event_role_permissions {
+            event_permission {
+              name
+            }
+          }
+        }
+        subscribed
+      }
+    }
+  }
+`;
+
+/**
+ * __useEventQuery__
+ *
+ * To run a query within a React component, call `useEventQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEventQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useEventQuery({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *   },
+ * });
+ */
+export function useEventQuery(
+  baseOptions: Apollo.QueryHookOptions<EventQuery, EventQueryVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<EventQuery, EventQueryVariables>(
+    EventDocument,
+    options,
+  );
+}
+export function useEventLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<EventQuery, EventQueryVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<EventQuery, EventQueryVariables>(
+    EventDocument,
+    options,
+  );
+}
+export type EventQueryHookResult = ReturnType<typeof useEventQuery>;
+export type EventLazyQueryHookResult = ReturnType<typeof useEventLazyQuery>;
+export type EventQueryResult = Apollo.QueryResult<
+  EventQuery,
+  EventQueryVariables
 >;
 export const HomeDocument = gql`
   query home($limit: Int, $offset: Int) {

--- a/client/src/modules/chapters/graphql/queries.ts
+++ b/client/src/modules/chapters/graphql/queries.ts
@@ -33,9 +33,9 @@ export const CHAPTER = gql`
   }
 `;
 
-export const CHAPTER_USERS = gql`
-  query chapterUsers($chapterId: Int!) {
-    chapter(id: $chapterId) {
+export const DASHBOARD_CHAPTER_USERS = gql`
+  query dashboardChapterUsers($chapterId: Int!) {
+    dashboardChapter(id: $chapterId) {
       chapter_users {
         user {
           id

--- a/client/src/modules/chapters/graphql/queries.ts
+++ b/client/src/modules/chapters/graphql/queries.ts
@@ -47,7 +47,7 @@ export const CHAPTER_USERS = gql`
           name
         }
         subscribed
-        canBeBanned
+        is_bannable
       }
       user_bans {
         user {

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -166,7 +166,7 @@ export const ChapterUsersPage: NextPage = () => {
                 </HStack>
               ),
               email: ({ user }) => user.email,
-              actions: ({ canBeBanned, user, chapter_role }) => (
+              actions: ({ is_bannable, user, chapter_role }) => (
                 <HStack>
                   <Button
                     data-cy="changeRole"
@@ -182,7 +182,7 @@ export const ChapterUsersPage: NextPage = () => {
                   >
                     Change
                   </Button>
-                  {canBeBanned &&
+                  {is_bannable &&
                     (bans.has(user.id) ? (
                       <Button
                         data-cy="unbanUser"
@@ -212,7 +212,7 @@ export const ChapterUsersPage: NextPage = () => {
         </Box>
         <Box display={{ base: 'block', lg: 'none' }}>
           {data.chapter.chapter_users.map(
-            ({ canBeBanned, user, chapter_role }, index) => (
+            ({ is_bannable, user, chapter_role }, index) => (
               <Flex key={index} marginBlock={'2em'}>
                 {data.chapter ? (
                   <DataTable
@@ -261,7 +261,7 @@ export const ChapterUsersPage: NextPage = () => {
                             >
                               Change
                             </Button>
-                            {canBeBanned &&
+                            {is_bannable &&
                               (bans.has(user.id) ? (
                                 <Button
                                   data-cy="unbanUser"

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -18,7 +18,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useConfirm } from 'chakra-confirm';
 import {
   useBanUserMutation,
-  useChapterUsersLazyQuery,
+  useDashboardChapterUsersLazyQuery,
   useChapterRolesQuery,
   useChangeChapterUserRoleMutation,
   useUnbanUserMutation,
@@ -30,14 +30,15 @@ import {
   RoleChangeModalData,
 } from '../../../shared/components/RoleChangeModal';
 import { useParam } from '../../../../../hooks/useParam';
-import { CHAPTER_USERS } from '../../../../chapters/graphql/queries';
+import { DASHBOARD_CHAPTER_USERS } from '../../../../chapters/graphql/queries';
 
 export const ChapterUsersPage: NextPage = () => {
   const { param: chapterId, isReady } = useParam('id');
 
-  const [getChapterUsers, { loading, error, data }] = useChapterUsersLazyQuery({
-    variables: { chapterId },
-  });
+  const [getChapterUsers, { loading, error, data }] =
+    useDashboardChapterUsersLazyQuery({
+      variables: { chapterId },
+    });
 
   useEffect(() => {
     if (isReady) getChapterUsers();
@@ -49,7 +50,9 @@ export const ChapterUsersPage: NextPage = () => {
   const [chapterUser, setChapterUser] = useState<RoleChangeModalData>();
 
   const refetch = {
-    refetchQueries: [{ query: CHAPTER_USERS, variables: { chapterId } }],
+    refetchQueries: [
+      { query: DASHBOARD_CHAPTER_USERS, variables: { chapterId } },
+    ],
   };
 
   const [changeRoleMutation] = useChangeChapterUserRoleMutation(refetch);
@@ -121,14 +124,14 @@ export const ChapterUsersPage: NextPage = () => {
   };
 
   const bans = useMemo(
-    () => new Set(data?.chapter?.user_bans.map((ban) => ban.user.id)),
-    [data?.chapter?.chapter_users, data?.chapter?.user_bans],
+    () => new Set(data?.dashboardChapter?.user_bans.map((ban) => ban.user.id)),
+    [data?.dashboardChapter?.chapter_users, data?.dashboardChapter?.user_bans],
   );
 
   const isLoading = loading || !isReady || !data;
   if (isLoading || error)
     return <DashboardLoading loading={isLoading} error={error} />;
-  if (!data.chapter)
+  if (!data.dashboardChapter)
     return <NextError statusCode={404} title="Chapter not found" />;
 
   return (
@@ -151,7 +154,7 @@ export const ChapterUsersPage: NextPage = () => {
         </Flex>
         <Box display={{ base: 'none', lg: 'block' }}>
           <DataTable
-            data={data.chapter.chapter_users}
+            data={data.dashboardChapter.chapter_users}
             tableProps={{ table: { 'aria-labelledby': 'page-heading' } }}
             keys={['name', 'email', 'role', 'actions'] as const}
             mapper={{
@@ -211,12 +214,12 @@ export const ChapterUsersPage: NextPage = () => {
           />
         </Box>
         <Box display={{ base: 'block', lg: 'none' }}>
-          {data.chapter.chapter_users.map(
+          {data.dashboardChapter.chapter_users.map(
             ({ is_bannable, user, chapter_role }, index) => (
               <Flex key={index} marginBlock={'2em'}>
-                {data.chapter ? (
+                {data.dashboardChapter ? (
                   <DataTable
-                    data={[data.chapter.chapter_users[index]]}
+                    data={[data.dashboardChapter.chapter_users[index]]}
                     keys={['type', 'actions'] as const}
                     showHeader={false}
                     tableProps={{

--- a/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
+++ b/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
@@ -4,7 +4,10 @@ import { useForm } from 'react-hook-form';
 import { Input } from '../../../../components/Form/Input';
 import { TextArea } from '../../../../components/Form/TextArea';
 import { Form } from '../../../../components/Form/Form';
-import type { Chapter, ChapterQuery } from '../../../../generated/graphql';
+import type {
+  Chapter,
+  DashboardChapterQuery,
+} from '../../../../generated/graphql';
 
 export type ChapterFormData = Omit<
   Chapter,
@@ -14,7 +17,7 @@ export type ChapterFormData = Omit<
 interface ChapterFormProps {
   loading: boolean;
   onSubmit: (data: ChapterFormData) => Promise<void>;
-  data?: ChapterQuery;
+  data?: DashboardChapterQuery;
   submitText: string;
   loadingText: string;
 }
@@ -89,7 +92,7 @@ const fields: Fields[] = [
 
 const ChapterForm: React.FC<ChapterFormProps> = (props) => {
   const { loading, onSubmit, data, submitText, loadingText } = props;
-  const chapter = data?.chapter;
+  const chapter = data?.dashboardChapter;
 
   const defaultValues: ChapterFormData = {
     name: chapter?.name ?? '',

--- a/client/src/modules/dashboard/Chapters/graphql/queries.ts
+++ b/client/src/modules/dashboard/Chapters/graphql/queries.ts
@@ -8,3 +8,36 @@ export const ChapterRoles = gql`
     }
   }
 `;
+
+export const DASHBOARD_CHAPTER = gql`
+  query dashboardChapter($chapterId: Int!) {
+    dashboardChapter(id: $chapterId) {
+      id
+      name
+      description
+      category
+      city
+      region
+      country
+      image_url
+      chat_url
+      events {
+        id
+        name
+        description
+        start_at
+        invite_only
+        canceled
+        image_url
+        tags {
+          tag {
+            id
+            name
+          }
+        }
+        invite_only
+        canceled
+      }
+    }
+  }
+`;

--- a/client/src/modules/dashboard/Chapters/graphql/queries.ts
+++ b/client/src/modules/dashboard/Chapters/graphql/queries.ts
@@ -35,8 +35,6 @@ export const DASHBOARD_CHAPTER = gql`
             name
           }
         }
-        invite_only
-        canceled
       }
     }
   }

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -10,7 +10,7 @@ import { LinkButton } from 'chakra-next-link';
 import { Card } from '../../../../components/Card';
 import ProgressCardContent from '../../../../components/ProgressCardContent';
 import {
-  useChapterLazyQuery,
+  useDashboardChapterLazyQuery,
   useDeleteChapterMutation,
 } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
@@ -42,7 +42,7 @@ export const ChapterPage: NextPage = () => {
     ],
   });
 
-  const [getChapter, { loading, error, data }] = useChapterLazyQuery({
+  const [getChapter, { loading, error, data }] = useDashboardChapterLazyQuery({
     variables: { chapterId },
   });
 
@@ -62,7 +62,7 @@ export const ChapterPage: NextPage = () => {
   const isLoading = loading || !isReady || !data;
   if (isLoading || error)
     return <DashboardLoading loading={isLoading} error={error} />;
-  if (!data.chapter)
+  if (!data.dashboardChapter)
     return <NextError statusCode={404} title="Chapter not found" />;
 
   return (
@@ -75,7 +75,7 @@ export const ChapterPage: NextPage = () => {
             fontWeight="semibold"
             marginBlock={'2'}
           >
-            {data.chapter.name}
+            {data.dashboardChapter.name}
           </Heading>
           <Box>
             <Link
@@ -108,7 +108,10 @@ export const ChapterPage: NextPage = () => {
           </HStack>
         </ProgressCardContent>
       </Card>
-      <EventsList title="Organized Events" events={data.chapter.events} />
+      <EventsList
+        title="Organized Events"
+        events={data.dashboardChapter.events}
+      />
     </Layout>
   );
 };

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 
 import {
-  useChapterLazyQuery,
+  useDashboardChapterLazyQuery,
   useUpdateChapterMutation,
 } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
@@ -18,7 +18,7 @@ export const EditChapterPage: NextPage = () => {
 
   const { param: chapterId, isReady } = useParam('id');
 
-  const [getChapter, { loading, error, data }] = useChapterLazyQuery({
+  const [getChapter, { loading, error, data }] = useDashboardChapterLazyQuery({
     variables: { chapterId },
   });
 

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -4,7 +4,8 @@ import { useConfirmDelete } from 'chakra-confirm';
 import { LinkButton } from 'chakra-next-link';
 import React, { useMemo } from 'react';
 import { CHAPTER } from '../../../chapters/graphql/queries';
-import { EVENT, EVENTS } from '../graphql/queries';
+import { DASHBOARD_EVENT, EVENTS } from '../graphql/queries';
+import { EVENT } from '../../../events/graphql/queries';
 import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 import EventCancelButton from './EventCancelButton';
 import SendEmailModal from './SendEmailModal';
@@ -32,6 +33,7 @@ const Actions: React.FC<ActionsProps> = ({
       refetchQueries: [
         { query: CHAPTER, variables: { chapterId: chapter_id } },
         { query: EVENT, variables: { eventId: event.id } },
+        { query: DASHBOARD_EVENT, variables: { eventId: event.id } },
         { query: EVENTS },
         { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
       ],

--- a/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
+++ b/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
@@ -2,7 +2,8 @@ import { Button, ButtonProps } from '@chakra-ui/react';
 import { useConfirm } from 'chakra-confirm';
 import React from 'react';
 import { Event, useCancelEventMutation } from '../../../../generated/graphql';
-import { EVENT, EVENTS } from '../graphql/queries';
+import { DASHBOARD_EVENT, EVENTS } from '../graphql/queries';
+import { EVENT } from '../../../events/graphql/queries';
 import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 
 interface EventCancelButtonProps {
@@ -28,6 +29,7 @@ const EventCancelButton = (props: EventCancelButtonProps) => {
     variables: { eventId: event.id },
     refetchQueries: [
       { query: EVENT, variables: { eventId: event.id } },
+      { query: DASHBOARD_EVENT, variables: { eventId: event.id } },
       { query: EVENTS },
       { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
     ],

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -93,34 +93,6 @@ export const EVENT = gql`
   }
 `;
 
-export const EVENT_WITH_VENU = gql`
-  query eventVenues($eventId: Int!) {
-    event(eventId: $eventId) {
-      id
-      name
-      description
-      url
-      streaming_url
-      capacity
-      start_at
-      ends_at
-      tags {
-        tag {
-          id
-          name
-        }
-      }
-      venue {
-        id
-      }
-    }
-    venues {
-      id
-      name
-    }
-  }
-`;
-
 export const Sponsors = gql`
   query sponsors {
     sponsors {
@@ -129,15 +101,6 @@ export const Sponsors = gql`
       website
       logo_path
       type
-    }
-  }
-`;
-
-export const EventRoles = gql`
-  query eventRoles {
-    eventRoles {
-      id
-      name
     }
   }
 `;

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -27,9 +27,9 @@ export const EVENTS = gql`
   }
 `;
 
-export const EVENT = gql`
-  query event($eventId: Int!) {
-    event(eventId: $eventId) {
+export const DASHBOARD_EVENT = gql`
+  query dashboardEvent($eventId: Int!) {
+    dashboardEvent(eventId: $eventId) {
       id
       name
       description

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { useToast } from '@chakra-ui/react';
 
 import {
-  useEventLazyQuery,
+  useDashboardEventLazyQuery,
   useUpdateEventMutation,
 } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
@@ -13,7 +13,8 @@ import { isOnline, isPhysical } from '../../../../util/venueType';
 import { Layout } from '../../shared/components/Layout';
 import EventForm from '../components/EventForm';
 import { EventFormData } from '../components/EventFormUtils';
-import { EVENTS, EVENT } from '../graphql/queries';
+import { EVENTS, DASHBOARD_EVENT } from '../graphql/queries';
+import { EVENT } from '../../../events/graphql/queries';
 import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 import { DashboardLoading } from 'modules/dashboard/shared/components/DashboardLoading';
 
@@ -22,7 +23,7 @@ export const EditEventPage: NextPage = () => {
   const [loadingUpdate, setLoadingUpdate] = useState<boolean>(false);
   const { param: eventId, isReady } = useParam();
 
-  const [getEvent, { loading, error, data }] = useEventLazyQuery({
+  const [getEvent, { loading, error, data }] = useDashboardEventLazyQuery({
     variables: { eventId: eventId },
   });
 
@@ -38,6 +39,7 @@ export const EditEventPage: NextPage = () => {
     refetchQueries: [
       { query: EVENTS },
       { query: EVENT, variables: { eventId } },
+      { query: DASHBOARD_EVENT, variables: { eventId } },
       { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
     ],
   });
@@ -90,10 +92,10 @@ export const EditEventPage: NextPage = () => {
 
   const isLoading = loading || !isReady || !data;
   if (isLoading) return <DashboardLoading loading={loading} error={error} />;
-  if (!data.event)
+  if (!data.dashboardEvent)
     return <NextError statusCode={404} title="Event not found" />;
 
-  const { sponsors, ...rest } = data.event;
+  const { sponsors, ...rest } = data.dashboardEvent;
   const sponsorData = sponsors?.map((s) => {
     return {
       id: s.sponsor.id,
@@ -106,14 +108,14 @@ export const EditEventPage: NextPage = () => {
         data={{
           ...rest,
           sponsors: sponsorData || [],
-          venue_id: data.event?.venue?.id,
-          tags: data.event.tags || [],
+          venue_id: data.dashboardEvent?.venue?.id,
+          tags: data.dashboardEvent.tags || [],
         }}
         loading={loadingUpdate}
         onSubmit={onSubmit}
         loadingText={'Saving Event Changes'}
         submitText={'Save Event Changes'}
-        chapterId={data.event.chapter.id}
+        chapterId={data.dashboardEvent.chapter.id}
       />
     </Layout>
   );

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -124,7 +124,7 @@ export const EventPage: NextPage = () => {
 
         <Actions
           event={data.dashboardEvent}
-          chapter_id={data.event.chapter.id}
+          chapter_id={data.dashboardEvent.chapter.id}
           onDelete={() => router.replace('/dashboard/events')}
         />
         {isPhysical(data.dashboardEvent.venue_type) &&

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -16,8 +16,8 @@ import React, { useEffect } from 'react';
 
 import {
   useConfirmRsvpMutation,
+  useDashboardEventLazyQuery,
   useDeleteRsvpMutation,
-  useEventLazyQuery,
   MutationConfirmRsvpArgs,
   MutationDeleteRsvpArgs,
 } from '../../../../generated/graphql';
@@ -28,17 +28,21 @@ import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import { Layout } from '../../shared/components/Layout';
 import Actions from '../components/Actions';
 import SponsorsCard from '../../../../components/SponsorsCard';
-import { EVENT } from '../graphql/queries';
+import { DASHBOARD_EVENT } from '../graphql/queries';
+import { EVENT } from '../../../events/graphql/queries';
 
 const args = (eventId: number) => ({
-  refetchQueries: [{ query: EVENT, variables: { eventId } }],
+  refetchQueries: [
+    { query: EVENT, variables: { eventId } },
+    { query: DASHBOARD_EVENT, variables: { eventId } },
+  ],
 });
 
 export const EventPage: NextPage = () => {
   const router = useRouter();
   const { param: eventId, isReady } = useParam('id');
 
-  const [getEvent, { loading, error, data }] = useEventLazyQuery({
+  const [getEvent, { loading, error, data }] = useDashboardEventLazyQuery({
     variables: { eventId },
   });
 
@@ -69,7 +73,7 @@ export const EventPage: NextPage = () => {
   const isLoading = loading || !isReady || !data;
   if (isLoading || error)
     return <DashboardLoading loading={isLoading} error={error} />;
-  if (!data.event)
+  if (!data.dashboardEvent)
     return <NextError statusCode={404} title="Event not found" />;
 
   const userLists = [
@@ -93,59 +97,63 @@ export const EventPage: NextPage = () => {
   return (
     <Layout>
       <Box p="2" borderWidth="1px" borderRadius="lg">
-        <Heading>{data.event.name}</Heading>
+        <Heading>{data.dashboardEvent.name}</Heading>
 
-        {data.event.canceled && <Heading color="red.500">Canceled</Heading>}
-        <Text>{data.event.description}</Text>
-        {data.event.image_url && (
+        {data.dashboardEvent.canceled && (
+          <Heading color="red.500">Canceled</Heading>
+        )}
+        <Text>{data.dashboardEvent.description}</Text>
+        {data.dashboardEvent.image_url && (
           <Text>
             Event Image Url:{' '}
-            <Link href={data.event.image_url} isExternal>
-              {data.event.image_url}
+            <Link href={data.dashboardEvent.image_url} isExternal>
+              {data.dashboardEvent.image_url}
             </Link>
           </Text>
         )}
-        {data.event.url && (
+        {data.dashboardEvent.url && (
           <Text>
             Event Url:{' '}
-            <Link href={data.event.url} isExternal>
-              {data.event.url}
+            <Link href={data.dashboardEvent.url} isExternal>
+              {data.dashboardEvent.url}
             </Link>
           </Text>
         )}
-        <Text>Capacity: {data.event.capacity}</Text>
-        {/* <Tags tags={data.event.tags} /> */}
+        <Text>Capacity: {data.dashboardEvent.capacity}</Text>
+        {/* <Tags tags={data.dashboardEvent.tags} /> */}
 
         <Actions
-          event={data.event}
+          event={data.dashboardEvent}
           chapter_id={data.event.chapter.id}
           onDelete={() => router.replace('/dashboard/events')}
         />
-        {isPhysical(data.event.venue_type) && data.event.venue && (
-          <>
-            <h2>Venue:</h2>
-            <h3>{data.event.venue.name}</h3>
-            <h4>{getLocationString(data.event.venue, true)}</h4>
-          </>
-        )}
-        {isOnline(data.event.venue_type) && data.event.streaming_url && (
-          <Text>
-            Streaming Url:{' '}
-            <Link href={data.event.streaming_url} isExternal>
-              {data.event.streaming_url}
-            </Link>
-          </Text>
-        )}
+        {isPhysical(data.dashboardEvent.venue_type) &&
+          data.dashboardEvent.venue && (
+            <>
+              <h2>Venue:</h2>
+              <h3>{data.dashboardEvent.venue.name}</h3>
+              <h4>{getLocationString(data.dashboardEvent.venue, true)}</h4>
+            </>
+          )}
+        {isOnline(data.dashboardEvent.venue_type) &&
+          data.dashboardEvent.streaming_url && (
+            <Text>
+              Streaming Url:{' '}
+              <Link href={data.dashboardEvent.streaming_url} isExternal>
+                {data.dashboardEvent.streaming_url}
+              </Link>
+            </Text>
+          )}
       </Box>
-      {data.event.sponsors.length ? (
-        <SponsorsCard sponsors={data.event.sponsors} />
+      {data.dashboardEvent.sponsors.length ? (
+        <SponsorsCard sponsors={data.dashboardEvent.sponsors} />
       ) : (
         false
       )}
       <Box p="2" borderWidth="1px" borderRadius="lg" mt="2">
         {userLists.map(({ title, rsvpFilter, action }) => {
-          const users = data.event
-            ? data.event.event_users.filter(
+          const users = data.dashboardEvent
+            ? data.dashboardEvent.event_users.filter(
                 ({ rsvp }) => rsvp.name === rsvpFilter,
               )
             : [];

--- a/client/src/modules/dashboard/Venues/graphql/queries.ts
+++ b/client/src/modules/dashboard/Venues/graphql/queries.ts
@@ -22,8 +22,8 @@ export const VENUES = gql`
 `;
 
 export const VENUE = gql`
-  query venue($id: Int!) {
-    venue(id: $id) {
+  query venue($venueId: Int!) {
+    venue(venueId: $venueId) {
       id
       name
       street_address

--- a/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
@@ -23,7 +23,7 @@ export const EditVenuePage: NextPage = () => {
   const isReady = isVenueIdReady && isChapterIdReady;
 
   const [getVenue, { loading, error, data }] = useVenueLazyQuery({
-    variables: { id: venueId },
+    variables: { venueId },
   });
 
   useEffect(() => {

--- a/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
@@ -17,7 +17,7 @@ export const VenuePage: NextPage = () => {
   const { param: venueId, isReady } = useParam('id');
 
   const [getVenue, { loading, error, data }] = useVenueLazyQuery({
-    variables: { id: venueId },
+    variables: { venueId },
   });
 
   useEffect(() => {

--- a/client/src/modules/events/graphql/queries.ts
+++ b/client/src/modules/events/graphql/queries.ts
@@ -26,28 +26,3 @@ export const DATA_PAGINATED_EVENTS_TOTAL_QUERY = gql`
     }
   }
 `;
-
-export const MINIMAL_DATA_EVENTS_QUERY = gql`
-  query minEvents {
-    events {
-      id
-      name
-      description
-      start_at
-      invite_only
-      canceled
-      image_url
-      tags {
-        tag {
-          id
-          name
-        }
-      }
-      chapter {
-        id
-        name
-        category
-      }
-    }
-  }
-`;

--- a/client/src/modules/events/graphql/queries.ts
+++ b/client/src/modules/events/graphql/queries.ts
@@ -26,3 +26,69 @@ export const DATA_PAGINATED_EVENTS_TOTAL_QUERY = gql`
     }
   }
 `;
+
+export const EVENT = gql`
+  query event($eventId: Int!) {
+    event(eventId: $eventId) {
+      id
+      name
+      description
+      url
+      invite_only
+      streaming_url
+      canceled
+      capacity
+      start_at
+      ends_at
+      image_url
+      chapter {
+        id
+        name
+      }
+      tags {
+        tag {
+          id
+          name
+        }
+      }
+      sponsors {
+        sponsor {
+          name
+          website
+          logo_path
+          type
+          id
+        }
+      }
+      venue_type
+      venue {
+        id
+        name
+        street_address
+        city
+        postal_code
+        region
+        country
+      }
+      event_users {
+        rsvp {
+          name
+        }
+        user {
+          id
+          name
+        }
+        event_role {
+          id
+          name
+          event_role_permissions {
+            event_permission {
+              name
+            }
+          }
+        }
+        subscribed
+      }
+    }
+  }
+`;

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -22,7 +22,8 @@ import React, { useEffect, useMemo } from 'react';
 import { useAuth } from '../../auth/store';
 import { Loading } from '../../../components/Loading';
 import SponsorsCard from '../../../components/SponsorsCard';
-import { EVENT } from '../../dashboard/Events/graphql/queries';
+import { EVENT } from '../graphql/queries';
+import { DASHBOARD_EVENT } from '../../dashboard/Events/graphql/queries';
 import {
   useCancelRsvpMutation,
   useEventLazyQuery,
@@ -39,7 +40,10 @@ export const EventPage: NextPage = () => {
   const { user } = useAuth();
 
   const refetch = {
-    refetchQueries: [{ query: EVENT, variables: { eventId } }],
+    refetchQueries: [
+      { query: EVENT, variables: { eventId } },
+      { query: DASHBOARD_EVENT, variables: { eventId } },
+    ],
   };
 
   const [rsvpToEvent] = useRsvpToEventMutation(refetch);

--- a/common/permissions.ts
+++ b/common/permissions.ts
@@ -1,7 +1,6 @@
 export enum ChapterPermission {
   ChapterEdit = 'chapter-edit',
   ChapterBanUser = 'chapter-ban-user',
-  ChapterViewUsers = 'chapter-view-users',
   EventCreate = 'event-create',
   EventEdit = 'event-edit',
   EventDelete = 'event-delete',

--- a/common/permissions.ts
+++ b/common/permissions.ts
@@ -1,6 +1,7 @@
 export enum ChapterPermission {
   ChapterEdit = 'chapter-edit',
-  ChapterBanUser = 'ban-user',
+  ChapterBanUser = 'chapter-ban-user',
+  ChapterViewUsers = 'chapter-view-users',
   EventCreate = 'event-create',
   EventEdit = 'event-edit',
   EventDelete = 'event-delete',

--- a/cypress/e2e/dashboard/all.cy.ts
+++ b/cypress/e2e/dashboard/all.cy.ts
@@ -30,5 +30,9 @@ describe('all dashboards', () => {
     cy.visit(`/dashboard/chapters/${bannedChapter}/venues/${bannedVenue}/edit`);
     cy.get('[data-cy=loading-error]').should('be.visible');
     cy.contains(deniedText);
+
+    cy.visit(`/dashboard/chapters/${bannedChapter}/users`);
+    cy.get('[data-cy=loading-error]').should('be.visible');
+    cy.contains(deniedText);
   });
 });

--- a/cypress/e2e/dashboard/all.cy.ts
+++ b/cypress/e2e/dashboard/all.cy.ts
@@ -6,6 +6,7 @@ const bannedVenue = 1;
 
 describe('all dashboards', () => {
   it('they should be forbidden to the admin banned from that chapter', () => {
+    cy.login('banned@chapter.admin');
     cy.visit(`/dashboard/chapters/${bannedChapter}`);
     cy.get('[data-cy=loading-error]').should('be.visible');
     cy.contains(deniedText);

--- a/cypress/e2e/dashboard/all.cy.ts
+++ b/cypress/e2e/dashboard/all.cy.ts
@@ -1,0 +1,33 @@
+const deniedText = 'Access denied!';
+// TODO: get these from the API, rather than relying on the seeding order
+const bannedChapter = 1;
+const bannedEvent = 1;
+const bannedVenue = 1;
+
+describe('all dashboards', () => {
+  it('they should be forbidden to the admin banned from that chapter', () => {
+    cy.visit(`/dashboard/chapters/${bannedChapter}`);
+    cy.get('[data-cy=loading-error]').should('be.visible');
+    cy.contains(deniedText);
+
+    cy.visit(`/dashboard/chapters/${bannedChapter}/edit`);
+    cy.get('[data-cy=loading-error]').should('be.visible');
+    cy.contains(deniedText);
+
+    cy.visit(`/dashboard/events/${bannedEvent}`);
+    cy.get('[data-cy=loading-error]').should('be.visible');
+    cy.contains(deniedText);
+
+    cy.visit(`/dashboard/events/${bannedEvent}/edit`);
+    cy.get('[data-cy=loading-error]').should('be.visible');
+    cy.contains(deniedText);
+
+    cy.visit(`/dashboard/venues/${bannedVenue}`);
+    cy.get('[data-cy=loading-error]').should('be.visible');
+    cy.contains(deniedText);
+
+    cy.visit(`/dashboard/chapters/${bannedChapter}/venues/${bannedVenue}/edit`);
+    cy.get('[data-cy=loading-error]').should('be.visible');
+    cy.contains(deniedText);
+  });
+});

--- a/cypress/e2e/dashboard/chapters/users.cy.ts
+++ b/cypress/e2e/dashboard/chapters/users.cy.ts
@@ -150,9 +150,6 @@ describe('Chapter Users dashboard', () => {
   it("admins of other chapters should NOT be able to ban (or unban) that chapter's users", () => {
     cy.login('admin@of.chapter.two');
 
-    cy.visit(`/dashboard/chapters/${chapterId}/users`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-
     cy.getChapterMembers(chapterId).each((member: any) => {
       cy.banUser({ chapterId, userId: member.user.id }).then(
         expectToBeRejected,

--- a/cypress/e2e/dashboard/events/[eventId].cy.ts
+++ b/cypress/e2e/dashboard/events/[eventId].cy.ts
@@ -30,7 +30,7 @@ describe('event dashboard', () => {
       cy.get('@email')
         .mhGetBody()
         .should('include', 'reservation is confirmed');
-      cy.getEventUsers(1).then((eventUsers) => {
+      cy.getDashboardEventUsers(1).then((eventUsers) => {
         cy.get<string>('@userName').then((userName) => {
           const userEmail = eventUsers
             .filter(({ user: { name } }) => name === userName)

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -49,7 +49,7 @@ describe('spec needing owner', () => {
     cy.findByLabelText('Confirmed').should('be.checked');
     cy.findByLabelText('Waitlist').should('not.be.checked');
     cy.findByLabelText('Canceled').should('not.be.checked');
-    cy.getEventUsers(1).then((results) => {
+    cy.getDashboardEventUsers(1).then((results) => {
       const eventUsers = results.filter(({ subscribed }) => subscribed);
       const isRsvpConfirmed = ({ rsvp }) => rsvp.name === 'yes';
       sendAndCheckEmails(isRsvpConfirmed, eventUsers);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -155,7 +155,7 @@ const getEventUsers = (eventId: number) => {
       eventId,
     },
     query: `query eventUsers($eventId: Int!) {
-      event(eventId: $eventId) {
+      dashboardEvent(eventId: $eventId) {
         event_users {
           rsvp {
             name

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -172,7 +172,7 @@ const getEventUsers = (eventId: number) => {
   };
   return cy
     .request(gqlOptions(eventQuery))
-    .then((response) => response.body.data.event.event_users);
+    .then((response) => response.body.data.dashboardEvent.event_users);
 };
 
 Cypress.Commands.add('getEventUsers', getEventUsers);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -155,7 +155,7 @@ const getEventUsers = (eventId: number) => {
       eventId,
     },
     query: `query eventUsers($eventId: Int!) {
-      dashboardEvent(eventId: $eventId) {
+      event(eventId: $eventId) {
         event_users {
           rsvp {
             name
@@ -172,10 +172,44 @@ const getEventUsers = (eventId: number) => {
   };
   return cy
     .request(gqlOptions(eventQuery))
-    .then((response) => response.body.data.dashboardEvent.event_users);
+    .then((response) => response.body.data.event.event_users);
 };
 
 Cypress.Commands.add('getEventUsers', getEventUsers);
+
+/**
+ * (Dashboard only) Get event users for event with eventId using GQL query
+ * @param eventId Id of the event
+ */
+
+const getDashboardEventUsers = (eventId: number) => {
+  const eventQuery = {
+    operationName: 'dashboardEventUsers',
+    variables: {
+      eventId,
+    },
+    query: `query dashboardEventUsers($eventId: Int!) {
+     dashboardEvent(eventId: $eventId) {
+       event_users {
+         rsvp {
+           name
+         }
+         user {
+           id
+           name
+           email
+         }
+         subscribed
+       }
+     }
+   }`,
+  };
+  return cy
+    .request(gqlOptions(eventQuery))
+    .then((response) => response.body.data.dashboardEvent.event_users);
+};
+
+Cypress.Commands.add('getDashboardEventUsers', getDashboardEventUsers);
 
 /**
  * Wait until emails are received by mailhog
@@ -757,6 +791,7 @@ declare global {
       getChapterEvents: typeof getChapterEvents;
       getChapterMembers: typeof getChapterMembers;
       getChapterRoles: typeof getChapterRoles;
+      getDashboardEventUsers: typeof getDashboardEventUsers;
       getEventUsers: typeof getEventUsers;
       interceptGQL: typeof interceptGQL;
       joinChapter: typeof joinChapter;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -155,7 +155,7 @@ const getEventUsers = (eventId: number) => {
       eventId,
     },
     query: `query eventUsers($eventId: Int!) {
-      dashboardEvent(eventId: $eventId) {
+      event(eventId: $eventId) {
         event_users {
           rsvp {
             name

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,7 +16,12 @@ import { isDev } from './config';
 import { authorizationChecker } from './authorization';
 import { ResolverCtx, Request } from './common-types/gql';
 import { resolvers } from './controllers';
-import { user, events, handleError } from './controllers/Auth/middleware';
+import {
+  user,
+  events,
+  handleError,
+  venues,
+} from './controllers/Auth/middleware';
 import { checkJwt } from './controllers/Auth/check-jwt';
 import { prisma } from './prisma';
 import { getBearerToken } from './util/sessions';
@@ -143,11 +148,14 @@ export const main = async (app: Express) => {
       });
   });
 
+  // TODO: Combine these three into a single middleware that gets the with
+  // relevant events and venues
   // userMiddleware must be added *after* the login and out routes, since they
   // are only concerned with creating and destroying sessions and not with using
   // them.
   app.use(user);
   app.use(events);
+  app.use(venues);
   if (process.env.NODE_ENV !== 'development') {
     app.use(handleError);
   }
@@ -211,6 +219,7 @@ export const main = async (app: Express) => {
       res,
       user: req.user,
       events: req.events,
+      venues: req.venues,
     }),
     csrfPrevention: true,
   });

--- a/server/src/common-types/gql.ts
+++ b/server/src/common-types/gql.ts
@@ -1,10 +1,11 @@
 import { Request as ExpressRequest, Response } from 'express';
 
-import type { User, Events } from '../controllers/Auth/middleware';
+import type { User, Events, Venues } from '../controllers/Auth/middleware';
 
 export interface ResolverCtx {
   user?: User;
   events?: Events;
+  venues?: Venues;
   res: Response;
   req: ExpressRequest;
 }
@@ -12,4 +13,5 @@ export interface ResolverCtx {
 export interface Request extends ExpressRequest {
   user?: User;
   events?: Events;
+  venues?: Venues;
 }

--- a/server/src/controllers/Auth/middleware.ts
+++ b/server/src/controllers/Auth/middleware.ts
@@ -53,7 +53,12 @@ export type User = Merge<Prisma.usersGetPayload<typeof userInclude>>;
 export type Events = Merge<
   Prisma.eventsGetPayload<{ select: { id: true; chapter_id: true } }>[]
 >;
+export type Venues = Merge<
+  Prisma.venuesGetPayload<{ select: { id: true; chapter_id: true } }>[]
+>;
 
+// TODO: get events in user middleware and only get those that the user is an
+// event_user for
 export const events = (req: Request, _res: Response, next: NextFunction) => {
   const id = req.session?.id;
 
@@ -71,6 +76,29 @@ export const events = (req: Request, _res: Response, next: NextFunction) => {
     })
     .then((events) => {
       req.events = events;
+      next();
+    });
+};
+
+// TODO: get venues in user middleware and only get those that the user is an
+// chapter_user for
+export const venues = (req: Request, _res: Response, next: NextFunction) => {
+  const id = req.session?.id;
+
+  // user is not logged in, so we don't need to do anything here
+  if (!id) {
+    return next();
+  }
+
+  prisma.venues
+    .findMany({
+      select: {
+        id: true,
+        chapter_id: true,
+      },
+    })
+    .then((venues) => {
+      req.venues = venues;
       next();
     });
 };

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -32,11 +32,37 @@ export class ChapterResolver {
   }
 
   @Authorized(Permission.ChapterEdit)
-  @Query(() => ChapterWithRelations, { nullable: true })
+  @Query(() => ChapterWithRelations)
+  async dashboardChapter(
+    @Arg('id', () => Int) id: number,
+  ): Promise<ChapterWithRelations> {
+    return await prisma.chapters.findUniqueOrThrow({
+      where: { id },
+      include: {
+        events: { include: { tags: { include: { tag: true } } } },
+        chapter_users: {
+          include: {
+            chapter_role: {
+              include: {
+                chapter_role_permissions: {
+                  include: { chapter_permission: true },
+                },
+              },
+            },
+            user: true,
+          },
+          orderBy: { user: { name: 'asc' } },
+        },
+        user_bans: { include: { user: true, chapter: true } },
+      },
+    });
+  }
+
+  @Query(() => ChapterWithRelations)
   async chapter(
     @Arg('id', () => Int) id: number,
-  ): Promise<ChapterWithRelations | null> {
-    return await prisma.chapters.findUnique({
+  ): Promise<ChapterWithRelations> {
+    return await prisma.chapters.findUniqueOrThrow({
       where: { id },
       include: {
         events: { include: { tags: { include: { tag: true } } } },

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -31,6 +31,7 @@ export class ChapterResolver {
     });
   }
 
+  @Authorized(Permission.ChapterEdit)
   @Query(() => ChapterWithRelations, { nullable: true })
   async chapter(
     @Arg('id', () => Int) id: number,

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -214,7 +214,6 @@ export class ChapterUserResolver {
     });
   }
 
-  @Authorized(Permission.ChapterBanUser)
   // TODO: it would be nice if this was a field on the ChapterUser type and we
   // could guarantee type safety of this resolver.
   @FieldResolver()

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -215,8 +215,13 @@ export class ChapterUserResolver {
   }
 
   @Authorized(Permission.ChapterBanUser)
+  // TODO: it would be nice if this was a field on the ChapterUser type and we
+  // could guarantee type safety of this resolver.
   @FieldResolver()
-  canBeBanned(@Ctx() ctx: ResolverCtx): boolean {
+  is_bannable(@Ctx() ctx: ResolverCtx): boolean {
+    // TODO: reimplement the logic of
+    // https://github.com/freeCodeCamp/chapter/commit/a71e570b22e8bad042438369b1162000dcee3f47,
+    // updated with the current roles and permissions
     if (!ctx.user) {
       return false;
     }

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -277,6 +277,7 @@ export class EventResolver {
     });
   }
 
+  @Authorized(Permission.EventEdit)
   @Query(() => EventWithRelations, { nullable: true })
   async event(
     @Arg('eventId', () => Int) eventId: number,

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -277,7 +277,36 @@ export class EventResolver {
     });
   }
 
+  // TODO: Check we need all the returned data
   @Authorized(Permission.EventEdit)
+  @Query(() => EventWithRelations, { nullable: true })
+  async dashboardEvent(
+    @Arg('eventId', () => Int) eventId: number,
+  ): Promise<EventWithRelations | null> {
+    return await prisma.events.findUnique({
+      where: { id: eventId },
+      include: {
+        chapter: true,
+        tags: { include: { tag: true } },
+        venue: true,
+        event_users: {
+          include: {
+            user: true,
+            rsvp: true,
+            event_role: {
+              include: {
+                event_role_permissions: { include: { event_permission: true } },
+              },
+            },
+          },
+          orderBy: { user: { name: 'asc' } },
+        },
+        sponsors: { include: { sponsor: true } },
+      },
+    });
+  }
+
+  // TODO: Check we need all the returned data
   @Query(() => EventWithRelations, { nullable: true })
   async event(
     @Arg('eventId', () => Int) eventId: number,

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -42,6 +42,7 @@ export class VenueResolver {
     });
   }
 
+  @Authorized(Permission.VenueEdit)
   @Query(() => Venue, { nullable: true })
   venue(@Arg('id', () => Int) id: number): Promise<Venue | null> {
     return prisma.venues.findUnique({

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -44,7 +44,7 @@ export class VenueResolver {
 
   @Authorized(Permission.VenueEdit)
   @Query(() => Venue, { nullable: true })
-  venue(@Arg('id', () => Int) id: number): Promise<Venue | null> {
+  venue(@Arg('venueId', () => Int) id: number): Promise<Venue | null> {
     return prisma.venues.findUnique({
       where: { id },
       include: venueIncludes,

--- a/server/tests/fixtures/venues.ts
+++ b/server/tests/fixtures/venues.ts
@@ -1,0 +1,19 @@
+// All the authChecker needs to know is which chapter a given venue belongs to:
+export const venues = [
+  {
+    id: 1,
+    chapter_id: 1,
+  },
+  {
+    id: 2,
+    chapter_id: 1,
+  },
+  {
+    id: 3,
+    chapter_id: 2,
+  },
+  {
+    id: 4,
+    chapter_id: 3,
+  },
+];


### PR DESCRIPTION

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Ref: https://github.com/freeCodeCamp/chapter/issues/1534

Partial progress on requiring permissions to see the dashboard. The main goal was to hide the set of dashboards shown in `all.cy.ts` from the banned user.

Currently the privacy protections are a sham, because the GraphQL server will still return data from the unprotected query resolvers.  We should audit all public routes to make sure nothing private is accessible through them.  However, protecting the views like this does reduce frustration (since the mutations *are* protected and it would be annoying to find that out after filling in the form!)

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
