### PR TITLE
feat: limit ability to delete chapter to the owner

### DIFF
--- a/common/permissions.ts
+++ b/common/permissions.ts
@@ -17,6 +17,7 @@ export enum ChapterPermission {
 export enum InstancePermission {
   ChapterCreate = 'chapter-create',
   ChapterJoin = 'chapter-join',
+  ChapterDelete = 'chapter-delete',
   ChapterSubscriptionsManage = 'chapter-subscriptions-manage',
   ChapterUserRoleChange = 'chapter-user-role-change',
   SponsorsManage = 'sponsors-manage',

--- a/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
@@ -75,7 +75,6 @@ describe('chapter edit dashboard', () => {
   });
 
   it('only accepts chapter deletion requests from owners', () => {
-    const chapterId = 1;
     cy.login('admin@of.chapter.one);
 
     cy.deleteChapter(chapterId).then((response) => {

--- a/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
@@ -75,7 +75,7 @@ describe('chapter edit dashboard', () => {
   });
 
   it('only accepts chapter deletion requests from owners', () => {
-    cy.login('admin@of.chapter.one);
+    cy.login('admin@of.chapter.one');
 
     cy.deleteChapter(chapterId).then((response) => {
       expectToBeRejected(response);

--- a/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
@@ -74,27 +74,18 @@ describe('chapter edit dashboard', () => {
     });
   });
 
-  it('deny admins to delete a chapter', () => {
+  it('only accepts chapter deletion requests from owners', () => {
     const chapterId = 1;
-    cy.login(Cypress.env('JWT_ADMIN_USER'));
+    cy.login('admin@of.chapter.one);
 
-    cy.updateChapter(chapterId, chapterData).then((response) => {
+    cy.deleteChapter(chapterId).then((response) => {
       expectToBeRejected(response);
-
-      cy.visit(`/dashboard/chapters/${chapterId}`);
-      cy.findByRole('button', { name: 'Delete Chapter' })
-        .click()
-        .findByRole('button', { name: 'Are you sure?' })
-        .click()
-        .findByRole('button', { name: 'Delete' })
-        .click();
     });
 
-    cy.updateChapter(chapterId, chapterData).then((response) => {
+    cy.login();
+    cy.deleteChapter(chapterId).then((response) => {
       expect(response.status).to.eq(200);
-
-      cy.visit(`/dashboard/chapters/${chapterId}`);
-      cy.contains(chapterData.name);
+      expect(response.body.errors).not.to.exist;
     });
   });
 });

--- a/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
@@ -82,9 +82,12 @@ describe('chapter edit dashboard', () => {
       expectToBeRejected(response);
 
       cy.visit(`/dashboard/chapters/${chapterId}`);
-      cy.findByRole('button', { name: 'Delete Chapter' }).click();
-      cy.findByRole('button', { name: 'Are you sure?' }).click();
-      cy.findByRole('button', { name: 'Delete' }).click();
+      cy.findByRole('button', { name: 'Delete Chapter' })
+        .click()
+        .findByRole('button', { name: 'Are you sure?' })
+        .click()
+        .findByRole('button', { name: 'Delete' })
+        .click();
     });
 
     cy.updateChapter(chapterId, chapterData).then((response) => {

--- a/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
@@ -9,6 +9,7 @@ const chapterData = {
   category: 'New Category',
   image_url: 'https://example.com/new-image.jpg',
 };
+const chapterId = 1;
 
 describe('chapter edit dashboard', () => {
   beforeEach(() => {
@@ -16,7 +17,7 @@ describe('chapter edit dashboard', () => {
   });
   it('allows admins to edit a chapter', () => {
     cy.login('admin@of.chapter.one');
-    cy.visit('/dashboard/chapters/1/edit');
+    cy.visit(`/dashboard/chapters/${chapterId}/edit`);
 
     cy.findByRole('textbox', { name: 'Chapter name' })
       .clear()
@@ -49,7 +50,6 @@ describe('chapter edit dashboard', () => {
   it('rejects requests from members, but allows them from owners', () => {
     // confirm the chapter is ready to be updated (i.e. doesn't not already have
     // the new name)
-    const chapterId = 1;
     cy.visit(`/dashboard/chapters/${chapterId}`);
     cy.contains('loading').should('not.exist');
     cy.contains(chapterData.name).should('not.exist');
@@ -68,6 +68,27 @@ describe('chapter edit dashboard', () => {
     cy.updateChapter(chapterId, chapterData).then((response) => {
       expect(response.status).to.eq(200);
       expect(response.body.errors).not.to.exist;
+
+      cy.visit(`/dashboard/chapters/${chapterId}`);
+      cy.contains(chapterData.name);
+    });
+  });
+
+  it('deny admins to delete a chapter', () => {
+    const chapterId = 1;
+    cy.login(Cypress.env('JWT_ADMIN_USER'));
+
+    cy.updateChapter(chapterId, chapterData).then((response) => {
+      expectToBeRejected(response);
+
+      cy.visit(`/dashboard/chapters/${chapterId}`);
+      cy.findByRole('button', { name: 'Delete Chapter' }).click();
+      cy.findByRole('button', { name: 'Are you sure?' }).click();
+      cy.findByRole('button', { name: 'Delete' }).click();
+    });
+
+    cy.updateChapter(chapterId, chapterData).then((response) => {
+      expect(response.status).to.eq(200);
 
       cy.visit(`/dashboard/chapters/${chapterId}`);
       cy.contains(chapterData.name);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -280,6 +280,7 @@ const deleteChapter = (chapterId: number) => {
   };
   return cy.authedRequest(gqlOptions(chapterMutation));
 };
+Cypress.Commands.add('deleteChapter', deleteChapter);
 /**
  * Update event using GQL mutation
  * @param eventId Id of the event

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -263,6 +263,24 @@ Cypress.Commands.add('updateChapter', (chapterId, data) => {
   return cy.authedRequest(gqlOptions(chapterMutation));
 });
 /**
+ * Delete chapter using GQL mutation
+ * @param chapterId Id of the chapter for deletion
+ */
+const deleteChapter = (chapterId: number) => {
+  const chapterMutation = {
+    operationName: 'deleteChapter',
+    variables: {
+      chapterId,
+    },
+    query: `mutation deleteChapter($chapterId: Int!) {
+      deleteChapter(id: $chapterId) {
+        id
+      }
+    }`,
+  };
+  return cy.authedRequest(gqlOptions(chapterMutation));
+};
+/**
  * Update event using GQL mutation
  * @param eventId Id of the event
  * @param data Data of the event. Equivalent of CreateEventInputs for the Events resolver.
@@ -751,6 +769,7 @@ declare global {
       createChapter: typeof createChapter;
       createEvent: typeof createEvent;
       createSponsor: typeof createSponsor;
+      deleteChapter: typeof deleteChapter;
       deleteEvent: typeof deleteEvent;
       deleteVenue: typeof deleteVenue;
       sendEventInvite: typeof sendEventInvite;

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -92,6 +92,7 @@ export class ChapterResolver {
     return prisma.chapters.update({ where: { id }, data: chapterData });
   }
 
+  @Authorized(Permission.ChapterDelete)
   @Mutation(() => Chapter)
   async deleteChapter(@Arg('id', () => Int) id: number): Promise<Chapter> {
     return await prisma.chapters.delete({ where: { id } });


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #1217

I have tried to login as admin and delete chapter, and got this 

![image](https://user-images.githubusercontent.com/88248797/192151593-2ba4342c-e9ee-429b-845d-4cc2a52e1e7e.png)

there is no cypress test yet, I am planning to give it a try. 👍 
<!-- Tell us in detail about the changes you made and how it will affect the platform. -->


Edit: This pull request was made to test myself "if I can add permission successfully", if you have PR that finish the issue feel free to open it and I will close this.

in hindsight should have asked in the issue before opening the pull request