### PR TITLE
fix: client sponsor actions displaying

### DIFF
--- a/client/src/modules/dashboard/Sponsors/pages/SponsorsPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/SponsorsPage.tsx
@@ -4,8 +4,11 @@ import { LinkButton } from 'chakra-next-link';
 import { NextPage } from 'next';
 import Head from 'next/head';
 import React from 'react';
+
+import { useCheckPermission } from '../../../../hooks/useCheckPermission';
 import { Layout } from '../../shared/components/Layout';
 import { DashboardLoading } from '../../shared/components/DashboardLoading';
+import { Permission } from '../../../../../../common/permissions';
 import { useSponsorsQuery } from 'generated/graphql';
 
 export const SponsorsPage: NextPage = () => {
@@ -24,9 +27,11 @@ export const SponsorsPage: NextPage = () => {
         <VStack>
           <Flex w="full" justify="space-between">
             <Heading id="page-heading">Sponsors</Heading>
-            <LinkButton href="/dashboard/sponsors/new" colorScheme={'blue'}>
-              Add new
-            </LinkButton>
+            {useCheckPermission(Permission.SponsorManage) && (
+              <LinkButton href="/dashboard/sponsors/new" colorScheme="blue">
+                Add new
+              </LinkButton>
+            )}
           </Flex>
           <Box width={'100%'}>
             <Box display={{ base: 'none', lg: 'block' }}>
@@ -42,15 +47,16 @@ export const SponsorsPage: NextPage = () => {
                   ),
                   type: (sponsor) => sponsor.type,
                   website: (sponsor) => sponsor.website,
-                  action: (sponsor) => (
-                    <LinkButton
-                      colorScheme="blue"
-                      size="xs"
-                      href={`/dashboard/sponsors/${sponsor.id}/edit`}
-                    >
-                      Edit
-                    </LinkButton>
-                  ),
+                  action: (sponsor) =>
+                    useCheckPermission(Permission.SponsorManage) && (
+                      <LinkButton
+                        colorScheme="blue"
+                        size="xs"
+                        href={`/dashboard/sponsors/${sponsor.id}/edit`}
+                      >
+                        Edit
+                      </LinkButton>
+                    ),
                 }}
               />
             </Box>

--- a/client/src/modules/dashboard/shared/components/Layout.tsx
+++ b/client/src/modules/dashboard/shared/components/Layout.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 
 import { Permission } from '../../../../../../common/permissions';
-import { useCheckPermission } from 'hooks/useCheckPermission';
+import { useCheckPermission } from '../../../../hooks/useCheckPermission';
 
 const links = [
   { text: 'Chapters', link: '/dashboard/chapters' },
@@ -13,7 +13,7 @@ const links = [
   {
     text: 'Sponsors',
     link: '/dashboard/sponsors',
-    requiredPermission: Permission.SponsorManage,
+    requiredPermission: Permission.SponsorView,
   },
   { text: 'Users', link: '/dashboard/users' },
 ];


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Shows _Sponsors_ button in dashboard for those with (instance) `SponsorView` permission.
- Hides actions (_Add Sponsor_, _Edit_) buttons for those without (instance) `SponsorManage` permission.
