### PR TITLE
feat: login when rsvping (take two)

### DIFF
--- a/client/src/components/PageLayout/Header.tsx
+++ b/client/src/components/PageLayout/Header.tsx
@@ -15,14 +15,13 @@ import { Link } from 'chakra-next-link';
 import { SkipNavLink } from '@chakra-ui/skip-nav';
 import { useRouter } from 'next/router';
 import React, { forwardRef } from 'react';
-import { useAuth0 } from '@auth0/auth0-react';
 import NextLink from 'next/link';
 
 import { useAuthStore } from '../../modules/auth/store';
 import styles from '../../styles/Header.module.css';
 import { Permission } from '../../../../common/permissions';
-import { useSession } from 'hooks/useSession';
 import { useCheckPermission } from 'hooks/useCheckPermission';
+import { useLogin, useLogout } from 'hooks/useAuth';
 
 interface Props {
   children: React.ReactNode;
@@ -33,20 +32,8 @@ const serverUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:5000';
 // TODO: distinguish between logging into the app and logging into Auth0. Maybe
 // use sign-in for the app?
 const LoginButton = () => {
-  const { loginWithRedirect } = useAuth0();
-
-  return <MenuItem onClick={() => loginWithRedirect()}>Log In</MenuItem>;
-};
-
-const DevLoginButton = () => {
-  const { createSession } = useSession();
-  return (
-    <MenuItem
-      onClick={() => createSession().then(() => window.location.reload())}
-    >
-      Log In
-    </MenuItem>
-  );
+  const login = useLogin();
+  return <MenuItem onClick={login}>Log In</MenuItem>;
 };
 
 const HeaderItem = forwardRef<HTMLDivElement, Props>((props, ref) => {
@@ -70,29 +57,14 @@ export const Header: React.FC = () => {
   const router = useRouter();
   const {
     data: { user },
-    setData,
   } = useAuthStore();
-
-  const { logout: logoutAuth0 } = useAuth0();
+  const logout = useLogout();
 
   const canAuthenticateWithGoogle = useCheckPermission(
     Permission.GoogleAuthenticate,
   );
 
-  const logout = () => {
-    setData({ user: undefined });
-    // TODO: logging out of auth0 and the server should be handled by the same
-    // module as logging in.
-    // TODO: inject the auth functions (logout) into the Header so we can switch
-    // strategies easily.
-    if (process.env.NEXT_PUBLIC_USE_AUTH0 !== 'false') logoutAuth0();
-    fetch(new URL('/logout', serverUrl).href, {
-      method: 'DELETE',
-      credentials: 'include',
-    });
-
-    router.push('/');
-  };
+  const goHome = () => router.push('/');
 
   return (
     <>
@@ -151,12 +123,13 @@ export const Header: React.FC = () => {
                         </MenuItem>
                       )}
 
-                      <MenuItem data-cy="logout-button" onClick={logout}>
+                      <MenuItem
+                        data-cy="logout-button"
+                        onClick={() => logout().then(goHome)}
+                      >
                         Logout
                       </MenuItem>
                     </>
-                  ) : process.env.NEXT_PUBLIC_USE_AUTH0 === 'false' ? (
-                    <DevLoginButton />
                   ) : (
                     <LoginButton />
                   )}

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,0 +1,34 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import { useMeQuery } from 'generated/graphql';
+import { useSession } from 'hooks/useSession';
+
+export const useLogin = () => {
+  const { loginWithRedirect } = useAuth0();
+  const { createSession } = useSession();
+  const { refetch } = useMeQuery();
+
+  const login = async () => {
+    if (process.env.NEXT_PUBLIC_USE_AUTH0 !== 'false') {
+      return loginWithRedirect();
+    } else {
+      await createSession();
+      return await refetch();
+    }
+  };
+
+  return login;
+};
+
+export const useLogout = () => {
+  const { logout: logoutAuth0 } = useAuth0();
+  const { destroySession } = useSession();
+  const { refetch } = useMeQuery();
+
+  const logout = async () => {
+    if (process.env.NEXT_PUBLIC_USE_AUTH0 !== 'false') logoutAuth0();
+    await destroySession();
+    return await refetch();
+  };
+
+  return logout;
+};

--- a/client/src/modules/auth/store/index.tsx
+++ b/client/src/modules/auth/store/index.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
-import { useMeQuery, MeQuery } from '../../../generated/graphql';
+import { MeQuery, useMeQuery } from '../../../generated/graphql';
 import { useSession } from 'hooks/useSession';
 
 interface AuthContextType {
@@ -9,11 +9,8 @@ interface AuthContextType {
 
 export const AuthContext = createContext<{
   data: AuthContextType;
-  setData: React.Dispatch<React.SetStateAction<AuthContextType>>;
 }>({
   data: {},
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  setData: () => {},
 });
 
 export const useAuthStore = () => useContext(AuthContext);
@@ -39,7 +36,7 @@ export const AuthContextProvider = ({
 
   useEffect(() => {
     if (!loading && !error) {
-      if (meData?.me) {
+      if (meData) {
         setData({ user: meData.me });
       } else if (!loginAttempted) {
         // TODO: figure out if we need this guard. Can we get away with only
@@ -50,7 +47,11 @@ export const AuthContextProvider = ({
   }, [loading, error, meData, loginAttempted, isAuthenticated]);
 
   return (
-    <AuthContext.Provider value={{ data, setData }}>
+    <AuthContext.Provider
+      value={{
+        data,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -19,7 +19,7 @@ import NextError from 'next/error';
 import { useRouter } from 'next/router';
 import React, { useEffect, useMemo } from 'react';
 
-import { useAuth } from '../../auth/store';
+import { useAuthStore } from '../../auth/store';
 import { Loading } from '../../../components/Loading';
 import SponsorsCard from '../../../components/SponsorsCard';
 import { EVENT } from '../../dashboard/Events/graphql/queries';
@@ -32,11 +32,15 @@ import {
   useUnsubscribeFromEventMutation,
 } from '../../../generated/graphql';
 import { useParam } from 'hooks/useParam';
+import { useLogin } from 'hooks/useAuth';
 
 export const EventPage: NextPage = () => {
   const { param: eventId, isReady } = useParam('eventId');
   const router = useRouter();
-  const { user } = useAuth();
+  const {
+    data: { user },
+  } = useAuthStore();
+  const login = useLogin();
 
   const refetch = {
     refetchQueries: [{ query: EVENT, variables: { eventId } }],
@@ -159,7 +163,7 @@ export const EventPage: NextPage = () => {
 
   // TODO: reimplment this the login modal with Auth0
   const checkOnRsvp = async () => {
-    if (!user) throw new Error('User not logged in');
+    if (!user) await login();
     await onRsvp();
   };
 

--- a/client/src/modules/profiles/pages/userProfile.tsx
+++ b/client/src/modules/profiles/pages/userProfile.tsx
@@ -5,12 +5,13 @@ import { useRouter } from 'next/router';
 import { Button } from '@chakra-ui/button';
 import { useDeleteMeMutation } from '../../../generated/graphql';
 import { useAuthStore } from '../../auth/store';
+import { useLogout } from 'hooks/useAuth';
 
 export const UserProfilePage = () => {
   const {
     data: { user },
-    setData,
   } = useAuthStore();
+  const logout = useLogout();
   const router = useRouter();
 
   const confirmDelete = useConfirmDelete({ doubleConfirm: true });
@@ -18,8 +19,8 @@ export const UserProfilePage = () => {
   const clickDelete = async () => {
     const ok = await confirmDelete();
     if (!ok) return;
-    deleteMe();
-    setData({});
+    await deleteMe();
+    await logout();
     router.push('/');
   };
 


### PR DESCRIPTION
- Revert "Revert "feat: login when rsvping (#1594)" (#1597)"
- fix: try to create session if no user data

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

The last attempt introduced a bug because the AuthStore only tried to create a session when no data at all came back from the `meQuery`. Instead it should try to create a session whenever it sees `null` user data.  Since it also needs `isAuthenticated` to be true, it will not attempt to login again after the user logs out of Auth0.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
