### PR TITLE
feat: internal chapter_administrator instance role

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -2929,14 +2929,14 @@
                 "deprecationReason": null
               },
               {
-                "name": "roleId",
+                "name": "roleName",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   }
                 },
@@ -2978,14 +2978,14 @@
             "description": null,
             "args": [
               {
-                "name": "roleId",
+                "name": "roleName",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   }
                 },

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -317,12 +317,12 @@ export type MutationCancelRsvpArgs = {
 
 export type MutationChangeChapterUserRoleArgs = {
   chapterId: Scalars['Int'];
-  roleId: Scalars['Int'];
+  roleName: Scalars['String'];
   userId: Scalars['Int'];
 };
 
 export type MutationChangeInstanceUserRoleArgs = {
-  roleId: Scalars['Int'];
+  roleName: Scalars['String'];
   userId: Scalars['Int'];
 };
 
@@ -862,7 +862,7 @@ export type UnbanUserMutation = {
 
 export type ChangeChapterUserRoleMutationVariables = Exact<{
   chapterId: Scalars['Int'];
-  roleId: Scalars['Int'];
+  roleName: Scalars['String'];
   userId: Scalars['Int'];
 }>;
 
@@ -870,7 +870,7 @@ export type ChangeChapterUserRoleMutation = {
   __typename?: 'Mutation';
   changeChapterUserRole: {
     __typename?: 'ChapterUser';
-    chapter_role: { __typename?: 'ChapterRole'; id: number };
+    chapter_role: { __typename?: 'ChapterRole'; name: string };
   };
 };
 
@@ -1178,7 +1178,7 @@ export type SponsorWithEventsQuery = {
 };
 
 export type ChangeInstanceUserRoleMutationVariables = Exact<{
-  roleId: Scalars['Int'];
+  roleName: Scalars['String'];
   userId: Scalars['Int'];
 }>;
 
@@ -1186,7 +1186,7 @@ export type ChangeInstanceUserRoleMutation = {
   __typename?: 'Mutation';
   changeInstanceUserRole: {
     __typename?: 'UserWithInstanceRole';
-    instance_role: { __typename?: 'InstanceRole'; id: number };
+    instance_role: { __typename?: 'InstanceRole'; name: string };
   };
 };
 
@@ -2277,16 +2277,16 @@ export type UnbanUserMutationOptions = Apollo.BaseMutationOptions<
 export const ChangeChapterUserRoleDocument = gql`
   mutation changeChapterUserRole(
     $chapterId: Int!
-    $roleId: Int!
+    $roleName: String!
     $userId: Int!
   ) {
     changeChapterUserRole(
       chapterId: $chapterId
-      roleId: $roleId
+      roleName: $roleName
       userId: $userId
     ) {
       chapter_role {
-        id
+        name
       }
     }
   }
@@ -2310,7 +2310,7 @@ export type ChangeChapterUserRoleMutationFn = Apollo.MutationFunction<
  * const [changeChapterUserRoleMutation, { data, loading, error }] = useChangeChapterUserRoleMutation({
  *   variables: {
  *      chapterId: // value for 'chapterId'
- *      roleId: // value for 'roleId'
+ *      roleName: // value for 'roleName'
  *      userId: // value for 'userId'
  *   },
  * });
@@ -3362,10 +3362,10 @@ export type SponsorWithEventsQueryResult = Apollo.QueryResult<
   SponsorWithEventsQueryVariables
 >;
 export const ChangeInstanceUserRoleDocument = gql`
-  mutation changeInstanceUserRole($roleId: Int!, $userId: Int!) {
-    changeInstanceUserRole(roleId: $roleId, userId: $userId) {
+  mutation changeInstanceUserRole($roleName: String!, $userId: Int!) {
+    changeInstanceUserRole(roleName: $roleName, userId: $userId) {
       instance_role {
-        id
+        name
       }
     }
   }
@@ -3388,7 +3388,7 @@ export type ChangeInstanceUserRoleMutationFn = Apollo.MutationFunction<
  * @example
  * const [changeInstanceUserRoleMutation, { data, loading, error }] = useChangeInstanceUserRoleMutation({
  *   variables: {
- *      roleId: // value for 'roleId'
+ *      roleName: // value for 'roleName'
  *      userId: // value for 'userId'
  *   },
  * });

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -61,11 +61,14 @@ export const ChapterUsersPage: NextPageWithLayout = () => {
     setChapterUser(data);
     modalProps.onOpen();
   };
-  const onModalSubmit = async (data: { newRoleId: number; userId: number }) => {
+  const onModalSubmit = async (data: {
+    newRoleName: string;
+    userId: number;
+  }) => {
     changeRoleMutation({
       variables: {
         chapterId: chapterId,
-        roleId: data.newRoleId,
+        roleName: data.newRoleName,
         userId: data.userId,
       },
     });
@@ -176,7 +179,7 @@ export const ChapterUsersPage: NextPageWithLayout = () => {
                     size="xs"
                     onClick={() =>
                       changeRole({
-                        roleId: chapter_role.id,
+                        roleName: chapter_role.name,
                         userId: user.id,
                         userName: user.name,
                       })
@@ -253,7 +256,7 @@ export const ChapterUsersPage: NextPageWithLayout = () => {
                               size="xs"
                               onClick={() =>
                                 changeRole({
-                                  roleId: chapter_role.id,
+                                  roleName: chapter_role.name,
                                   userId: user.id,
                                   userName: user.name,
                                 })

--- a/client/src/modules/dashboard/Chapters/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Chapters/graphql/mutations.ts
@@ -59,16 +59,16 @@ export const unbanUser = gql`
 export const changeChapterUserRole = gql`
   mutation changeChapterUserRole(
     $chapterId: Int!
-    $roleId: Int!
+    $roleName: String!
     $userId: Int!
   ) {
     changeChapterUserRole(
       chapterId: $chapterId
-      roleId: $roleId
+      roleName: $roleName
       userId: $userId
     ) {
       chapter_role {
-        id
+        name
       }
     }
   }

--- a/client/src/modules/dashboard/Users/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Users/graphql/mutations.ts
@@ -1,10 +1,10 @@
 import { gql } from '@apollo/client';
 
 export const changeInstanceUserRole = gql`
-  mutation changeInstanceUserRole($roleId: Int!, $userId: Int!) {
-    changeInstanceUserRole(roleId: $roleId, userId: $userId) {
+  mutation changeInstanceUserRole($roleName: String!, $userId: Int!) {
+    changeInstanceUserRole(roleName: $roleName, userId: $userId) {
       instance_role {
-        id
+        name
       }
     }
   }

--- a/client/src/modules/dashboard/Users/pages/UsersPage.tsx
+++ b/client/src/modules/dashboard/Users/pages/UsersPage.tsx
@@ -40,10 +40,10 @@ export const UsersPage: NextPageWithLayout = () => {
     modalProps.onOpen();
   };
 
-  const onModalSubmit = (data: { newRoleId: number; userId: number }) => {
+  const onModalSubmit = (data: { newRoleName: string; userId: number }) => {
     changeRoleMutation({
       variables: {
-        roleId: data.newRoleId,
+        roleName: data.newRoleName,
         userId: data.userId,
       },
     });
@@ -88,7 +88,7 @@ export const UsersPage: NextPageWithLayout = () => {
                     size="xs"
                     onClick={() =>
                       changeRole({
-                        roleId: instance_role.id,
+                        roleName: instance_role.name,
                         userId: id,
                         userName: name,
                       })
@@ -135,7 +135,7 @@ export const UsersPage: NextPageWithLayout = () => {
                         size="xs"
                         onClick={() =>
                           changeRole({
-                            roleId: instance_role.id,
+                            roleName: instance_role.name,
                             userId: id,
                             userName: name,
                           })

--- a/client/src/modules/dashboard/shared/components/RoleChangeModal.tsx
+++ b/client/src/modules/dashboard/shared/components/RoleChangeModal.tsx
@@ -6,13 +6,13 @@ import { useForm } from 'react-hook-form';
 import { Modal } from '../../../../components/Modal';
 
 export interface RoleChangeModalData {
-  roleId: number;
+  roleName: string;
   userId: number;
   userName: string;
 }
 
 interface SubmitData {
-  newRoleId: number;
+  newRoleName: string;
   userId: number;
 }
 
@@ -24,10 +24,15 @@ export const RoleChangeModal: React.FC<{
   onSubmit: (submitData: SubmitData) => void;
 }> = ({ modalProps, data, roles, title, onSubmit }) => {
   const { handleSubmit, register, setValue, getValues } = useForm<SubmitData>();
+  const currentRole = data.roleName;
 
   const confirm = useConfirm();
 
   const confirmSubmit = async (data: SubmitData) => {
+    if (data.newRoleName === currentRole) {
+      modalProps.onClose();
+      return;
+    }
     const ok = await confirm({
       body: 'Are you sure you want to change role?',
     });
@@ -37,7 +42,7 @@ export const RoleChangeModal: React.FC<{
   };
 
   setValue('userId', data.userId);
-  setValue('newRoleId', data.roleId);
+  setValue('newRoleName', data.roleName);
 
   return (
     <Modal
@@ -50,11 +55,11 @@ export const RoleChangeModal: React.FC<{
     >
       <Text>Select role for {data.userName}</Text>
       <Select
-        defaultValue={getValues('newRoleId')}
-        {...register('newRoleId', { valueAsNumber: true })}
+        defaultValue={getValues('newRoleName')}
+        {...register('newRoleName')}
       >
         {roles.map(({ id, name }) => (
-          <option key={id} value={id}>
+          <option key={id} value={name}>
             {name}
           </option>
         ))}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -23,6 +23,14 @@ const getEventUsers = (eventId: number) =>
 
 export type EventUsers = Awaited<ReturnType<typeof getEventUsers>>;
 
+const getUser = async (email: string) =>
+  await prisma.users.findUnique({
+    where: { email },
+    include: { instance_role: true },
+  });
+
+export type User = Awaited<ReturnType<typeof getUser>>;
+
 const promoteToOwner = async ({ email }: { email: string }) => {
   const name: InstanceRole['name'] = 'owner';
   return await prisma.users.update({
@@ -59,7 +67,13 @@ export default defineConfig({
         execSync('npm run db:reset');
       });
 
-      on('task', { getChapterMembers, getEventUsers, seedDb, promoteToOwner });
+      on('task', {
+        getChapterMembers,
+        getEventUsers,
+        getUser,
+        seedDb,
+        promoteToOwner,
+      });
       coverage(on, config);
       return config;
     },

--- a/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
@@ -25,6 +25,23 @@ describe('Chapter Administrator', () => {
     cy.joinChapter(firstChapterId);
   });
 
+  function confirmInstanceRole(email: string, expectedRole: string) {
+    cy.task<User>('getUser', email).then(({ instance_role: { name } }) => {
+      expect(name).to.eq(expectedRole);
+    });
+  }
+
+  function applyChapterRoleChanges(
+    userId: number,
+    changes: { chapterId: number; roleName: string }[],
+  ) {
+    for (const { chapterId, roleName } of changes) {
+      cy.changeChapterUserRole({ chapterId, userId, roleName }).then(
+        expectNoErrors,
+      );
+    }
+  }
+
   function changeChapterRole({
     userEmail,
     initialInstanceRole,
@@ -61,23 +78,6 @@ describe('Chapter Administrator', () => {
       );
       confirmInstanceRole(userEmail, expectedRole);
     });
-  }
-
-  function confirmInstanceRole(email: string, expectedRole: string) {
-    cy.task<User>('getUser', email).then(({ instance_role: { name } }) => {
-      expect(name).to.eq(expectedRole);
-    });
-  }
-
-  function applyChapterRoleChanges(
-    userId: number,
-    changes: { chapterId: number; roleName: string }[],
-  ) {
-    for (const { chapterId, roleName } of changes) {
-      cy.changeChapterUserRole({ chapterId, userId, roleName }).then(
-        expectNoErrors,
-      );
-    }
   }
 
   describe('when promoted to administrator of chapter', () => {

--- a/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
@@ -29,17 +29,17 @@ describe('Chapter Administrator', () => {
     userEmail,
     initialInstanceRole,
     changesToApply,
-    expectedRole,
+    expectedInstanceRole,
   }: {
     userEmail: string;
     initialInstanceRole: string;
     changesToApply: { chapterId: number; roleName: string }[];
-    expectedRole: string;
+    expectedInstanceRole: string;
   }) {
     cy.task<User>('getUser', userEmail).then(({ id, instance_role }) => {
       expect(instance_role.name).to.eq(initialInstanceRole);
       applyChapterRoleChanges(id, changesToApply);
-      confirmInstanceRole(userEmail, expectedRole);
+      confirmInstanceRole(userEmail, expectedInstanceRole);
     });
   }
 
@@ -89,7 +89,7 @@ describe('Chapter Administrator', () => {
         changesToApply: [
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ],
-        expectedRole: instanceRoles.CHAPTER_ADMINISTRATOR,
+        expectedInstanceRole: instanceRoles.CHAPTER_ADMINISTRATOR,
       });
     });
 
@@ -101,7 +101,7 @@ describe('Chapter Administrator', () => {
         changesToApply: [
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ],
-        expectedRole: instanceRoles.OWNER,
+        expectedInstanceRole: instanceRoles.OWNER,
       });
     });
   });
@@ -115,7 +115,7 @@ describe('Chapter Administrator', () => {
         changesToApply: [
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ],
-        expectedRole: instanceRoles.CHAPTER_ADMINISTRATOR,
+        expectedInstanceRole: instanceRoles.CHAPTER_ADMINISTRATOR,
       });
       changeChapterRole({
         userEmail: users.testUser.email,
@@ -123,7 +123,7 @@ describe('Chapter Administrator', () => {
         changesToApply: [
           { chapterId: firstChapterId, roleName: chapterRoles.MEMBER },
         ],
-        expectedRole: instanceRoles.MEMBER,
+        expectedInstanceRole: instanceRoles.MEMBER,
       });
     });
 
@@ -137,7 +137,7 @@ describe('Chapter Administrator', () => {
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           { chapterId: secondChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ],
-        expectedRole: instanceRoles.CHAPTER_ADMINISTRATOR,
+        expectedInstanceRole: instanceRoles.CHAPTER_ADMINISTRATOR,
       });
       changeChapterRole({
         userEmail: users.testUser.email,
@@ -145,7 +145,7 @@ describe('Chapter Administrator', () => {
         changesToApply: [
           { chapterId: firstChapterId, roleName: chapterRoles.MEMBER },
         ],
-        expectedRole: instanceRoles.CHAPTER_ADMINISTRATOR,
+        expectedInstanceRole: instanceRoles.CHAPTER_ADMINISTRATOR,
       });
     });
 
@@ -159,7 +159,7 @@ describe('Chapter Administrator', () => {
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           { chapterId: secondChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ],
-        expectedRole: instanceRoles.CHAPTER_ADMINISTRATOR,
+        expectedInstanceRole: instanceRoles.CHAPTER_ADMINISTRATOR,
       });
       changeChapterRole({
         userEmail: users.testUser.email,
@@ -168,7 +168,7 @@ describe('Chapter Administrator', () => {
           { chapterId: firstChapterId, roleName: chapterRoles.MEMBER },
           { chapterId: secondChapterId, roleName: chapterRoles.MEMBER },
         ],
-        expectedRole: instanceRoles.MEMBER,
+        expectedInstanceRole: instanceRoles.MEMBER,
       });
     });
 
@@ -181,7 +181,7 @@ describe('Chapter Administrator', () => {
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           { chapterId: secondChapterId, roleName: chapterRoles.MEMBER },
         ],
-        expectedRole: instanceRoles.OWNER,
+        expectedInstanceRole: instanceRoles.OWNER,
       });
     });
   });
@@ -195,7 +195,7 @@ describe('Chapter Administrator', () => {
         changesToApply: [
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ],
-        expectedRole: instanceRoles.CHAPTER_ADMINISTRATOR,
+        expectedInstanceRole: instanceRoles.CHAPTER_ADMINISTRATOR,
       });
       changeInstanceRole({
         userEmail: users.testUser.email,
@@ -219,7 +219,7 @@ describe('Chapter Administrator', () => {
         changesToApply: [
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ],
-        expectedRole: instanceRoles.CHAPTER_ADMINISTRATOR,
+        expectedInstanceRole: instanceRoles.CHAPTER_ADMINISTRATOR,
       });
       changeInstanceRole({
         userEmail: users.testUser.email,
@@ -237,7 +237,7 @@ describe('Chapter Administrator', () => {
         changesToApply: [
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ],
-        expectedRole: instanceRoles.CHAPTER_ADMINISTRATOR,
+        expectedInstanceRole: instanceRoles.CHAPTER_ADMINISTRATOR,
       });
       changeInstanceRole({
         userEmail: users.testUser.email,

--- a/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
@@ -9,14 +9,14 @@ describe('Chapter Administrator', () => {
   let instanceRoles;
   let users;
   before(() => {
-    cy.fixture('chapterRoles').then((r) => {
-      chapterRoles = r;
+    cy.fixture('chapterRoles').then((fixture) => {
+      chapterRoles = fixture;
     });
-    cy.fixture('instanceRoles').then((r) => {
-      instanceRoles = r;
+    cy.fixture('instanceRoles').then((fixture) => {
+      instanceRoles = fixture;
     });
-    cy.fixture('users').then((u) => {
-      users = u;
+    cy.fixture('users').then((fixture) => {
+      users = fixture;
     });
   });
   beforeEach(() => {

--- a/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
@@ -31,7 +31,7 @@ describe('Chapter Administrator', () => {
       cy.task<User>('getUser', users.testUser.email).then(
         ({ id, instance_role }) => {
           expect(instance_role.name).to.eq(instanceRoles.MEMBER);
-          sequenceChangeChapterUserRole(id, [
+          applyChapterRoleChanges(id, [
             { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           ]);
         },
@@ -47,7 +47,7 @@ describe('Chapter Administrator', () => {
       cy.task<User>('getUser', users.owner.email).then(
         ({ id, instance_role }) => {
           expect(instance_role.name).to.eq(instanceRoles.OWNER);
-          sequenceChangeChapterUserRole(id, [
+          applyChapterRoleChanges(id, [
             { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           ]);
         },
@@ -60,7 +60,7 @@ describe('Chapter Administrator', () => {
     it('chapter_administrator should receive member instance role', () => {
       cy.login();
       cy.task<User>('getUser', users.testUser.email).then(({ id }) => {
-        sequenceChangeChapterUserRole(id, [
+        applyChapterRoleChanges(id, [
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ]);
         confirmInstanceRole(
@@ -68,7 +68,7 @@ describe('Chapter Administrator', () => {
           instanceRoles.CHAPTER_ADMINISTRATOR,
         );
 
-        sequenceChangeChapterUserRole(id, [
+        applyChapterRoleChanges(id, [
           { chapterId: firstChapterId, roleName: chapterRoles.MEMBER },
         ]);
       });
@@ -80,7 +80,7 @@ describe('Chapter Administrator', () => {
       cy.joinChapter(secondChapterId);
       cy.login();
       cy.task<User>('getUser', users.testUser.email).then(({ id }) => {
-        sequenceChangeChapterUserRole(id, [
+        applyChapterRoleChanges(id, [
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           { chapterId: secondChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ]);
@@ -89,7 +89,7 @@ describe('Chapter Administrator', () => {
           instanceRoles.CHAPTER_ADMINISTRATOR,
         );
 
-        sequenceChangeChapterUserRole(id, [
+        applyChapterRoleChanges(id, [
           { chapterId: firstChapterId, roleName: chapterRoles.MEMBER },
         ]);
       });
@@ -104,7 +104,7 @@ describe('Chapter Administrator', () => {
       cy.joinChapter(secondChapterId);
       cy.login();
       cy.task<User>('getUser', users.testUser.email).then(({ id }) => {
-        sequenceChangeChapterUserRole(id, [
+        applyChapterRoleChanges(id, [
           { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           { chapterId: secondChapterId, roleName: chapterRoles.ADMINISTRATOR },
         ]);
@@ -113,7 +113,7 @@ describe('Chapter Administrator', () => {
           instanceRoles.CHAPTER_ADMINISTRATOR,
         );
 
-        sequenceChangeChapterUserRole(id, [
+        applyChapterRoleChanges(id, [
           { chapterId: firstChapterId, roleName: chapterRoles.MEMBER },
           { chapterId: secondChapterId, roleName: chapterRoles.MEMBER },
         ]);
@@ -126,7 +126,7 @@ describe('Chapter Administrator', () => {
       cy.task<User>('getUser', users.owner.email).then(
         ({ id, instance_role }) => {
           expect(instance_role.name).to.eq(instanceRoles.OWNER);
-          sequenceChangeChapterUserRole(id, [
+          applyChapterRoleChanges(id, [
             { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
             { chapterId: secondChapterId, roleName: chapterRoles.MEMBER },
           ]);
@@ -142,7 +142,7 @@ describe('Chapter Administrator', () => {
       cy.task<User>('getUser', users.testUser.email).then(
         ({ id, instance_role }) => {
           expect(instance_role.name).to.eq(instanceRoles.MEMBER);
-          sequenceChangeChapterUserRole(id, [
+          applyChapterRoleChanges(id, [
             { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           ]);
           cy.changeInstanceUserRole({
@@ -168,7 +168,7 @@ describe('Chapter Administrator', () => {
       cy.task<User>('getUser', users.testUser.email).then(
         ({ id, instance_role }) => {
           expect(instance_role.name).to.eq(instanceRoles.MEMBER);
-          sequenceChangeChapterUserRole(id, [
+          applyChapterRoleChanges(id, [
             { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           ]);
           confirmInstanceRole(
@@ -193,7 +193,7 @@ describe('Chapter Administrator', () => {
       cy.task<User>('getUser', users.testUser.email).then(
         ({ id, instance_role }) => {
           expect(instance_role.name).to.eq(instanceRoles.MEMBER);
-          sequenceChangeChapterUserRole(id, [
+          applyChapterRoleChanges(id, [
             { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           ]);
           confirmInstanceRole(
@@ -224,7 +224,7 @@ describe('Chapter Administrator', () => {
     });
   }
 
-  function sequenceChangeChapterUserRole(
+  function applyChapterRoleChanges(
     userId: number,
     changes: { chapterId: number; roleName: string }[],
   ) {

--- a/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
@@ -1,0 +1,195 @@
+import { User } from '../../../../cypress.config';
+import { expectNoErrors } from '../../../support/util';
+
+const firstChapterId = 1;
+const secondChapterId = 2;
+
+describe('Chapter Administrator', () => {
+  let chapterRoles;
+  let instanceRoles;
+  let users;
+  before(() => {
+    cy.fixture('chapterRoles').then((r) => {
+      chapterRoles = r;
+    });
+    cy.fixture('instanceRoles').then((r) => {
+      instanceRoles = r;
+    });
+    cy.fixture('users').then((u) => {
+      users = u;
+    });
+  });
+  beforeEach(() => {
+    cy.task('seedDb');
+    cy.login(users.testUser.email);
+    cy.joinChapter(firstChapterId);
+  });
+
+  describe('when promoted to administrator of chapter', () => {
+    it('instance member should get chapter_administrator instance role', () => {
+      cy.login();
+      cy.task<User>('getUser', users.testUser.email).then(
+        ({ id, instance_role }) => {
+          expect(instance_role.name).to.eq(instanceRoles.MEMBER);
+          sequenceChangeChapterUserRole(id, [
+            { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
+          ]);
+        },
+      );
+      confirmInstanceRole(
+        users.testUser.email,
+        instanceRoles.CHAPTER_ADMINISTRATOR,
+      );
+    });
+
+    it('instance owner should keep instance role', () => {
+      cy.login();
+      cy.task<User>('getUser', users.owner.email).then(
+        ({ id, instance_role }) => {
+          expect(instance_role.name).to.eq(instanceRoles.OWNER);
+          sequenceChangeChapterUserRole(id, [
+            { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
+          ]);
+          cy.changeChapterUserRole({
+            chapterId: firstChapterId,
+            roleName: chapterRoles.ADMINISTRATOR,
+            userId: id,
+          }).then(expectNoErrors);
+        },
+      );
+      confirmInstanceRole(users.owner.email, instanceRoles.OWNER);
+    });
+  });
+
+  describe('when demoted from administrator of chapter', () => {
+    it('chapter_administrator should receive member instance role', () => {
+      cy.login();
+      cy.task<User>('getUser', users.testUser.email).then(({ id }) => {
+        sequenceChangeChapterUserRole(id, [
+          { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
+        ]);
+        confirmInstanceRole(
+          users.testUser.email,
+          instanceRoles.CHAPTER_ADMINISTRATOR,
+        );
+
+        sequenceChangeChapterUserRole(id, [
+          { chapterId: firstChapterId, roleName: chapterRoles.MEMBER },
+        ]);
+      });
+
+      confirmInstanceRole(users.testUser.email, instanceRoles.MEMBER);
+    });
+
+    it('administrator of multiple chapters should keep chapter_administrator instance role, when demoted in one chapter', () => {
+      cy.joinChapter(secondChapterId);
+      cy.login();
+      cy.task<User>('getUser', users.testUser.email).then(({ id }) => {
+        sequenceChangeChapterUserRole(id, [
+          { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
+          { chapterId: secondChapterId, roleName: chapterRoles.ADMINISTRATOR },
+        ]);
+        confirmInstanceRole(
+          users.testUser.email,
+          instanceRoles.CHAPTER_ADMINISTRATOR,
+        );
+
+        sequenceChangeChapterUserRole(id, [
+          { chapterId: firstChapterId, roleName: chapterRoles.MEMBER },
+        ]);
+      });
+
+      confirmInstanceRole(
+        users.testUser.email,
+        instanceRoles.CHAPTER_ADMINISTRATOR,
+      );
+    });
+
+    it('administrator of multiple chapters should receive member instance role when demoted from last administrator role', () => {
+      cy.joinChapter(secondChapterId);
+      cy.login();
+      cy.task<User>('getUser', users.testUser.email).then(({ id }) => {
+        sequenceChangeChapterUserRole(id, [
+          { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
+          { chapterId: secondChapterId, roleName: chapterRoles.ADMINISTRATOR },
+        ]);
+        confirmInstanceRole(
+          users.testUser.email,
+          instanceRoles.CHAPTER_ADMINISTRATOR,
+        );
+
+        sequenceChangeChapterUserRole(id, [
+          { chapterId: firstChapterId, roleName: chapterRoles.MEMBER },
+          { chapterId: secondChapterId, roleName: chapterRoles.MEMBER },
+        ]);
+      });
+      confirmInstanceRole(users.testUser.email, instanceRoles.MEMBER);
+    });
+
+    it('instance owner should keep instance role', () => {
+      cy.login();
+      cy.task<User>('getUser', users.owner.email).then(
+        ({ id, instance_role }) => {
+          expect(instance_role.name).to.eq(instanceRoles.OWNER);
+          sequenceChangeChapterUserRole(id, [
+            { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
+            { chapterId: secondChapterId, roleName: chapterRoles.MEMBER },
+          ]);
+        },
+      );
+      confirmInstanceRole(users.owner.email, instanceRoles.OWNER);
+    });
+  });
+
+  describe('chapter_administrator instance role', () => {
+    it('should be instance role again, when administrator of chapter is demoted from instance owner to instance member', () => {
+      cy.login();
+      cy.task<User>('getUser', users.testUser.email).then(
+        ({ id, instance_role }) => {
+          expect(instance_role.name).to.eq(instanceRoles.MEMBER);
+          sequenceChangeChapterUserRole(id, [
+            { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
+          ]);
+          cy.changeInstanceUserRole({
+            roleName: instanceRoles.OWNER,
+            userId: id,
+          }).then(expectNoErrors);
+
+          confirmInstanceRole(users.testUser.email, instanceRoles.OWNER);
+          cy.changeInstanceUserRole({
+            roleName: instanceRoles.MEMBER,
+            userId: id,
+          }).then(expectNoErrors);
+        },
+      );
+      confirmInstanceRole(
+        users.testUser.email,
+        instanceRoles.CHAPTER_ADMINISTRATOR,
+      );
+    });
+
+    it('should not be visible on users list', () => {
+      cy.login();
+      cy.visit('/dashboard/users');
+      cy.findByRole('table', { name: 'Instance Users' }).should('be.visible');
+      cy.contains('chapter_administrator').should('not.exist');
+    });
+  });
+
+  function confirmInstanceRole(email: string, expectedRole: string) {
+    cy.task<User>('getUser', email).then(({ instance_role: { name } }) => {
+      expect(name).to.eq(expectedRole);
+    });
+  }
+
+  function sequenceChangeChapterUserRole(
+    userId: number,
+    changes: { chapterId: number; roleName: string }[],
+  ) {
+    for (const { chapterId, roleName } of changes) {
+      cy.changeChapterUserRole({ chapterId, userId, roleName }).then(
+        expectNoErrors,
+      );
+    }
+  }
+});

--- a/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
@@ -163,6 +163,53 @@ describe('Chapter Administrator', () => {
       );
     });
 
+    it('should be kept when changing chapter_administrator instance role to member for administrator of chapter', () => {
+      cy.login();
+      cy.task<User>('getUser', users.testUser.email).then(
+        ({ id, instance_role }) => {
+          expect(instance_role.name).to.eq(instanceRoles.MEMBER);
+          sequenceChangeChapterUserRole(id, [
+            { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
+          ]);
+          confirmInstanceRole(
+            users.testUser.email,
+            instanceRoles.CHAPTER_ADMINISTRATOR,
+          );
+
+          cy.changeInstanceUserRole({
+            roleName: instanceRoles.MEMBER,
+            userId: id,
+          }).then(expectNoErrors);
+        },
+      );
+      confirmInstanceRole(
+        users.testUser.email,
+        instanceRoles.CHAPTER_ADMINISTRATOR,
+      );
+    });
+
+    it('should be changed to owner when changing instance role to owner, for administrator of chapter', () => {
+      cy.login();
+      cy.task<User>('getUser', users.testUser.email).then(
+        ({ id, instance_role }) => {
+          expect(instance_role.name).to.eq(instanceRoles.MEMBER);
+          sequenceChangeChapterUserRole(id, [
+            { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
+          ]);
+          confirmInstanceRole(
+            users.testUser.email,
+            instanceRoles.CHAPTER_ADMINISTRATOR,
+          );
+
+          cy.changeInstanceUserRole({
+            roleName: instanceRoles.OWNER,
+            userId: id,
+          }).then(expectNoErrors);
+        },
+      );
+      confirmInstanceRole(users.testUser.email, instanceRoles.OWNER);
+    });
+
     it('should not be visible on users list', () => {
       cy.login();
       cy.visit('/dashboard/users');

--- a/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
@@ -25,6 +25,23 @@ describe('Chapter Administrator', () => {
     cy.joinChapter(firstChapterId);
   });
 
+  function confirmInstanceRole(email: string, expectedRole: string) {
+    cy.task<User>('getUser', email).then(({ instance_role: { name } }) => {
+      expect(name).to.eq(expectedRole);
+    });
+  }
+
+  function applyChapterRoleChanges(
+    userId: number,
+    changes: { chapterId: number; roleName: string }[],
+  ) {
+    for (const { chapterId, roleName } of changes) {
+      cy.changeChapterUserRole({ chapterId, userId, roleName }).then(
+        expectNoErrors,
+      );
+    }
+  }
+
   describe('when promoted to administrator of chapter', () => {
     it('instance member should get chapter_administrator instance role', () => {
       cy.login();
@@ -217,21 +234,4 @@ describe('Chapter Administrator', () => {
       cy.contains('chapter_administrator').should('not.exist');
     });
   });
-
-  function confirmInstanceRole(email: string, expectedRole: string) {
-    cy.task<User>('getUser', email).then(({ instance_role: { name } }) => {
-      expect(name).to.eq(expectedRole);
-    });
-  }
-
-  function applyChapterRoleChanges(
-    userId: number,
-    changes: { chapterId: number; roleName: string }[],
-  ) {
-    for (const { chapterId, roleName } of changes) {
-      cy.changeChapterUserRole({ chapterId, userId, roleName }).then(
-        expectNoErrors,
-      );
-    }
-  }
 });

--- a/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapter-administrator.cy.ts
@@ -50,11 +50,6 @@ describe('Chapter Administrator', () => {
           sequenceChangeChapterUserRole(id, [
             { chapterId: firstChapterId, roleName: chapterRoles.ADMINISTRATOR },
           ]);
-          cy.changeChapterUserRole({
-            chapterId: firstChapterId,
-            roleName: chapterRoles.ADMINISTRATOR,
-            userId: id,
-          }).then(expectNoErrors);
         },
       );
       confirmInstanceRole(users.owner.email, instanceRoles.OWNER);

--- a/cypress/e2e/dashboard/chapters/users.cy.ts
+++ b/cypress/e2e/dashboard/chapters/users.cy.ts
@@ -65,7 +65,7 @@ describe('Chapter Users dashboard', () => {
     });
   });
 
-  // Currently only instance users can change chapter roles
+  // Currently only instance owners can change chapter roles
   it('rejects chapter admin from changing chapter user role', () => {
     cy.login('admin@of.chapter.one');
 
@@ -78,14 +78,14 @@ describe('Chapter Users dashboard', () => {
           ({ user: { name } }) => name === 'Chapter One Admin',
         ).user.id;
         cy.getChapterRoles().then((roles) => {
-          const roleIds = roles.map(({ id }) => id);
-          roleIds.forEach((roleId) => {
-            cy.changeChapterUserRole({ chapterId, roleId, userId }).then(
+          const roleNames = roles.map(({ name }) => name);
+          roleNames.forEach((roleName) => {
+            cy.changeChapterUserRole({ chapterId, roleName, userId }).then(
               expectToBeRejected,
             );
             cy.changeChapterUserRole({
               chapterId,
-              roleId,
+              roleName,
               userId: selfUserId,
             }).then(expectToBeRejected);
           });

--- a/cypress/fixtures/chapterRoles.json
+++ b/cypress/fixtures/chapterRoles.json
@@ -1,0 +1,4 @@
+{
+  "ADMINISTRATOR": "administrator",
+  "MEMBER": "member"
+}

--- a/cypress/fixtures/instanceRoles.json
+++ b/cypress/fixtures/instanceRoles.json
@@ -1,0 +1,5 @@
+{
+  "CHAPTER_ADMINISTRATOR": "chapter_administrator",
+  "MEMBER": "member",
+  "OWNER": "owner"
+}

--- a/cypress/fixtures/users.json
+++ b/cypress/fixtures/users.json
@@ -1,0 +1,22 @@
+{
+  "bannedAdmin": {
+    "email": "banned@chapter.admin",
+    "name": "Banned Chapter Admin"
+  },
+  "chapter1Admin": {
+    "email": "admin@of.chapter.one",
+    "name": "Chapter One Admin"
+  },
+  "chapter2Admin": {
+    "email": "admin@of.chapter.two",
+    "name": "Chapter Two Admin"
+  },
+  "owner": {
+    "email": "foo@bar.com",
+    "name": "The Owner"
+  },
+  "testUser": {
+    "email": "test@user.org",
+    "name": "Test User"
+  }
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -576,25 +576,25 @@ Cypress.Commands.add('toggleChapterSubscription', toggleChapterSubscription);
  * Change chapter user role using GQL mutation
  * @param data Data about change
  * @param data.chapterId Chapter id
- * @param data.roleId Role id
+ * @param data.roleName Role name
  * @param data.userId User id
  * @param {object} [options={ withAuth: boolean }] Optional options object.
  */
 const changeChapterUserRole = (
   {
     chapterId,
-    roleId,
+    roleName,
     userId,
-  }: { chapterId: number; roleId: number; userId: number },
+  }: { chapterId: number; roleName: string; userId: number },
   options = { withAuth: true },
 ) => {
   const chapterUserRoleMutation = {
     operationName: 'changeChapterUserRole',
-    variables: { chapterId, roleId, userId },
-    query: `mutation changeChapterUserRole($chapterId: Int!, $roleId: Int!, $userId: Int!) {
-      changeChapterUserRole(chapterId: $chapterId, roleId: $roleId, userId: $userId) {
+    variables: { chapterId, roleName, userId },
+    query: `mutation changeChapterUserRole($chapterId: Int!, $roleName: String!, $userId: Int!) {
+      changeChapterUserRole(chapterId: $chapterId, roleName: $roleName, userId: $userId) {
         chapter_role {
-          id
+          name
         }
       }
     }`,

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -607,6 +607,35 @@ const changeChapterUserRole = (
 Cypress.Commands.add('changeChapterUserRole', changeChapterUserRole);
 
 /**
+ * Change user instance role using GQL mutation
+ * @param data Data about change
+ * @param data.roleName Role name
+ * @param data.userId User id
+ * @param {object} [options={ withAuth: boolean }] Optional options object.
+ */
+const changeInstanceUserRole = (
+  { roleName, userId }: { roleName: string; userId: number },
+  options = { withAuth: true },
+) => {
+  const instanceUserRoleMutation = {
+    operationName: 'changeInstanceUserRole',
+    variables: { roleName, userId },
+    query: `mutation changeInstanceUserRole($roleName: String!, $userId: Int!) {
+      changeInstanceUserRole(roleName: $roleName, userId: $userId) {
+        instance_role {
+          name
+        }
+      }
+    }`,
+  };
+  const requestOptions = gqlOptions(instanceUserRoleMutation);
+  return options.withAuth
+    ? cy.authedRequest(requestOptions)
+    : cy.request(requestOptions);
+};
+Cypress.Commands.add('changeInstanceUserRole', changeInstanceUserRole);
+
+/**
  * Ban user using GQL mutation
  * @param data.chapterId Chapter id
  * @param data.userId User id
@@ -706,6 +735,7 @@ declare global {
       authedRequest: typeof authedRequest;
       banUser: typeof banUser;
       changeChapterUserRole: typeof changeChapterUserRole;
+      changeInstanceUserRole: typeof changeInstanceUserRole;
       createChapter: typeof createChapter;
       createEvent: typeof createEvent;
       createSponsor: typeof createSponsor;

--- a/cypress/support/util.ts
+++ b/cypress/support/util.ts
@@ -7,6 +7,11 @@ export function expectToBeRejected(response) {
   );
 }
 
+export function expectNoErrors(response) {
+  expect(response.status).to.eq(200);
+  expect(response.body.errors).not.to.exist;
+}
+
 export function gqlOptions(body: any, additionalOptions?: any) {
   return {
     method: 'POST',

--- a/server/prisma/generator/factories/chapterRoles.factory.ts
+++ b/server/prisma/generator/factories/chapterRoles.factory.ts
@@ -4,10 +4,17 @@ import { ChapterPermission } from '../../../../common/permissions';
 
 const chapterPermissions = Object.values(ChapterPermission);
 
-const roles: Array<{
-  name: string;
-  permissions: readonly ChapterPermission[];
-}> = [
+export enum ChapterRoles {
+  administrator = 'administrator',
+  member = 'member',
+}
+
+export interface ChapterRole {
+  name: keyof typeof ChapterRoles;
+  permissions: typeof chapterPermissions;
+}
+
+const roles: ChapterRole[] = [
   {
     name: 'administrator',
     permissions: Object.values(ChapterPermission),

--- a/server/prisma/generator/factories/instanceRoles.factory.ts
+++ b/server/prisma/generator/factories/instanceRoles.factory.ts
@@ -4,7 +4,7 @@ import { InstancePermission, Permission } from '../../../../common/permissions';
 
 const allPermissions = Object.values(Permission);
 
-interface InstanceRole {
+export interface InstanceRole {
   name: 'owner' | 'chapter_administrator' | 'member';
   permissions: typeof allPermissions;
 }

--- a/server/prisma/generator/factories/instanceRoles.factory.ts
+++ b/server/prisma/generator/factories/instanceRoles.factory.ts
@@ -4,8 +4,14 @@ import { InstancePermission, Permission } from '../../../../common/permissions';
 
 const allPermissions = Object.values(Permission);
 
+export enum InstanceRoles {
+  chapter_administrator = 'chapter_administrator',
+  member = 'member',
+  owner = 'owner',
+}
+
 export interface InstanceRole {
-  name: 'owner' | 'chapter_administrator' | 'member';
+  name: keyof typeof InstanceRoles;
   permissions: typeof allPermissions;
 }
 

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -14,17 +14,10 @@ import { ResolverCtx } from '../../common-types/gql';
 import { prisma } from '../../prisma';
 import { ChapterUser, UserBan } from '../../graphql-types';
 import { Permission } from '../../../../common/permissions';
+import { ChapterRoles } from '../../../prisma/generator/factories/chapterRoles.factory';
+import { InstanceRoles } from '../../../prisma/generator/factories/instanceRoles.factory';
 
 const UNIQUE_CONSTRAINT_FAILED_CODE = 'P2002';
-const instanceRoles = {
-  MEMBER: 'member',
-  CHAPTER_ADMINISTRATOR: 'chapter_administrator',
-  OWNER: 'owner',
-};
-const chapterRoles = {
-  MEMBER: 'member',
-  ADMINISTRATOR: 'administrator',
-};
 
 @Resolver(() => ChapterUser)
 export class ChapterUserResolver {
@@ -205,27 +198,27 @@ export class ChapterUserResolver {
     });
 
     const previousInstanceRole = chapterUser.user.instance_role.name;
-    if (updated.chapter_role.name === chapterRoles.ADMINISTRATOR) {
+    if (updated.chapter_role.name === ChapterRoles.administrator) {
       if (
-        previousInstanceRole !== instanceRoles.OWNER &&
-        previousInstanceRole !== instanceRoles.CHAPTER_ADMINISTRATOR
+        previousInstanceRole !== InstanceRoles.owner &&
+        previousInstanceRole !== InstanceRoles.chapter_administrator
       ) {
         await prisma.users.update({
           data: {
             instance_role: {
-              connect: { name: instanceRoles.CHAPTER_ADMINISTRATOR },
+              connect: { name: InstanceRoles.chapter_administrator },
             },
           },
           where: { id: userId },
         });
       }
-    } else if (chapterUser.chapter_role.name === chapterRoles.ADMINISTRATOR) {
-      if (previousInstanceRole !== instanceRoles.OWNER) {
+    } else if (chapterUser.chapter_role.name === ChapterRoles.administrator) {
+      if (previousInstanceRole !== InstanceRoles.owner) {
         const isStillAdmin = chapterUser.user.user_chapters.some(
           (chapter_user) => {
             return (
               chapter_user.chapter_id !== chapterId &&
-              chapter_user.chapter_role.name === chapterRoles.ADMINISTRATOR
+              chapter_user.chapter_role.name === ChapterRoles.administrator
             );
           },
         );
@@ -233,7 +226,7 @@ export class ChapterUserResolver {
         if (!isStillAdmin) {
           await prisma.users.update({
             data: {
-              instance_role: { connect: { name: instanceRoles.MEMBER } },
+              instance_role: { connect: { name: InstanceRoles.member } },
             },
             where: { id: userId },
           });

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -139,7 +139,7 @@ export class ChapterUserResolver {
   @Mutation(() => ChapterUser)
   async changeChapterUserRole(
     @Arg('chapterId', () => Int) chapterId: number,
-    @Arg('roleName', () => String) roleName: string,
+    @Arg('roleName', () => String) newChapterRole: string,
     @Arg('userId', () => Int) userId: number,
   ): Promise<ChapterUser> {
     const chapterUser = await prisma.chapter_users.findUniqueOrThrow({
@@ -156,7 +156,6 @@ export class ChapterUserResolver {
     });
 
     const oldChapterRole = chapterUser.chapter_role.name;
-    const newChapterRole = roleName;
     if (oldChapterRole === newChapterRole) return chapterUser;
 
     const updatedChapterUser = await prisma.chapter_users.update({

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -55,7 +55,7 @@ const getInstanceRoleName = ({
   newChapterRole,
   oldInstanceRole,
 }: ChangeInstanceRoleData) => {
-  if (oldInstanceRole === InstanceRoles.owner) return;
+  if (oldInstanceRole === InstanceRoles.owner) return oldInstanceRole;
 
   if (
     newChapterRole === ChapterRoles.administrator &&
@@ -76,7 +76,7 @@ const getInstanceRoleName = ({
 
     if (!isStillAdmin) return InstanceRoles.member;
   }
-  return;
+  return oldInstanceRole;
 };
 
 @Resolver(() => ChapterUser)
@@ -224,7 +224,7 @@ export class ChapterUserResolver {
       newChapterRole,
       oldInstanceRole,
     });
-    if (newInstanceRole) {
+    if (newInstanceRole !== oldInstanceRole) {
       await prisma.users.update({
         data: {
           instance_role: { connect: { name: newInstanceRole } },

--- a/server/src/controllers/InstanceRole/resolver.ts
+++ b/server/src/controllers/InstanceRole/resolver.ts
@@ -12,6 +12,7 @@ export class InstanceRoleResolver {
       include: {
         instance_role_permissions: { include: { instance_permission: true } },
       },
+      where: { name: { not: 'chapter_administrator' } },
     });
   }
 }

--- a/server/src/controllers/InstanceRole/resolver.ts
+++ b/server/src/controllers/InstanceRole/resolver.ts
@@ -3,6 +3,7 @@ import { Query, Resolver } from 'type-graphql';
 import { prisma } from '../../prisma';
 
 import { InstanceRole } from '../../graphql-types/InstanceRole';
+import { InstanceRoles } from '../../../prisma/generator/factories/instanceRoles.factory';
 
 @Resolver()
 export class InstanceRoleResolver {
@@ -12,7 +13,7 @@ export class InstanceRoleResolver {
       include: {
         instance_role_permissions: { include: { instance_permission: true } },
       },
-      where: { name: { not: 'chapter_administrator' } },
+      where: { name: { not: InstanceRoles.chapter_administrator } },
     });
   }
 }

--- a/server/src/controllers/Users/resolver.ts
+++ b/server/src/controllers/Users/resolver.ts
@@ -5,43 +5,74 @@ import { prisma } from '../../prisma';
 import { UserWithInstanceRole } from '../../graphql-types';
 import { Permission } from '../../../../common/permissions';
 
+const chapterRoles = {
+  ADMINISTRATOR: 'administrator',
+};
+
+const instanceRoleInclude = {
+  instance_role: {
+    include: {
+      instance_role_permissions: {
+        include: { instance_permission: true },
+      },
+    },
+  },
+};
+
 @Resolver()
 export class UsersResolver {
   @Authorized(Permission.UsersView)
   @Query(() => [UserWithInstanceRole])
   async users(): Promise<UserWithInstanceRole[]> {
-    return await prisma.users.findMany({
+    const users = await prisma.users.findMany({
       orderBy: { name: 'asc' },
-      include: {
-        instance_role: {
-          include: {
-            instance_role_permissions: {
-              include: { instance_permission: true },
-            },
-          },
-        },
-      },
+      include: instanceRoleInclude,
     });
+
+    const usersWithReplacedAdministrator = users.map((user) => {
+      if (user.instance_role.name !== 'chapter_administrator') {
+        return user;
+      }
+      const userWithReplacedRoleName = { ...user };
+      userWithReplacedRoleName.instance_role.name = 'member';
+      return userWithReplacedRoleName;
+    });
+    return usersWithReplacedAdministrator;
   }
 
   @Authorized(Permission.UserInstanceRoleChange)
   @Mutation(() => UserWithInstanceRole)
   async changeInstanceUserRole(
-    @Arg('roleId', () => Int) roleId: number,
+    @Arg('roleName', () => String) roleName: string,
     @Arg('userId', () => Int) userId: number,
   ): Promise<UserWithInstanceRole> {
-    return await prisma.users.update({
-      data: { instance_role: { connect: { id: roleId } } },
+    const user = await prisma.users.findUniqueOrThrow({
       where: { id: userId },
       include: {
-        instance_role: {
-          include: {
-            instance_role_permissions: {
-              include: { instance_permission: true },
-            },
-          },
-        },
+        ...instanceRoleInclude,
+        user_chapters: { include: { chapter_role: true } },
       },
     });
+
+    if (user.instance_role.name === roleName) return user;
+
+    if (user.instance_role.name === 'owner') {
+      const isAdmin = user.user_chapters.some(
+        (chapter_user) =>
+          chapter_user.chapter_role.name === chapterRoles.ADMINISTRATOR,
+      );
+
+      if (isAdmin) {
+        roleName = 'chapter_administrator';
+      }
+    }
+
+    const updated = await prisma.users.update({
+      data: { instance_role: { connect: { name: roleName } } },
+      where: { id: userId },
+      include: instanceRoleInclude,
+    });
+
+    return updated;
   }
 }

--- a/server/src/controllers/Users/resolver.ts
+++ b/server/src/controllers/Users/resolver.ts
@@ -27,6 +27,7 @@ export class UsersResolver {
       include: instanceRoleInclude,
     });
 
+    // The chapter_administrator role is internal, so should not be displayed
     const usersWithReplacedAdministrator = users.map((user) => {
       if (user.instance_role.name !== InstanceRoles.chapter_administrator) {
         return user;

--- a/server/src/controllers/Users/resolver.ts
+++ b/server/src/controllers/Users/resolver.ts
@@ -42,7 +42,7 @@ export class UsersResolver {
   @Authorized(Permission.UserInstanceRoleChange)
   @Mutation(() => UserWithInstanceRole)
   async changeInstanceUserRole(
-    @Arg('roleName', () => String) roleName: string,
+    @Arg('roleName', () => String) newRole: string,
     @Arg('userId', () => Int) userId: number,
   ): Promise<UserWithInstanceRole> {
     const user = await prisma.users.findUniqueOrThrow({
@@ -54,7 +54,6 @@ export class UsersResolver {
     });
 
     const oldRole = user.instance_role.name;
-    const newRole = roleName;
     if (oldRole === newRole) return user;
 
     return await prisma.users.update({

--- a/server/src/controllers/Users/resolver.ts
+++ b/server/src/controllers/Users/resolver.ts
@@ -56,7 +56,11 @@ export class UsersResolver {
 
     if (user.instance_role.name === roleName) return user;
 
-    if (user.instance_role.name === 'owner') {
+    if (
+      user.instance_role.name === 'owner' ||
+      (roleName !== 'owner' &&
+        user.instance_role.name === 'chapter_administrator')
+    ) {
       const isAdmin = user.user_chapters.some(
         (chapter_user) =>
           chapter_user.chapter_role.name === chapterRoles.ADMINISTRATOR,

--- a/server/src/controllers/Users/resolver.ts
+++ b/server/src/controllers/Users/resolver.ts
@@ -4,10 +4,8 @@ import { prisma } from '../../prisma';
 
 import { UserWithInstanceRole } from '../../graphql-types';
 import { Permission } from '../../../../common/permissions';
-
-const chapterRoles = {
-  ADMINISTRATOR: 'administrator',
-};
+import { ChapterRoles } from '../../../prisma/generator/factories/chapterRoles.factory';
+import { InstanceRoles } from '../../../prisma/generator/factories/instanceRoles.factory';
 
 const instanceRoleInclude = {
   instance_role: {
@@ -30,11 +28,11 @@ export class UsersResolver {
     });
 
     const usersWithReplacedAdministrator = users.map((user) => {
-      if (user.instance_role.name !== 'chapter_administrator') {
+      if (user.instance_role.name !== InstanceRoles.chapter_administrator) {
         return user;
       }
       const userWithReplacedRoleName = { ...user };
-      userWithReplacedRoleName.instance_role.name = 'member';
+      userWithReplacedRoleName.instance_role.name = InstanceRoles.member;
       return userWithReplacedRoleName;
     });
     return usersWithReplacedAdministrator;
@@ -57,17 +55,17 @@ export class UsersResolver {
     if (user.instance_role.name === roleName) return user;
 
     if (
-      user.instance_role.name === 'owner' ||
-      (roleName !== 'owner' &&
-        user.instance_role.name === 'chapter_administrator')
+      user.instance_role.name === InstanceRoles.owner ||
+      (roleName !== InstanceRoles.owner &&
+        user.instance_role.name === InstanceRoles.chapter_administrator)
     ) {
       const isAdmin = user.user_chapters.some(
         (chapter_user) =>
-          chapter_user.chapter_role.name === chapterRoles.ADMINISTRATOR,
+          chapter_user.chapter_role.name === ChapterRoles.administrator,
       );
 
       if (isAdmin) {
-        roleName = 'chapter_administrator';
+        roleName = InstanceRoles.chapter_administrator;
       }
     }
 

--- a/server/src/controllers/Users/resolver.ts
+++ b/server/src/controllers/Users/resolver.ts
@@ -25,19 +25,19 @@ type UserWithUserChapters = Prisma.usersGetPayload<{
 }>;
 
 interface ChangeRoleNameData {
-  prevRole: string;
+  oldRole: string;
   newRole: string;
   user: UserWithUserChapters;
 }
 
-const getRoleName = ({ prevRole, newRole, user }: ChangeRoleNameData) => {
+const getRoleName = ({ oldRole, newRole, user }: ChangeRoleNameData) => {
   if (
-    prevRole === InstanceRoles.chapter_administrator &&
+    oldRole === InstanceRoles.chapter_administrator &&
     newRole === InstanceRoles.member
   )
     return InstanceRoles.chapter_administrator;
 
-  if (prevRole === InstanceRoles.owner) {
+  if (oldRole === InstanceRoles.owner) {
     const isAdmin = user.user_chapters.some(
       (chapter_user) =>
         chapter_user.chapter_role.name === ChapterRoles.administrator,
@@ -83,17 +83,15 @@ export class UsersResolver {
       },
     });
 
-    if (user.instance_role.name === roleName) return user;
+    const oldRole = user.instance_role.name;
+    const newRole = roleName;
+    if (oldRole === newRole) return user;
 
     return await prisma.users.update({
       data: {
         instance_role: {
           connect: {
-            name: getRoleName({
-              prevRole: user.instance_role.name,
-              newRole: roleName,
-              user,
-            }),
+            name: getRoleName({ oldRole, newRole, user }),
           },
         },
       },

--- a/server/src/util/chapterAdministrator.ts
+++ b/server/src/util/chapterAdministrator.ts
@@ -57,15 +57,19 @@ export const getRoleName = ({
   newRole,
   userChapters,
 }: ChangeRoleNameData) => {
+  // The client should not request this change, but if it does it's ignored.
   if (oldRole === InstanceRoles.owner && newRole === InstanceRoles.owner)
     return oldRole;
 
+  // The client should not request this change, but if it does it's ignored.
   if (
     oldRole === InstanceRoles.chapter_administrator &&
     newRole === InstanceRoles.member
   )
     return InstanceRoles.chapter_administrator;
 
+  // since the former owner may still be an administator, we check if they will
+  // need the chapter_administrator role
   if (oldRole === InstanceRoles.owner) {
     const isAdmin = userChapters.some(
       (userChapter) =>

--- a/server/src/util/chapterAdministrator.ts
+++ b/server/src/util/chapterAdministrator.ts
@@ -63,10 +63,12 @@ export const getRoleName = ({
 
   // The client should not request this change, but if it does it's ignored.
   if (
-    oldRole === InstanceRoles.chapter_administrator &&
-    newRole === InstanceRoles.member
+    (oldRole === InstanceRoles.chapter_administrator &&
+      newRole === InstanceRoles.member) ||
+    (oldRole === InstanceRoles.member &&
+      newRole === InstanceRoles.chapter_administrator)
   )
-    return InstanceRoles.chapter_administrator;
+    return oldRole;
 
   // since the former owner may still be an administator, we check if they will
   // need the chapter_administrator role

--- a/server/src/util/chapterAdministrator.ts
+++ b/server/src/util/chapterAdministrator.ts
@@ -1,0 +1,78 @@
+import { Prisma } from '@prisma/client';
+
+import { ChapterRoles } from '../..//prisma/generator/factories/chapterRoles.factory';
+import { InstanceRoles } from '../../prisma/generator/factories/instanceRoles.factory';
+
+type UserChapters = Prisma.chapter_usersGetPayload<{
+  include: {
+    chapter_role: true;
+  };
+}>;
+
+interface ChangeInstanceRoleData {
+  changedChapterId: number;
+  newChapterRole: string;
+  oldInstanceRole: string;
+  userChapters: UserChapters[];
+}
+
+export const getInstanceRoleName = ({
+  changedChapterId,
+  newChapterRole,
+  oldInstanceRole,
+  userChapters,
+}: ChangeInstanceRoleData) => {
+  if (oldInstanceRole === InstanceRoles.owner) return oldInstanceRole;
+
+  if (
+    newChapterRole === ChapterRoles.administrator &&
+    oldInstanceRole !== InstanceRoles.chapter_administrator
+  ) {
+    return InstanceRoles.chapter_administrator;
+  }
+
+  if (
+    newChapterRole === ChapterRoles.member &&
+    oldInstanceRole === InstanceRoles.chapter_administrator
+  ) {
+    const isStillAdmin = userChapters.some(
+      (chapterUser) =>
+        chapterUser.chapter_id !== changedChapterId &&
+        chapterUser.chapter_role.name === ChapterRoles.administrator,
+    );
+
+    if (!isStillAdmin) return InstanceRoles.member;
+  }
+  return oldInstanceRole;
+};
+
+interface ChangeRoleNameData {
+  oldRole: string;
+  newRole: string;
+  userChapters: UserChapters[];
+}
+
+export const getRoleName = ({
+  oldRole,
+  newRole,
+  userChapters,
+}: ChangeRoleNameData) => {
+  if (oldRole === InstanceRoles.owner && newRole === InstanceRoles.owner)
+    return oldRole;
+
+  if (
+    oldRole === InstanceRoles.chapter_administrator &&
+    newRole === InstanceRoles.member
+  )
+    return InstanceRoles.chapter_administrator;
+
+  if (oldRole === InstanceRoles.owner) {
+    const isAdmin = userChapters.some(
+      (userChapter) =>
+        userChapter.chapter_role.name === ChapterRoles.administrator,
+    );
+
+    if (isAdmin) return InstanceRoles.chapter_administrator;
+  }
+  return newRole;
+};

--- a/server/tests/chapterAdministrator.test.ts
+++ b/server/tests/chapterAdministrator.test.ts
@@ -1,0 +1,314 @@
+import { ChapterRoles } from '../prisma/generator/factories/chapterRoles.factory';
+import { InstanceRoles } from '../prisma/generator/factories/instanceRoles.factory';
+import {
+  getInstanceRoleName,
+  getRoleName,
+} from '../src/util/chapterAdministrator';
+import {
+  userChaptersWithChapter1Admin,
+  userChaptersWithChapter2Admin,
+  userChaptersWithTwoAdmins,
+  userChaptersWithTwoMembers,
+} from './fixtures/chapterUsers';
+
+describe('chapterAdministrator', () => {
+  describe('getInstanceRoleName', () => {
+    describe('for instance owner', () => {
+      it.each([
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.member,
+          userChapters: userChaptersWithChapter1Admin,
+          expected: InstanceRoles.owner,
+          description: 'admin of 1 chapter',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.administrator,
+          userChapters: userChaptersWithChapter1Admin,
+          expected: InstanceRoles.owner,
+          description: 'admin of 1 chapter',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.member,
+          userChapters: userChaptersWithChapter2Admin,
+          expected: InstanceRoles.owner,
+          description: 'admin of 2 chapter',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.administrator,
+          userChapters: userChaptersWithChapter2Admin,
+          expected: InstanceRoles.owner,
+          description: 'admin of 2 chapter',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.member,
+          userChapters: userChaptersWithTwoAdmins,
+          expected: InstanceRoles.owner,
+          description: 'admin of chapters',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.administrator,
+          userChapters: userChaptersWithTwoAdmins,
+          expected: InstanceRoles.owner,
+          description: 'admin of chapters',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.member,
+          userChapters: userChaptersWithTwoMembers,
+          expected: InstanceRoles.owner,
+          description: 'member of chapters',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.administrator,
+          userChapters: userChaptersWithTwoMembers,
+          expected: InstanceRoles.owner,
+          description: 'member of chapters',
+        },
+      ])(
+        'should return $expected when changing $description to chapter $changedChapterId $newChapterRole',
+        ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+          expect(
+            getInstanceRoleName({
+              changedChapterId,
+              newChapterRole,
+              oldInstanceRole: InstanceRoles.owner,
+              userChapters,
+            }),
+          ).toBe(expected);
+        },
+      );
+    });
+
+    describe('for instance chapter_administrator', () => {
+      it.each([
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.member,
+          userChapters: userChaptersWithChapter1Admin,
+          expected: InstanceRoles.member,
+          description: 'admin of 1 chapter',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.administrator,
+          userChapters: userChaptersWithChapter1Admin,
+          expected: InstanceRoles.chapter_administrator,
+          description: 'admin of 1 chapter',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.member,
+          userChapters: userChaptersWithChapter2Admin,
+          expected: InstanceRoles.chapter_administrator,
+          description: 'admin of 2 chapter',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.administrator,
+          userChapters: userChaptersWithChapter2Admin,
+          expected: InstanceRoles.chapter_administrator,
+          description: 'admin of 2 chapter',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.member,
+          userChapters: userChaptersWithTwoAdmins,
+          expected: InstanceRoles.chapter_administrator,
+          description: 'admin of chapters',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.administrator,
+          userChapters: userChaptersWithTwoAdmins,
+          expected: InstanceRoles.chapter_administrator,
+          description: 'admin of chapters',
+        },
+      ])(
+        'should return $expected when changing $description to chapter $changedChapterId $newChapterRole',
+        ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+          expect(
+            getInstanceRoleName({
+              changedChapterId,
+              newChapterRole,
+              oldInstanceRole: InstanceRoles.chapter_administrator,
+              userChapters,
+            }),
+          ).toBe(expected);
+        },
+      );
+    });
+
+    describe('for instance member', () => {
+      it.each([
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.member,
+          userChapters: userChaptersWithTwoMembers,
+          expected: InstanceRoles.member,
+          description: 'member of chapters',
+        },
+        {
+          changedChapterId: 1,
+          newChapterRole: ChapterRoles.administrator,
+          userChapters: userChaptersWithTwoMembers,
+          expected: InstanceRoles.chapter_administrator,
+          description: 'member of chapters',
+        },
+      ])(
+        'should return $expected when changing $description to chapter $changedChapterId $newChapterRole',
+        ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+          expect(
+            getInstanceRoleName({
+              changedChapterId,
+              newChapterRole,
+              oldInstanceRole: InstanceRoles.member,
+              userChapters,
+            }),
+          ).toBe(expected);
+        },
+      );
+    });
+  });
+
+  describe('getRoleName', () => {
+    it.each([
+      {
+        oldRole: InstanceRoles.chapter_administrator,
+        newRole: InstanceRoles.member,
+        userChapters: userChaptersWithChapter1Admin,
+        expected: InstanceRoles.chapter_administrator,
+        description: 'admin of 1 chapter',
+      },
+      {
+        oldRole: InstanceRoles.chapter_administrator,
+        newRole: InstanceRoles.member,
+        userChapters: userChaptersWithChapter2Admin,
+        expected: InstanceRoles.chapter_administrator,
+        description: 'admin of 2 chapter',
+      },
+      {
+        oldRole: InstanceRoles.chapter_administrator,
+        newRole: InstanceRoles.member,
+        userChapters: userChaptersWithTwoAdmins,
+        expected: InstanceRoles.chapter_administrator,
+        description: 'admin of chapters',
+      },
+      {
+        oldRole: InstanceRoles.member,
+        newRole: InstanceRoles.member,
+        userChapters: userChaptersWithTwoMembers,
+        expected: InstanceRoles.member,
+        description: 'member of chapters',
+      },
+      {
+        oldRole: InstanceRoles.member,
+        newRole: InstanceRoles.chapter_administrator,
+        userChapters: userChaptersWithTwoMembers,
+        expected: InstanceRoles.chapter_administrator,
+        description: 'member of chapters',
+      },
+      {
+        oldRole: InstanceRoles.chapter_administrator,
+        newRole: InstanceRoles.chapter_administrator,
+        userChapters: userChaptersWithChapter1Admin,
+        expected: InstanceRoles.chapter_administrator,
+        description: 'admin of 1 chapter',
+      },
+      {
+        oldRole: InstanceRoles.member,
+        newRole: InstanceRoles.owner,
+        userChapters: userChaptersWithTwoMembers,
+        expected: InstanceRoles.owner,
+        description: 'member of chapters',
+      },
+      {
+        oldRole: InstanceRoles.owner,
+        newRole: InstanceRoles.member,
+        userChapters: userChaptersWithChapter1Admin,
+        expected: InstanceRoles.chapter_administrator,
+        description: 'admin of 1 chapter',
+      },
+      {
+        oldRole: InstanceRoles.owner,
+        newRole: InstanceRoles.member,
+        userChapters: userChaptersWithChapter2Admin,
+        expected: InstanceRoles.chapter_administrator,
+        description: 'admin of 2 chapter',
+      },
+      {
+        oldRole: InstanceRoles.owner,
+        newRole: InstanceRoles.member,
+        userChapters: userChaptersWithTwoMembers,
+        expected: InstanceRoles.member,
+        description: 'member of chapters',
+      },
+      {
+        oldRole: InstanceRoles.owner,
+        newRole: InstanceRoles.owner,
+        userChapters: userChaptersWithChapter1Admin,
+        expected: InstanceRoles.owner,
+        description: 'admin of 1 chapter',
+      },
+      {
+        oldRole: InstanceRoles.owner,
+        newRole: InstanceRoles.owner,
+        userChapters: userChaptersWithChapter2Admin,
+        expected: InstanceRoles.owner,
+        description: 'admin of 2 chapter',
+      },
+      {
+        oldRole: InstanceRoles.owner,
+        newRole: InstanceRoles.owner,
+        userChapters: userChaptersWithTwoAdmins,
+        expected: InstanceRoles.owner,
+        description: 'admin of chapters',
+      },
+      {
+        oldRole: InstanceRoles.owner,
+        newRole: InstanceRoles.owner,
+        userChapters: userChaptersWithTwoMembers,
+        expected: InstanceRoles.owner,
+        description: 'member of chapters',
+      },
+      {
+        oldRole: InstanceRoles.owner,
+        newRole: InstanceRoles.owner,
+        userChapters: [],
+        expected: InstanceRoles.owner,
+        description: 'member of no chapters',
+      },
+      {
+        oldRole: InstanceRoles.member,
+        newRole: InstanceRoles.owner,
+        userChapters: [],
+        expected: InstanceRoles.owner,
+        description: 'member of no chapters',
+      },
+      {
+        oldRole: InstanceRoles.owner,
+        newRole: InstanceRoles.member,
+        userChapters: [],
+        expected: InstanceRoles.member,
+        description: 'member of no chapters',
+      },
+    ])(
+      'should return $expected when changing from $oldRole to $newRole for $description',
+      ({ oldRole, newRole, userChapters, expected }) => {
+        expect(
+          getRoleName({
+            oldRole,
+            newRole,
+            userChapters,
+          }),
+        ).toBe(expected);
+      },
+    );
+  });
+});

--- a/server/tests/chapterAdministrator.test.ts
+++ b/server/tests/chapterAdministrator.test.ts
@@ -14,301 +14,436 @@ import {
 describe('chapterAdministrator', () => {
   describe('getInstanceRoleName', () => {
     describe('for instance owner', () => {
-      it.each([
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.member,
-          userChapters: userChaptersWithChapter1Admin,
-          expected: InstanceRoles.owner,
-          description: 'admin of 1 chapter',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.administrator,
-          userChapters: userChaptersWithChapter1Admin,
-          expected: InstanceRoles.owner,
-          description: 'admin of 1 chapter',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.member,
-          userChapters: userChaptersWithChapter2Admin,
-          expected: InstanceRoles.owner,
-          description: 'admin of 2 chapter',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.administrator,
-          userChapters: userChaptersWithChapter2Admin,
-          expected: InstanceRoles.owner,
-          description: 'admin of 2 chapter',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.member,
-          userChapters: userChaptersWithTwoAdmins,
-          expected: InstanceRoles.owner,
-          description: 'admin of chapters',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.administrator,
-          userChapters: userChaptersWithTwoAdmins,
-          expected: InstanceRoles.owner,
-          description: 'admin of chapters',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.member,
-          userChapters: userChaptersWithTwoMembers,
-          expected: InstanceRoles.owner,
-          description: 'member of chapters',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.administrator,
-          userChapters: userChaptersWithTwoMembers,
-          expected: InstanceRoles.owner,
-          description: 'member of chapters',
-        },
-      ])(
-        'should return $expected when changing $description to chapter $changedChapterId $newChapterRole',
-        ({ changedChapterId, newChapterRole, userChapters, expected }) => {
-          expect(
-            getInstanceRoleName({
-              changedChapterId,
-              newChapterRole,
-              oldInstanceRole: InstanceRoles.owner,
-              userChapters,
-            }),
-          ).toBe(expected);
-        },
-      );
+      describe('for admin of 1 chapter', () => {
+        it.each([
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.member,
+            userChapters: userChaptersWithChapter1Admin,
+            expected: InstanceRoles.owner,
+          },
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.administrator,
+            userChapters: userChaptersWithChapter1Admin,
+            expected: InstanceRoles.owner,
+          },
+        ])(
+          'should return $expected when changing to chapter $changedChapterId $newChapterRole',
+          ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+            expect(
+              getInstanceRoleName({
+                changedChapterId,
+                newChapterRole,
+                oldInstanceRole: InstanceRoles.owner,
+                userChapters,
+              }),
+            ).toBe(expected);
+          },
+        );
+      });
+      describe('for admin of 2 chapter', () => {
+        it.each([
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.member,
+            userChapters: userChaptersWithChapter2Admin,
+            expected: InstanceRoles.owner,
+          },
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.administrator,
+            userChapters: userChaptersWithChapter2Admin,
+            expected: InstanceRoles.owner,
+          },
+        ])(
+          'should return $expected when changing to chapter $changedChapterId $newChapterRole',
+          ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+            expect(
+              getInstanceRoleName({
+                changedChapterId,
+                newChapterRole,
+                oldInstanceRole: InstanceRoles.owner,
+                userChapters,
+              }),
+            ).toBe(expected);
+          },
+        );
+      });
+
+      describe('for admin of chapters', () => {
+        it.each([
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.member,
+            userChapters: userChaptersWithTwoAdmins,
+            expected: InstanceRoles.owner,
+          },
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.administrator,
+            userChapters: userChaptersWithTwoAdmins,
+            expected: InstanceRoles.owner,
+          },
+        ])(
+          'should return $expected when changing to chapter $changedChapterId $newChapterRole',
+          ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+            expect(
+              getInstanceRoleName({
+                changedChapterId,
+                newChapterRole,
+                oldInstanceRole: InstanceRoles.owner,
+                userChapters,
+              }),
+            ).toBe(expected);
+          },
+        );
+      });
+
+      describe('for member of chapters', () => {
+        it.each([
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.member,
+            userChapters: userChaptersWithTwoMembers,
+            expected: InstanceRoles.owner,
+          },
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.administrator,
+            userChapters: userChaptersWithTwoMembers,
+            expected: InstanceRoles.owner,
+          },
+        ])(
+          'should return $expected when changing to chapter $changedChapterId $newChapterRole',
+          ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+            expect(
+              getInstanceRoleName({
+                changedChapterId,
+                newChapterRole,
+                oldInstanceRole: InstanceRoles.owner,
+                userChapters,
+              }),
+            ).toBe(expected);
+          },
+        );
+      });
     });
 
     describe('for instance chapter_administrator', () => {
-      it.each([
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.member,
-          userChapters: userChaptersWithChapter1Admin,
-          expected: InstanceRoles.member,
-          description: 'admin of 1 chapter',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.administrator,
-          userChapters: userChaptersWithChapter1Admin,
-          expected: InstanceRoles.chapter_administrator,
-          description: 'admin of 1 chapter',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.member,
-          userChapters: userChaptersWithChapter2Admin,
-          expected: InstanceRoles.chapter_administrator,
-          description: 'admin of 2 chapter',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.administrator,
-          userChapters: userChaptersWithChapter2Admin,
-          expected: InstanceRoles.chapter_administrator,
-          description: 'admin of 2 chapter',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.member,
-          userChapters: userChaptersWithTwoAdmins,
-          expected: InstanceRoles.chapter_administrator,
-          description: 'admin of chapters',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.administrator,
-          userChapters: userChaptersWithTwoAdmins,
-          expected: InstanceRoles.chapter_administrator,
-          description: 'admin of chapters',
-        },
-      ])(
-        'should return $expected when changing $description to chapter $changedChapterId $newChapterRole',
-        ({ changedChapterId, newChapterRole, userChapters, expected }) => {
-          expect(
-            getInstanceRoleName({
-              changedChapterId,
-              newChapterRole,
-              oldInstanceRole: InstanceRoles.chapter_administrator,
-              userChapters,
-            }),
-          ).toBe(expected);
-        },
-      );
+      describe('for admin of 1 chapter', () => {
+        it.each([
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.member,
+            userChapters: userChaptersWithChapter1Admin,
+            expected: InstanceRoles.member,
+          },
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.administrator,
+            userChapters: userChaptersWithChapter1Admin,
+            expected: InstanceRoles.chapter_administrator,
+          },
+        ])(
+          'should return $expected when changing to chapter $changedChapterId $newChapterRole',
+          ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+            expect(
+              getInstanceRoleName({
+                changedChapterId,
+                newChapterRole,
+                oldInstanceRole: InstanceRoles.chapter_administrator,
+                userChapters,
+              }),
+            ).toBe(expected);
+          },
+        );
+      });
+
+      describe('for admin of 2 chapter', () => {
+        it.each([
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.member,
+            userChapters: userChaptersWithChapter2Admin,
+            expected: InstanceRoles.chapter_administrator,
+          },
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.administrator,
+            userChapters: userChaptersWithChapter2Admin,
+            expected: InstanceRoles.chapter_administrator,
+          },
+        ])(
+          'should return $expected when changing to chapter $changedChapterId $newChapterRole',
+          ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+            expect(
+              getInstanceRoleName({
+                changedChapterId,
+                newChapterRole,
+                oldInstanceRole: InstanceRoles.chapter_administrator,
+                userChapters,
+              }),
+            ).toBe(expected);
+          },
+        );
+      });
+
+      describe('for admin of chapters', () => {
+        it.each([
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.member,
+            userChapters: userChaptersWithTwoAdmins,
+            expected: InstanceRoles.chapter_administrator,
+          },
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.administrator,
+            userChapters: userChaptersWithTwoAdmins,
+            expected: InstanceRoles.chapter_administrator,
+          },
+        ])(
+          'should return $expected when changing to chapter $changedChapterId $newChapterRole',
+          ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+            expect(
+              getInstanceRoleName({
+                changedChapterId,
+                newChapterRole,
+                oldInstanceRole: InstanceRoles.chapter_administrator,
+                userChapters,
+              }),
+            ).toBe(expected);
+          },
+        );
+      });
     });
 
     describe('for instance member', () => {
-      it.each([
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.member,
-          userChapters: userChaptersWithTwoMembers,
-          expected: InstanceRoles.member,
-          description: 'member of chapters',
-        },
-        {
-          changedChapterId: 1,
-          newChapterRole: ChapterRoles.administrator,
-          userChapters: userChaptersWithTwoMembers,
-          expected: InstanceRoles.chapter_administrator,
-          description: 'member of chapters',
-        },
-      ])(
-        'should return $expected when changing $description to chapter $changedChapterId $newChapterRole',
-        ({ changedChapterId, newChapterRole, userChapters, expected }) => {
-          expect(
-            getInstanceRoleName({
-              changedChapterId,
-              newChapterRole,
-              oldInstanceRole: InstanceRoles.member,
-              userChapters,
-            }),
-          ).toBe(expected);
-        },
-      );
+      describe('for member of chapters', () => {
+        it.each([
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.member,
+            userChapters: userChaptersWithTwoMembers,
+            expected: InstanceRoles.member,
+          },
+          {
+            changedChapterId: 1,
+            newChapterRole: ChapterRoles.administrator,
+            userChapters: userChaptersWithTwoMembers,
+            expected: InstanceRoles.chapter_administrator,
+          },
+        ])(
+          'should return $expected when changing to chapter $changedChapterId $newChapterRole',
+          ({ changedChapterId, newChapterRole, userChapters, expected }) => {
+            expect(
+              getInstanceRoleName({
+                changedChapterId,
+                newChapterRole,
+                oldInstanceRole: InstanceRoles.member,
+                userChapters,
+              }),
+            ).toBe(expected);
+          },
+        );
+      });
     });
   });
 
   describe('getRoleName', () => {
-    it.each([
-      {
-        oldRole: InstanceRoles.chapter_administrator,
-        newRole: InstanceRoles.member,
-        userChapters: userChaptersWithChapter1Admin,
-        expected: InstanceRoles.chapter_administrator,
-        description: 'admin of 1 chapter',
-      },
-      {
-        oldRole: InstanceRoles.chapter_administrator,
-        newRole: InstanceRoles.member,
-        userChapters: userChaptersWithChapter2Admin,
-        expected: InstanceRoles.chapter_administrator,
-        description: 'admin of 2 chapter',
-      },
-      {
-        oldRole: InstanceRoles.chapter_administrator,
-        newRole: InstanceRoles.member,
-        userChapters: userChaptersWithTwoAdmins,
-        expected: InstanceRoles.chapter_administrator,
-        description: 'admin of chapters',
-      },
-      {
-        oldRole: InstanceRoles.member,
-        newRole: InstanceRoles.member,
-        userChapters: userChaptersWithTwoMembers,
-        expected: InstanceRoles.member,
-        description: 'member of chapters',
-      },
-      {
-        oldRole: InstanceRoles.member,
-        newRole: InstanceRoles.chapter_administrator,
-        userChapters: userChaptersWithTwoMembers,
-        expected: InstanceRoles.chapter_administrator,
-        description: 'member of chapters',
-      },
-      {
-        oldRole: InstanceRoles.chapter_administrator,
-        newRole: InstanceRoles.chapter_administrator,
-        userChapters: userChaptersWithChapter1Admin,
-        expected: InstanceRoles.chapter_administrator,
-        description: 'admin of 1 chapter',
-      },
-      {
-        oldRole: InstanceRoles.member,
-        newRole: InstanceRoles.owner,
-        userChapters: userChaptersWithTwoMembers,
-        expected: InstanceRoles.owner,
-        description: 'member of chapters',
-      },
-      {
-        oldRole: InstanceRoles.owner,
-        newRole: InstanceRoles.member,
-        userChapters: userChaptersWithChapter1Admin,
-        expected: InstanceRoles.chapter_administrator,
-        description: 'admin of 1 chapter',
-      },
-      {
-        oldRole: InstanceRoles.owner,
-        newRole: InstanceRoles.member,
-        userChapters: userChaptersWithChapter2Admin,
-        expected: InstanceRoles.chapter_administrator,
-        description: 'admin of 2 chapter',
-      },
-      {
-        oldRole: InstanceRoles.owner,
-        newRole: InstanceRoles.member,
-        userChapters: userChaptersWithTwoMembers,
-        expected: InstanceRoles.member,
-        description: 'member of chapters',
-      },
-      {
-        oldRole: InstanceRoles.owner,
-        newRole: InstanceRoles.owner,
-        userChapters: userChaptersWithChapter1Admin,
-        expected: InstanceRoles.owner,
-        description: 'admin of 1 chapter',
-      },
-      {
-        oldRole: InstanceRoles.owner,
-        newRole: InstanceRoles.owner,
-        userChapters: userChaptersWithChapter2Admin,
-        expected: InstanceRoles.owner,
-        description: 'admin of 2 chapter',
-      },
-      {
-        oldRole: InstanceRoles.owner,
-        newRole: InstanceRoles.owner,
-        userChapters: userChaptersWithTwoAdmins,
-        expected: InstanceRoles.owner,
-        description: 'admin of chapters',
-      },
-      {
-        oldRole: InstanceRoles.owner,
-        newRole: InstanceRoles.owner,
-        userChapters: userChaptersWithTwoMembers,
-        expected: InstanceRoles.owner,
-        description: 'member of chapters',
-      },
-      {
-        oldRole: InstanceRoles.owner,
-        newRole: InstanceRoles.owner,
-        userChapters: [],
-        expected: InstanceRoles.owner,
-        description: 'member of no chapters',
-      },
-      {
-        oldRole: InstanceRoles.member,
-        newRole: InstanceRoles.owner,
-        userChapters: [],
-        expected: InstanceRoles.owner,
-        description: 'member of no chapters',
-      },
-      {
-        oldRole: InstanceRoles.owner,
-        newRole: InstanceRoles.member,
-        userChapters: [],
-        expected: InstanceRoles.member,
-        description: 'member of no chapters',
-      },
-    ])(
-      'should return $expected when changing from $oldRole to $newRole for $description',
-      ({ oldRole, newRole, userChapters, expected }) => {
-        expect(
-          getRoleName({
-            oldRole,
-            newRole,
-            userChapters,
-          }),
-        ).toBe(expected);
-      },
-    );
+    describe('for admin of 1 chapter', () => {
+      it.each([
+        {
+          oldRole: InstanceRoles.chapter_administrator,
+          newRole: InstanceRoles.member,
+          userChapters: userChaptersWithChapter1Admin,
+          expected: InstanceRoles.chapter_administrator,
+        },
+        {
+          oldRole: InstanceRoles.chapter_administrator,
+          newRole: InstanceRoles.chapter_administrator,
+          userChapters: userChaptersWithChapter1Admin,
+          expected: InstanceRoles.chapter_administrator,
+        },
+        {
+          oldRole: InstanceRoles.chapter_administrator,
+          newRole: InstanceRoles.owner,
+          userChapters: userChaptersWithChapter1Admin,
+          expected: InstanceRoles.owner,
+        },
+        {
+          oldRole: InstanceRoles.owner,
+          newRole: InstanceRoles.member,
+          userChapters: userChaptersWithChapter1Admin,
+          expected: InstanceRoles.chapter_administrator,
+        },
+        {
+          oldRole: InstanceRoles.owner,
+          newRole: InstanceRoles.owner,
+          userChapters: userChaptersWithChapter1Admin,
+          expected: InstanceRoles.owner,
+        },
+      ])(
+        'should return $expected when changing from $oldRole to $newRole',
+        ({ oldRole, newRole, userChapters, expected }) => {
+          expect(
+            getRoleName({
+              oldRole,
+              newRole,
+              userChapters,
+            }),
+          ).toBe(expected);
+        },
+      );
+    });
+
+    describe('for admin of 2 chapter', () => {
+      it.each([
+        {
+          oldRole: InstanceRoles.chapter_administrator,
+          newRole: InstanceRoles.member,
+          userChapters: userChaptersWithChapter2Admin,
+          expected: InstanceRoles.chapter_administrator,
+        },
+        {
+          oldRole: InstanceRoles.owner,
+          newRole: InstanceRoles.member,
+          userChapters: userChaptersWithChapter2Admin,
+          expected: InstanceRoles.chapter_administrator,
+        },
+        {
+          oldRole: InstanceRoles.owner,
+          newRole: InstanceRoles.owner,
+          userChapters: userChaptersWithChapter2Admin,
+          expected: InstanceRoles.owner,
+        },
+      ])(
+        'should return $expected when changing from $oldRole to $newRole',
+        ({ oldRole, newRole, userChapters, expected }) => {
+          expect(
+            getRoleName({
+              oldRole,
+              newRole,
+              userChapters,
+            }),
+          ).toBe(expected);
+        },
+      );
+    });
+
+    describe('for admin of chapters', () => {
+      it.each([
+        {
+          oldRole: InstanceRoles.chapter_administrator,
+          newRole: InstanceRoles.member,
+          userChapters: userChaptersWithTwoAdmins,
+          expected: InstanceRoles.chapter_administrator,
+        },
+        {
+          oldRole: InstanceRoles.owner,
+          newRole: InstanceRoles.owner,
+          userChapters: userChaptersWithTwoAdmins,
+          expected: InstanceRoles.owner,
+        },
+      ])(
+        'should return $expected when changing from $oldRole to $newRole',
+        ({ oldRole, newRole, userChapters, expected }) => {
+          expect(
+            getRoleName({
+              oldRole,
+              newRole,
+              userChapters,
+            }),
+          ).toBe(expected);
+        },
+      );
+    });
+
+    describe('for member of chapters', () => {
+      it.each([
+        {
+          oldRole: InstanceRoles.member,
+          newRole: InstanceRoles.member,
+          userChapters: userChaptersWithTwoMembers,
+          expected: InstanceRoles.member,
+        },
+        {
+          oldRole: InstanceRoles.member,
+          newRole: InstanceRoles.chapter_administrator,
+          userChapters: userChaptersWithTwoMembers,
+          expected: InstanceRoles.member,
+        },
+        {
+          oldRole: InstanceRoles.member,
+          newRole: InstanceRoles.owner,
+          userChapters: userChaptersWithTwoMembers,
+          expected: InstanceRoles.owner,
+        },
+        {
+          oldRole: InstanceRoles.owner,
+          newRole: InstanceRoles.member,
+          userChapters: userChaptersWithTwoMembers,
+          expected: InstanceRoles.member,
+        },
+        {
+          oldRole: InstanceRoles.owner,
+          newRole: InstanceRoles.owner,
+          userChapters: userChaptersWithTwoMembers,
+          expected: InstanceRoles.owner,
+        },
+      ])(
+        'should return $expected when changing from $oldRole to $newRole',
+        ({ oldRole, newRole, userChapters, expected }) => {
+          expect(
+            getRoleName({
+              oldRole,
+              newRole,
+              userChapters,
+            }),
+          ).toBe(expected);
+        },
+      );
+    });
+
+    describe('for member of no chapters', () => {
+      it.each([
+        {
+          oldRole: InstanceRoles.member,
+          newRole: InstanceRoles.chapter_administrator,
+          userChapters: [],
+          expected: InstanceRoles.member,
+        },
+        {
+          oldRole: InstanceRoles.owner,
+          newRole: InstanceRoles.owner,
+          userChapters: [],
+          expected: InstanceRoles.owner,
+        },
+        {
+          oldRole: InstanceRoles.member,
+          newRole: InstanceRoles.owner,
+          userChapters: [],
+          expected: InstanceRoles.owner,
+        },
+        {
+          oldRole: InstanceRoles.owner,
+          newRole: InstanceRoles.member,
+          userChapters: [],
+          expected: InstanceRoles.member,
+        },
+      ])(
+        'should return $expected when changing from $oldRole to $newRole',
+        ({ oldRole, newRole, userChapters, expected }) => {
+          expect(
+            getRoleName({
+              oldRole,
+              newRole,
+              userChapters,
+            }),
+          ).toBe(expected);
+        },
+      );
+    });
   });
 });

--- a/server/tests/fixtures/chapterUsers.ts
+++ b/server/tests/fixtures/chapterUsers.ts
@@ -1,0 +1,56 @@
+import { merge } from 'lodash/fp';
+
+import { chapter_roles, chapter_users } from '@prisma/client';
+
+import { ChapterRoles } from '../../prisma/generator/factories/chapterRoles.factory';
+
+type UserChapter = chapter_users & {
+  chapter_role: chapter_roles;
+};
+
+const baseChapterUser: UserChapter = {
+  chapter_id: 1,
+  chapter_role_id: 1,
+  created_at: new Date(),
+  joined_date: new Date(),
+  subscribed: false,
+  updated_at: new Date(),
+  user_id: 1,
+  chapter_role: {
+    name: 'some-role',
+    created_at: new Date(),
+    updated_at: new Date(),
+    id: 1,
+  },
+};
+
+const administratorOfChapter1 = merge(baseChapterUser, {
+  chapter_role: { name: ChapterRoles.administrator },
+});
+
+const administratorOfChapter2 = merge(baseChapterUser, {
+  chapter_role: { name: ChapterRoles.administrator },
+  chapter_id: 2,
+});
+
+const memberOfChapter1 = merge(baseChapterUser, {
+  chapter_role: { name: ChapterRoles.member },
+});
+const memberOfChapter2 = merge(baseChapterUser, {
+  chapter_role: { name: ChapterRoles.member },
+  chapter_id: 2,
+});
+
+export const userChaptersWithChapter1Admin = [
+  administratorOfChapter1,
+  memberOfChapter2,
+];
+export const userChaptersWithChapter2Admin = [
+  memberOfChapter1,
+  administratorOfChapter2,
+];
+export const userChaptersWithTwoAdmins = [
+  administratorOfChapter1,
+  administratorOfChapter2,
+];
+export const userChaptersWithTwoMembers = [memberOfChapter1, memberOfChapter2];


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Reference #1621

---
- Makes chapter_administrator instance role an internal role.
- For convenience changing roles relies now on the role names, instead of ids.
- Client doesn't send request if role isn't actually changed.
- Cypress
  - Adds few fixtures.
  - Adds task for getting user.
  - Adds custom command changing instance role.
  - Adds util to expect no errors in response. I was confused for a while when one request was quietly erroring.
- Uses chapter and instance roles enums imported from factories.