### PR TITLE
fix: populate rsvp table during init

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,6 +5,7 @@ import { config } from 'dotenv';
 import coverage from '@cypress/code-coverage/task';
 
 import { prisma } from './server/src/prisma';
+import { InstanceRole } from './server/prisma/generator/factories/instanceRoles.factory';
 
 const getChapterMembers = (chapterId: number) =>
   prisma.chapter_users.findMany({

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -22,6 +22,14 @@ const getEventUsers = (eventId: number) =>
 
 export type EventUsers = Awaited<ReturnType<typeof getEventUsers>>;
 
+const promoteToOwner = async ({ email }: { email: string }) => {
+  const name: InstanceRole['name'] = 'owner';
+  return await prisma.users.update({
+    where: { email },
+    data: { instance_role: { connect: { name } } },
+  });
+};
+
 const seedDb = () => execSync('node server/prisma/generator/seed.js');
 
 config();
@@ -50,7 +58,7 @@ export default defineConfig({
         execSync('npm run db:reset');
       });
 
-      on('task', { getChapterMembers, getEventUsers, seedDb });
+      on('task', { getChapterMembers, getEventUsers, seedDb, promoteToOwner });
       coverage(on, config);
       return config;
     },

--- a/cypress/e2e/dashboard/chapters/chapters-index.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapters-index.cy.ts
@@ -10,6 +10,34 @@ const chapterData = {
   image_url: 'https://example.com/image.jpg',
 };
 
+// TODO: move this and other fixtures to a common file
+const venueData = {
+  name: 'Test Venue',
+  street_address: '123 Main St',
+  city: 'New York',
+  postal_code: '10001',
+  region: 'NY',
+  country: 'US',
+  latitude: 40.7128,
+  longitude: -74.006,
+};
+
+const eventData = {
+  venue_id: 1,
+  sponsor_ids: [],
+  name: 'Other Event',
+  description: 'Test Description',
+  url: 'https://test.event.org',
+  venue_type: 'PhysicalAndOnline',
+  capacity: 10,
+  image_url: 'https://test.event.org/image',
+  streaming_url: 'https://test.event.org/video',
+  start_at: '2022-01-01T00:01',
+  ends_at: '2022-01-02T00:02',
+  tags: 'Test, Event, Tag',
+  invite_only: false,
+};
+
 describe('chapters dashboard', () => {
   before(() => {
     cy.task('seedDb');
@@ -66,7 +94,38 @@ describe('chapters dashboard', () => {
     cy.contains(chapterData.name);
   });
 
+  it('lets a user create a chapter and an event in a fresh instance', () => {
+    cy.exec('npm run db:sync && npm run db:init');
+    const userEmail = 'fresh@start';
+    cy.login(userEmail);
+    cy.task('promoteToOwner', { email: userEmail });
+    const chapterId = 1;
+
+    cy.createChapter(chapterData).then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body.errors).not.to.exist;
+
+      cy.visit(`/dashboard/chapters/${chapterId}`);
+      cy.contains(chapterData.name);
+    });
+    cy.createVenue({ chapterId }, venueData).then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body.errors).not.to.exist;
+
+      cy.visit(`/dashboard/venues/`);
+      cy.contains(venueData.name);
+    });
+    cy.createEvent(chapterId, eventData).then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body.errors).not.to.exist;
+
+      cy.visit(`/dashboard/events/`);
+      cy.contains(eventData.name);
+    });
+  });
+
   it('only allows owners to create chapters', () => {
+    cy.task('seedDb');
     cy.login('admin@of.chapter.one');
 
     cy.visit('/dashboard/chapters');

--- a/cypress/e2e/dashboard/chapters/chapters-index.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapters-index.cy.ts
@@ -95,7 +95,7 @@ describe('chapters dashboard', () => {
   });
 
   it('lets a user create a chapter and an event in a fresh instance', () => {
-    cy.exec('npm run db:sync && npm run db:init');
+    cy.exec('npm run db:init');
     const userEmail = 'fresh@start';
     cy.login(userEmail);
     cy.task('promoteToOwner', { email: userEmail });

--- a/server/prisma/generator/factories/rsvps.factory.ts
+++ b/server/prisma/generator/factories/rsvps.factory.ts
@@ -3,16 +3,19 @@ import { sub } from 'date-fns';
 import { prisma } from '../../../src/prisma';
 import { random, randomItems } from '../lib/random';
 
+export const createRsvpTypes = async () => {
+  const rsvpNames = ['yes', 'no', 'maybe', 'waitlist'];
+  await prisma.rsvp.createMany({
+    data: rsvpNames.map((rsvp) => ({ name: rsvp })),
+  });
+};
+
 const createRsvps = async (
   eventIds: number[],
   userIds: number[],
   eventRoles: Record<string, { name: string; id: number }>,
 ) => {
-  const rsvpNames = ['yes', 'no', 'maybe', 'waitlist'];
-  await prisma.rsvp.createMany({
-    data: rsvpNames.map((rsvp) => ({ name: rsvp })),
-  });
-
+  await createRsvpTypes();
   for (const eventId of eventIds) {
     const eventUserIds = randomItems(userIds, userIds.length / 2);
     const numberWaiting = 1 + random(eventUserIds.length - 2);

--- a/server/prisma/generator/init.ts
+++ b/server/prisma/generator/init.ts
@@ -1,3 +1,4 @@
+import { prisma } from '../../src/prisma';
 import createChapterRoles from './factories/chapterRoles.factory';
 import createEventRoles from './factories/eventRoles.factory';
 import createInstanceRoles from './factories/instanceRoles.factory';
@@ -5,8 +6,14 @@ import { createRsvpTypes } from './factories/rsvps.factory';
 
 const myArgs = process.argv.slice(2);
 if (myArgs.length === 1 && myArgs[0] === '--execute') {
-  createRoles();
-  createRsvpTypes();
+  // First truncate any existing tables. This is necessary in testing, because
+  // the database needs to be initialized before use. However, if we recreate
+  // the schema, cached queries targetting the old schema will fail with ERROR:
+  // cached plan must not change result type.
+  truncateTables().then(() => {
+    createRoles();
+    createRsvpTypes();
+  });
 } else if (myArgs.length === 0) {
   // do nothing, it's just being imported and will be called by the importing script
 } else {
@@ -16,7 +23,25 @@ if (myArgs.length === 1 && myArgs[0] === '--execute') {
 `);
 }
 
-async function createRoles() {
+export async function truncateTables() {
+  const tablenames = await prisma.$queryRaw<
+    Array<{ tablename: string }>
+  >`SELECT tablename FROM pg_tables WHERE schemaname='public'`;
+
+  for (const { tablename } of tablenames) {
+    if (tablename !== '_prisma_migrations') {
+      try {
+        await prisma.$executeRawUnsafe(
+          `TRUNCATE TABLE "public"."${tablename}" RESTART IDENTITY CASCADE;`,
+        );
+      } catch (error) {
+        console.log({ error });
+      }
+    }
+  }
+}
+
+export async function createRoles() {
   const instanceRoles = await createInstanceRoles();
   const eventRoles = await createEventRoles();
   const chapterRoles = await createChapterRoles();

--- a/server/prisma/generator/init.ts
+++ b/server/prisma/generator/init.ts
@@ -1,10 +1,12 @@
 import createChapterRoles from './factories/chapterRoles.factory';
 import createEventRoles from './factories/eventRoles.factory';
 import createInstanceRoles from './factories/instanceRoles.factory';
+import { createRsvpTypes } from './factories/rsvps.factory';
 
 const myArgs = process.argv.slice(2);
 if (myArgs.length === 1 && myArgs[0] === '--execute') {
   createRoles();
+  createRsvpTypes();
 } else if (myArgs.length === 0) {
   // do nothing, it's just being imported and will be called by the importing script
 } else {

--- a/server/prisma/generator/seed.ts
+++ b/server/prisma/generator/seed.ts
@@ -1,5 +1,4 @@
-import { prisma } from '../../src/prisma';
-import createRoles from './init';
+import { truncateTables, createRoles } from './init';
 import createChapters from './factories/chapters.factory';
 import createEvents from './factories/events.factory';
 import createRsvps from './factories/rsvps.factory';
@@ -9,22 +8,7 @@ import createVenues from './factories/venues.factory';
 import setupRoles from './setupRoles';
 
 (async () => {
-  const tablenames = await prisma.$queryRaw<
-    Array<{ tablename: string }>
-  >`SELECT tablename FROM pg_tables WHERE schemaname='public'`;
-
-  for (const { tablename } of tablenames) {
-    if (tablename !== '_prisma_migrations') {
-      try {
-        await prisma.$executeRawUnsafe(
-          `TRUNCATE TABLE "public"."${tablename}" RESTART IDENTITY CASCADE;`,
-        );
-      } catch (error) {
-        console.log({ error });
-      }
-    }
-  }
-
+  await truncateTables();
   const { instanceRoles, chapterRoles, eventRoles } = await createRoles();
 
   const { ownerId, chapter1AdminId, chapter2AdminId, bannedAdminId, userIds } =


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

The majority of changes were to the test code, to ensure that a fresh start is tested at least once.  Their organisation is a little messy now, but I'm not sure there's an obviously better approach.

The issue itself was simply that the rsvp table had no entries causing event creation to fail (it tries to connect and fails)

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
