### PR TITLE
fix: wait for specific number of emails

### DIFF
--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -84,7 +84,10 @@ describe('spec needing owner', () => {
     const recipientEmails = users
       .filter(filterCallback)
       .map(({ user: { email } }) => email);
-    cy.waitUntilMail().should('have.length', recipientEmails.length);
+    cy.waitUntilMail({ expectedNumberOfEmails: recipientEmails.length }).should(
+      'have.length',
+      recipientEmails.length,
+    );
     recipientEmails.forEach((recipientEmail) => {
       cy.mhGetMailsByRecipient(recipientEmail).as('currentRecipient');
       cy.get('@currentRecipient').should('have.length', 1);

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -84,10 +84,7 @@ describe('spec needing owner', () => {
     const recipientEmails = users
       .filter(filterCallback)
       .map(({ user: { email } }) => email);
-    cy.waitUntilMail({ expectedNumberOfEmails: recipientEmails.length }).should(
-      'have.length',
-      recipientEmails.length,
-    );
+    cy.waitUntilMail({ expectedNumberOfEmails: recipientEmails.length });
     recipientEmails.forEach((recipientEmail) => {
       cy.mhGetMailsByRecipient(recipientEmail).as('currentRecipient');
       cy.get('@currentRecipient').should('have.length', 1);


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Uses waiting for specific number of emails.
- It's kind of implied that after waiting for x emails, emails should have length of x. So _should_ might not be necessarily needed anymore.