### PR TITLE
fix: use node 16 (not alpine) in dev for M1

### DIFF
--- a/client.Dockerfile
+++ b/client.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine as development
+FROM node:16 as development
 WORKDIR /usr/chapter/
 
 FROM development as build
@@ -18,7 +18,8 @@ COPY package*.json ./
 RUN npm ci -w=client --ignore-scripts
 RUN npm -w=client run build
 
-FROM development as production
+FROM node:16-alpine as production
+WORKDIR /usr/chapter/
 
 COPY --from=build /usr/chapter/client/.next ./client/.next
 COPY client/public ./client/public

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,5 +1,7 @@
-FROM node:16-alpine as development
+FROM node:16 as development
 WORKDIR /usr/chapter/
+
+RUN apt-get update && apt-get install netcat -y
 
 FROM development as build
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
   // since we support Docker as well as 'manual' we need to add additional
   // targets
   // TODO: specify single target via env()
-  binaryTargets = ["native", "linux-musl"]
+  binaryTargets = ["native", "linux-musl", "debian-openssl-1.1.x"]
 }
 
 datasource db {


### PR DESCRIPTION
Until prisma provide more binaries, this seems necessary to support M1
processors

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes https://github.com/freeCodeCamp/chapter/issues/1571 (hopefully)

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
