### PR TITLE
fix: updating chapter on event changes

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -904,6 +904,7 @@ export type UpdateEventMutation = {
     url?: string | null;
     streaming_url?: string | null;
     capacity: number;
+    invite_only: boolean;
     tags: Array<{
       __typename?: 'EventTag';
       tag: { __typename?: 'Tag'; id: number; name: string };
@@ -2405,6 +2406,7 @@ export const UpdateEventDocument = gql`
           name
         }
       }
+      invite_only
     }
   }
 `;

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -3,6 +3,7 @@ import { Button, HStack } from '@chakra-ui/react';
 import { useConfirmDelete } from 'chakra-confirm';
 import { LinkButton } from 'chakra-next-link';
 import React, { useMemo } from 'react';
+import { CHAPTER } from '../../../chapters/graphql/queries';
 import { EVENT, EVENTS } from '../graphql/queries';
 import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 import EventCancelButton from './EventCancelButton';
@@ -13,9 +14,15 @@ interface ActionsProps {
   event: Pick<Event, 'id' | 'canceled'>;
   onDelete?: () => any;
   hideCancel?: boolean;
+  chapter_id: number;
 }
 
-const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
+const Actions: React.FC<ActionsProps> = ({
+  event,
+  onDelete,
+  hideCancel,
+  chapter_id,
+}) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [remove] = useDeleteEventMutation();
 
@@ -23,6 +30,7 @@ const Actions: React.FC<ActionsProps> = ({ event, onDelete, hideCancel }) => {
     () => ({
       variables: { eventId: event.id },
       refetchQueries: [
+        { query: CHAPTER, variables: { chapterId: chapter_id } },
         { query: EVENT, variables: { eventId: event.id } },
         { query: EVENTS },
         { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },

--- a/client/src/modules/dashboard/Events/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Events/graphql/mutations.ts
@@ -36,6 +36,7 @@ export const updateEvent = gql`
           name
         }
       }
+      invite_only
     }
   }
 `;

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -118,6 +118,7 @@ export const EventPage: NextPage = () => {
 
         <Actions
           event={data.event}
+          chapter_id={data.event.chapter.id}
           onDelete={() => router.replace('/dashboard/events')}
         />
         {isPhysical(data.event.venue_type) && data.event.venue && (

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -10,6 +10,7 @@ import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import { Layout } from '../../shared/components/Layout';
 import EventForm from '../components/EventForm';
 import { EventFormData } from '../components/EventFormUtils';
+import { CHAPTER } from '../../../chapters/graphql/queries';
 import { EVENTS } from '../graphql/queries';
 import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 import { useParam } from '../../../../hooks/useParam';
@@ -19,12 +20,7 @@ export const NewEventPage: NextPage = () => {
   const router = useRouter();
   const [loading, setLoading] = useState<boolean>(false);
 
-  const [createEvent] = useCreateEventMutation({
-    refetchQueries: [
-      { query: EVENTS },
-      { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
-    ],
-  });
+  const [createEvent] = useCreateEventMutation();
 
   const [publish] = useSendEventInviteMutation();
 
@@ -53,6 +49,11 @@ export const NewEventPage: NextPage = () => {
       };
       const event = await createEvent({
         variables: { chapterId: chapter_id, data: { ...eventData } },
+        refetchQueries: [
+          { query: CHAPTER, variables: { chapterId: chapter_id } },
+          { query: EVENTS },
+          { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
+        ],
       });
 
       if (event.data) {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Fixes updating event list in the chapter dashboard, ie. `/dashboard/chapters/1` after various changes.
- It's a bit confusing, because some updates are seemingly already done when refetching just event/events, but some not.

action                           |      before     |  after        |
-------------------------------- |-----------------|---------------|
add new event            (form)  |       no        |   yes         |
delete event          (actions)  |       no        |   yes         |
edit event (name)        (form)  |       yes       |   yes         |
edit event (invite-only) (form)  |       no (wut)  |   yes         |
cancel event             (form)  |       yes       |   yes         |
cancel event          (actions)  |       yes       |   yes         |