### PR TITLE
fix: rsvp when clicking on invitation

### DIFF
--- a/client/src/components/PageLayout/Header.tsx
+++ b/client/src/components/PageLayout/Header.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/router';
 import React, { forwardRef } from 'react';
 import NextLink from 'next/link';
 
-import { useAuthStore } from '../../modules/auth/store';
+import { useAuth } from '../../modules/auth/store';
 import styles from '../../styles/Header.module.css';
 import { Permission } from '../../../../common/permissions';
 import { checkPermission } from '../../util/check-permission';
@@ -58,9 +58,7 @@ const LoginButton = () => {
 
 export const Header: React.FC = () => {
   const router = useRouter();
-  const {
-    data: { user, loadingUser },
-  } = useAuthStore();
+  const { user, loadingUser } = useAuth();
   const logout = useLogout();
 
   const canAuthenticateWithGoogle = checkPermission(

--- a/client/src/modules/auth/store/index.tsx
+++ b/client/src/modules/auth/store/index.tsx
@@ -15,7 +15,6 @@ export const AuthContext = createContext<{
   data: { loadingUser: true, isLoggedIn: false },
 });
 
-export const useAuthStore = () => useContext(AuthContext);
 export const useAuth = () => useContext(AuthContext).data;
 
 export const AuthContextProvider = ({

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -66,16 +66,14 @@ export const EventPage: NextPage = () => {
   const confirm = useConfirm();
 
   const eventUser = useMemo(() => {
-    const eUser = data?.event?.event_users.find(
+    return data?.event?.event_users.find(
       ({ user: event_user }) => event_user.id === user?.id,
     );
-    if (!eUser) return null;
-    return eUser;
   }, [data?.event]);
-  const userRsvped =
+  const rsvpStatus =
     eventUser?.rsvp.name !== 'no' ? eventUser?.rsvp.name : null;
   const allDataLoaded = !loading && user;
-  const canCheckRsvp = router.query?.emaillink && !userRsvped;
+  const canCheckRsvp = router.query?.emaillink && !rsvpStatus;
   useEffect(() => {
     if (allDataLoaded && canCheckRsvp) checkOnRsvp();
   }, [allDataLoaded, canCheckRsvp]);
@@ -213,14 +211,14 @@ export const EventPage: NextPage = () => {
           </Heading>
         )}
       </HStack>
-      {userRsvped === 'yes' ? (
+      {rsvpStatus === 'yes' ? (
         <HStack>
           <Heading>You&lsquo;ve RSVPed to this event</Heading>
           <Button onClick={onCancelRsvp} paddingInline={'2'} paddingBlock={'1'}>
             Cancel
           </Button>
         </HStack>
-      ) : userRsvped === 'waitlist' ? (
+      ) : rsvpStatus === 'waitlist' ? (
         <HStack>
           {data.event.invite_only ? (
             <Heading as={'h4'} fontSize={'md'} fontWeight={'500'}>

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -144,7 +144,7 @@ export const EventPage: NextPage = () => {
 
   const onCancelRsvp = async () => {
     const ok = await confirm({
-      title: 'Are you sure you want to cancel your RSVP',
+      title: 'Are you sure you want to cancel your RSVP?',
     });
 
     if (ok) {

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -86,7 +86,7 @@ export const EventPage: NextPage = () => {
 
   const chapterId = data.event.chapter.id;
 
-  const onSubscribeToEvent = async () => {
+  async function onSubscribeToEvent() {
     const ok = await confirm({ title: 'Do you want to subscribe?' });
     if (ok) {
       try {
@@ -100,9 +100,9 @@ export const EventPage: NextPage = () => {
         console.error(err);
       }
     }
-  };
+  }
 
-  const onUnsubscribeFromEvent = async () => {
+  async function onUnsubscribeFromEvent() {
     const ok = await confirm({
       title: 'Unsubscribe from event?',
       body: 'After unsubscribing you will not receive any communication regarding this event, including reminder before the event.',
@@ -119,9 +119,9 @@ export const EventPage: NextPage = () => {
         console.error(err);
       }
     }
-  };
+  }
 
-  const onRsvp = async () => {
+  async function onRsvp() {
     const ok = await confirm({ title: 'You want to join this?' });
 
     if (ok) {
@@ -140,9 +140,9 @@ export const EventPage: NextPage = () => {
         console.error(err);
       }
     }
-  };
+  }
 
-  const onCancelRsvp = async () => {
+  async function onCancelRsvp() {
     const ok = await confirm({
       title: 'Are you sure you want to cancel your RSVP?',
     });
@@ -159,13 +159,13 @@ export const EventPage: NextPage = () => {
         console.error(err);
       }
     }
-  };
+  }
 
   // TODO: reimplment this the login modal with Auth0
-  const checkOnRsvp = async () => {
+  async function checkOnRsvp() {
     if (!user) await login();
     await onRsvp();
-  };
+  }
 
   const rsvps = data.event.event_users.filter(
     ({ rsvp }) => rsvp.name === 'yes',

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -19,7 +19,7 @@ import NextError from 'next/error';
 import { useRouter } from 'next/router';
 import React, { useEffect, useMemo } from 'react';
 
-import { useAuthStore } from '../../auth/store';
+import { useAuth } from '../../auth/store';
 import { Loading } from '../../../components/Loading';
 import SponsorsCard from '../../../components/SponsorsCard';
 import { EVENT } from '../graphql/queries';
@@ -38,9 +38,7 @@ import { useLogin } from 'hooks/useAuth';
 export const EventPage: NextPage = () => {
   const { param: eventId, isReady } = useParam('eventId');
   const router = useRouter();
-  const {
-    data: { user },
-  } = useAuthStore();
+  const { user } = useAuth();
   const login = useLogin();
 
   const refetch = {

--- a/client/src/modules/profiles/pages/userProfile.tsx
+++ b/client/src/modules/profiles/pages/userProfile.tsx
@@ -8,16 +8,14 @@ import {
   useUpdateMeMutation,
   UpdateUserInputs,
 } from '../../../generated/graphql';
-import { useAuthStore } from '../../auth/store';
+import { useAuth } from '../../auth/store';
 import { ProfileForm } from '../component/ProfileForm';
 import { meQuery } from 'modules/auth/graphql/queries';
 import { useLogout } from 'hooks/useAuth';
 
 export const UserProfilePage = () => {
   const [loadingUpdate, setLoadingUpdate] = useState(false);
-  const {
-    data: { user },
-  } = useAuthStore();
+  const { user } = useAuth();
   const logout = useLogout();
   const router = useRouter();
 

--- a/cypress/e2e/events/[eventId].cy.ts
+++ b/cypress/e2e/events/[eventId].cy.ts
@@ -92,9 +92,9 @@ describe('event page', () => {
     cy.login('test@user.org');
     cy.visit('/events/1?emaillink=true');
 
-    cy.contains('Are you sure you want join this?');
+    cy.contains('Are you sure you want to join this?');
     cy.findByRole('button', { name: 'Confirm' }).click();
-    cy.contains("You've RSVPed to this event");
+    cy.get('[data-cy="rsvp-success"]').should('be.visible');
     cy.findByRole('button', { name: 'Cancel' }).should('be.visible');
   });
 

--- a/cypress/e2e/events/[eventId].cy.ts
+++ b/cypress/e2e/events/[eventId].cy.ts
@@ -69,9 +69,33 @@ describe('event page', () => {
         // NOTE: we can't cy.get('@login-submit').should('not.exist') here
         // because that dom element is no longer in the DOM, resolves to
         // undefined and the test fails.
-        cy.contains('You want to join this?');
+        cy.contains('Are you sure you want join this?');
         cy.findByRole('button', { name: 'Confirm' }).should('be.visible');
       });
+  });
+
+  it('is possible to cancel using the email links', () => {
+    cy.login('test@user.org');
+    const chapterId = 1;
+    cy.joinChapter(chapterId).then(() => {
+      cy.rsvpToEvent({ eventId: 1, chapterId }).then(() => {
+        cy.visit('/events/1?emaillink=true');
+
+        cy.contains('Are you sure you want to cancel your RSVP?');
+        cy.findByRole('button', { name: 'Confirm' }).click();
+        cy.findByRole('button', { name: 'RSVP' }).should('be.visible');
+      });
+    });
+  });
+
+  it('is possible to join using the email links', () => {
+    cy.login('test@user.org');
+    cy.visit('/events/1?emaillink=true');
+
+    cy.contains('Are you sure you want join this?');
+    cy.findByRole('button', { name: 'Confirm' }).click();
+    cy.contains("You've RSVPed to this event");
+    cy.findByRole('button', { name: 'Cancel' }).should('be.visible');
   });
 
   it('should be possible to RSVP and cancel', () => {


### PR DESCRIPTION
- refactor: replace useAuthStore with useAuth
- refactor: slight tweaks to eventPage
- test: add tests for rsvp/cancel via email
- refactor: use functions so they're hoisted
- fix(test): target the right text
- fix: rsvp automatically when using invitation link

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

This started off life as a refactor, but I realised that the rsvp flow was broken when you arrived via the link in the invitation.  And that there was a regression (probably caused by me!) at some point. Variable hoisting turns out to be confusing! 

Anyways, all should be well now.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
