### PR TITLE
feat: change permission for displaying edit sponsor form

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -4477,6 +4477,39 @@
             "deprecationReason": null
           },
           {
+            "name": "dashboardSponsor",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Sponsor",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "event",
             "description": null,
             "args": [
@@ -4700,35 +4733,6 @@
                 "name": "PaginatedEventsWithTotal",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sponsor",
-            "description": null,
-            "args": [
-              {
-                "name": "id",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Sponsor",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -457,6 +457,7 @@ export type Query = {
   chapters: Array<ChapterWithEvents>;
   dashboardChapter: ChapterWithRelations;
   dashboardEvent?: Maybe<EventWithRelations>;
+  dashboardSponsor: Sponsor;
   event?: Maybe<EventWithRelations>;
   eventRoles: Array<EventRole>;
   events: Array<EventWithRelations>;
@@ -464,7 +465,6 @@ export type Query = {
   me?: Maybe<UserWithInstanceRole>;
   paginatedEvents: Array<EventWithChapter>;
   paginatedEventsWithTotal: PaginatedEventsWithTotal;
-  sponsor?: Maybe<Sponsor>;
   sponsorWithEvents: SponsorWithEvents;
   sponsors: Array<Sponsor>;
   users: Array<UserWithInstanceRole>;
@@ -496,6 +496,10 @@ export type QueryDashboardEventArgs = {
   eventId: Scalars['Int'];
 };
 
+export type QueryDashboardSponsorArgs = {
+  id: Scalars['Int'];
+};
+
 export type QueryEventArgs = {
   eventId: Scalars['Int'];
 };
@@ -513,10 +517,6 @@ export type QueryPaginatedEventsArgs = {
 export type QueryPaginatedEventsWithTotalArgs = {
   limit?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
-};
-
-export type QuerySponsorArgs = {
-  id: Scalars['Int'];
 };
 
 export type QuerySponsorWithEventsArgs = {
@@ -1175,20 +1175,20 @@ export type UpdateSponsorMutation = {
   };
 };
 
-export type SponsorQueryVariables = Exact<{
+export type DashboardSponsorQueryVariables = Exact<{
   sponsorId: Scalars['Int'];
 }>;
 
-export type SponsorQuery = {
+export type DashboardSponsorQuery = {
   __typename?: 'Query';
-  sponsor?: {
+  dashboardSponsor: {
     __typename?: 'Sponsor';
     id: number;
     name: string;
     website: string;
     logo_path: string;
     type: string;
-  } | null;
+  };
 };
 
 export type SponsorWithEventsQueryVariables = Exact<{
@@ -3317,9 +3317,9 @@ export type UpdateSponsorMutationOptions = Apollo.BaseMutationOptions<
   UpdateSponsorMutation,
   UpdateSponsorMutationVariables
 >;
-export const SponsorDocument = gql`
-  query sponsor($sponsorId: Int!) {
-    sponsor(id: $sponsorId) {
+export const DashboardSponsorDocument = gql`
+  query dashboardSponsor($sponsorId: Int!) {
+    dashboardSponsor(id: $sponsorId) {
       id
       name
       website
@@ -3330,47 +3330,54 @@ export const SponsorDocument = gql`
 `;
 
 /**
- * __useSponsorQuery__
+ * __useDashboardSponsorQuery__
  *
- * To run a query within a React component, call `useSponsorQuery` and pass it any options that fit your needs.
- * When your component renders, `useSponsorQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useDashboardSponsorQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDashboardSponsorQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSponsorQuery({
+ * const { data, loading, error } = useDashboardSponsorQuery({
  *   variables: {
  *      sponsorId: // value for 'sponsorId'
  *   },
  * });
  */
-export function useSponsorQuery(
-  baseOptions: Apollo.QueryHookOptions<SponsorQuery, SponsorQueryVariables>,
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<SponsorQuery, SponsorQueryVariables>(
-    SponsorDocument,
-    options,
-  );
-}
-export function useSponsorLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    SponsorQuery,
-    SponsorQueryVariables
+export function useDashboardSponsorQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    DashboardSponsorQuery,
+    DashboardSponsorQueryVariables
   >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<SponsorQuery, SponsorQueryVariables>(
-    SponsorDocument,
+  return Apollo.useQuery<DashboardSponsorQuery, DashboardSponsorQueryVariables>(
+    DashboardSponsorDocument,
     options,
   );
 }
-export type SponsorQueryHookResult = ReturnType<typeof useSponsorQuery>;
-export type SponsorLazyQueryHookResult = ReturnType<typeof useSponsorLazyQuery>;
-export type SponsorQueryResult = Apollo.QueryResult<
-  SponsorQuery,
-  SponsorQueryVariables
+export function useDashboardSponsorLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    DashboardSponsorQuery,
+    DashboardSponsorQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    DashboardSponsorQuery,
+    DashboardSponsorQueryVariables
+  >(DashboardSponsorDocument, options);
+}
+export type DashboardSponsorQueryHookResult = ReturnType<
+  typeof useDashboardSponsorQuery
+>;
+export type DashboardSponsorLazyQueryHookResult = ReturnType<
+  typeof useDashboardSponsorLazyQuery
+>;
+export type DashboardSponsorQueryResult = Apollo.QueryResult<
+  DashboardSponsorQuery,
+  DashboardSponsorQueryVariables
 >;
 export const SponsorWithEventsDocument = gql`
   query sponsorWithEvents($sponsorId: Int!) {

--- a/client/src/modules/dashboard/Sponsors/components/SponsorForm.tsx
+++ b/client/src/modules/dashboard/Sponsors/components/SponsorForm.tsx
@@ -4,9 +4,10 @@ import { Select } from '@chakra-ui/select';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { VStack } from '@chakra-ui/layout';
+
 import { Input } from '../../../../components/Form/Input';
 import styles from '../../../../styles/Form.module.css';
-import { Sponsor, SponsorQuery } from 'generated/graphql';
+import { DashboardSponsorQuery, Sponsor } from '../../../../generated/graphql';
 
 export type SponsorFormData = Omit<
   Sponsor,
@@ -16,7 +17,7 @@ export type SponsorFormData = Omit<
 interface SponsorFormProps {
   loading: boolean;
   onSubmit: (data: SponsorFormData) => Promise<void>;
-  data?: SponsorQuery;
+  data?: DashboardSponsorQuery;
   submitText: string;
   loadingText: string;
 }
@@ -48,7 +49,7 @@ const fields: FormField[] = [
 ];
 const SponsorForm: React.FC<SponsorFormProps> = (props) => {
   const { loading, onSubmit, data, submitText, loadingText } = props;
-  const sponsor = data?.sponsor;
+  const sponsor = data?.dashboardSponsor;
   const defaultValues: SponsorFormData = {
     name: sponsor?.name ?? '',
     website: sponsor?.website ?? '',

--- a/client/src/modules/dashboard/Sponsors/graphql/queries.ts
+++ b/client/src/modules/dashboard/Sponsors/graphql/queries.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
-export const SPONSOR = gql`
-  query sponsor($sponsorId: Int!) {
-    sponsor(id: $sponsorId) {
+export const DASHBOARD_SPONSOR = gql`
+  query dashboardSponsor($sponsorId: Int!) {
+    dashboardSponsor(id: $sponsorId) {
       id
       name
       website

--- a/cypress/e2e/dashboard/pages-needing-permission.cy.ts
+++ b/cypress/e2e/dashboard/pages-needing-permission.cy.ts
@@ -47,12 +47,9 @@ describe('all dashboards', () => {
     cy.get('[data-cy=loading-error]').should('be.visible');
     cy.contains(deniedText);
 
-    // TODO: EditSponsorPage should be denied, too, but it shares a resolver
-    // with SponsorPage (which should not be denied), so it needs a separate
-    // resolver protected by SponsorManage.
-    // cy.visit(`/dashboard/sponsors/1/edit`);
-    // cy.get('[data-cy=loading-error]').should('be.visible');
-    // cy.contains(deniedText);
+    cy.visit(`/dashboard/sponsors/1/edit`);
+    cy.get('[data-cy=loading-error]').should('be.visible');
+    cy.contains(deniedText);
   }
 
   function visitNonMemberDashboards() {

--- a/server/src/controllers/Sponsors/resolver.ts
+++ b/server/src/controllers/Sponsors/resolver.ts
@@ -13,10 +13,11 @@ export class SponsorResolver {
   sponsors(): Promise<Sponsor[]> {
     return prisma.sponsors.findMany();
   }
-  @Authorized(Permission.SponsorView)
-  @Query(() => Sponsor, { nullable: true })
-  sponsor(@Arg('id', () => Int) id: number): Promise<Sponsor | null> {
-    return prisma.sponsors.findUnique({ where: { id } });
+
+  @Authorized(Permission.SponsorManage)
+  @Query(() => Sponsor)
+  dashboardSponsor(@Arg('id', () => Int) id: number): Promise<Sponsor> {
+    return prisma.sponsors.findUniqueOrThrow({ where: { id } });
   }
 
   @Authorized(Permission.SponsorView)


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Ref: #1608

---

- Changes permission for _viewing data_ in the sponsor form edit.
- As it turned out, the `sponsor` resolver was used only for filling edit sponsor form. As such new resolver wasn't needed, but I've renamed it for clarity. And removed the nullable return.