### PR TITLE
chore: consistent color scheme

### DIFF
--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -63,12 +63,10 @@ export const Modal = (props: ModalProps) => {
           <ModalFooter>
             {buttonsLeft}
             <HStack>
-              <Button colorScheme="blue" onClick={modalProps.onClose}>
-                Close
-              </Button>
+              <Button onClick={modalProps.onClose}>Close</Button>
               {buttons}
               {formButtonText && (
-                <Button colorScheme={'green'} type="submit">
+                <Button colorScheme={'blue'} type="submit">
                   {formButtonText}
                 </Button>
               )}

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -144,17 +144,13 @@ export const ChapterPage: NextPage = () => {
                     {dataChapterUser.chapterUser.chapter_role.name} of the
                     chapter
                   </Text>
-                  <Button
-                    colorScheme="orange"
-                    onClick={() => chapterSubscribe(false)}
-                    size="md"
-                  >
+                  <Button onClick={() => chapterSubscribe(false)} size="md">
                     Unsubscribe
                   </Button>
                 </HStack>
               ) : (
                 <Button
-                  colorScheme="green"
+                  colorScheme="blue"
                   onClick={() => chapterSubscribe(true)}
                   size="md"
                 >

--- a/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
+++ b/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
@@ -43,7 +43,6 @@ const EventCancelButton = (props: EventCancelButtonProps) => {
     <Button
       {...rest}
       width={isFullWidth ? 'full' : 'auto'}
-      colorScheme="orange"
       onClick={clickCancel}
       isDisabled={isDisabled}
     >

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -209,12 +209,7 @@ export const EventPage: NextPage = () => {
       {userRsvped === 'yes' ? (
         <HStack>
           <Heading>You&lsquo;ve RSVPed to this event</Heading>
-          <Button
-            colorScheme="red"
-            onClick={onCancelRsvp}
-            paddingInline={'2'}
-            paddingBlock={'1'}
-          >
+          <Button onClick={onCancelRsvp} paddingInline={'2'} paddingBlock={'1'}>
             Cancel
           </Button>
         </HStack>
@@ -229,12 +224,7 @@ export const EventPage: NextPage = () => {
               You&lsquo;re on waitlist for this event
             </Heading>
           )}
-          <Button
-            colorScheme="red"
-            onClick={onCancelRsvp}
-            paddingInline={'2'}
-            paddingBlock={'1'}
-          >
+          <Button onClick={onCancelRsvp} paddingInline={'2'} paddingBlock={'1'}>
             Cancel
           </Button>
         </HStack>
@@ -257,7 +247,6 @@ export const EventPage: NextPage = () => {
                 You are subscribed
               </Heading>
               <Button
-                colorScheme="orange"
                 onClick={onUnsubscribeFromEvent}
                 paddingInline={'2'}
                 paddingBlock={'1'}


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->
 
 Although this makes it uglier, it's consistent and not confusing.
 
 - cancel and close are colorless, everywhere
 - everything that can be changed easily are `blue` and without risky affects.
 
 I wish it wasn't blue 😞 
 
<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
