### PR TITLE
refactor: always define before use

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,7 @@ server/src/**/*.js
 server/reminders/**/*.js
 server/prisma/**/*.js
 server/tests/**/*.js
+
+common/**/*.js
+
+client/src/generated/graphql.tsx

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,7 +62,8 @@
     "react/prop-types": 0,
     "import/no-unresolved": "error",
     "import/order": "error",
-    "no-only-tests/no-only-tests": "error"
+    "no-only-tests/no-only-tests": "error",
+    "no-use-before-define": "error"
   },
   "settings": {
     "react": {

--- a/client/src/hooks/useSession.ts
+++ b/client/src/hooks/useSession.ts
@@ -7,6 +7,21 @@ const serverUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:5000';
 // of the site in one or the other?
 const needsDevLogin = process.env.NEXT_PUBLIC_USE_AUTH0 === 'false';
 
+const requestSession = (token: string) =>
+  fetch(new URL('/login', serverUrl).href, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    credentials: 'include',
+  });
+
+const destroySession = () =>
+  fetch(new URL('/logout', serverUrl).href, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+
 const useAuth0Session = (): {
   isAuthenticated: boolean;
   createSession: () => Promise<Response>;
@@ -42,21 +57,6 @@ export const useDevSession = (): {
     destroySession,
   };
 };
-
-const requestSession = (token: string) =>
-  fetch(new URL('/login', serverUrl).href, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-    credentials: 'include',
-  });
-
-const destroySession = () =>
-  fetch(new URL('/logout', serverUrl).href, {
-    method: 'DELETE',
-    credentials: 'include',
-  });
 
 export const useSession: () => {
   isAuthenticated: boolean;

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -29,6 +29,39 @@ import {
 } from 'generated/graphql';
 import { useParam } from 'hooks/useParam';
 
+const ChatLink = ({ chatUrl }: { chatUrl?: string | null }) => {
+  return chatUrl ? (
+    <div>
+      <Heading size="md" color={'gray.700'}>
+        Chat Link:
+      </Heading>
+      <Link>{chatUrl}</Link>
+    </div>
+  ) : null;
+};
+
+const SubscriptionWidget = ({
+  chapterUser,
+  chapterSubscribe,
+}: {
+  chapterUser: ChapterUserQuery['chapterUser'];
+  chapterSubscribe: (toSubscribe: boolean) => Promise<void>;
+}) => {
+  return chapterUser.subscribed ? (
+    <HStack>
+      <CheckIcon />
+      <Text>{chapterUser.chapter_role.name} of the chapter</Text>
+      <Button onClick={() => chapterSubscribe(false)} size="md">
+        Unsubscribe
+      </Button>
+    </HStack>
+  ) : (
+    <Button colorScheme="blue" onClick={() => chapterSubscribe(true)} size="md">
+      Subscribe
+    </Button>
+  );
+};
+
 export const ChapterPage: NextPage = () => {
   const { param: chapterId, isReady } = useParam('chapterId');
   const { isLoggedIn } = useAuth();
@@ -162,38 +195,5 @@ export const ChapterPage: NextPage = () => {
         ))}
       </Stack>
     </VStack>
-  );
-};
-
-const ChatLink = ({ chatUrl }: { chatUrl?: string | null }) => {
-  return chatUrl ? (
-    <div>
-      <Heading size="md" color={'gray.700'}>
-        Chat Link:
-      </Heading>
-      <Link>{chatUrl}</Link>
-    </div>
-  ) : null;
-};
-
-const SubscriptionWidget = ({
-  chapterUser,
-  chapterSubscribe,
-}: {
-  chapterUser: ChapterUserQuery['chapterUser'];
-  chapterSubscribe: (toSubscribe: boolean) => Promise<void>;
-}) => {
-  return chapterUser.subscribed ? (
-    <HStack>
-      <CheckIcon />
-      <Text>{chapterUser.chapter_role.name} of the chapter</Text>
-      <Button onClick={() => chapterSubscribe(false)} size="md">
-        Unsubscribe
-      </Button>
-    </HStack>
-  ) : (
-    <Button colorScheme="blue" onClick={() => chapterSubscribe(true)} size="md">
-      Subscribe
-    </Button>
   );
 };

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -6,6 +6,29 @@ import {
 } from '../../../../generated/graphql';
 
 import { isOnline, isPhysical } from '../../../../util/venueType';
+
+export interface EventSponsorInput {
+  id: number;
+  type: string;
+}
+
+export interface EventFormData {
+  name: string;
+  description: string;
+  url?: string | null;
+  image_url: string;
+  streaming_url?: string | null;
+  capacity: number;
+  start_at: Date;
+  ends_at: Date;
+  venue_type: VenueType;
+  venue_id?: number | null;
+  invite_only?: boolean;
+  sponsors: Array<EventSponsorInput>;
+  canceled: boolean;
+  chapter_id: number;
+}
+
 export interface Field {
   key: keyof EventFormData;
   label: string;
@@ -54,10 +77,6 @@ export const venueTypes: VenueTypeInput[] = [
   },
 ];
 
-export interface EventSponsorInput {
-  id: number;
-  type: string;
-}
 export const fields: Field[] = [
   {
     key: 'name',
@@ -108,23 +127,6 @@ export const fields: Field[] = [
   },
 ];
 
-export interface EventFormData {
-  name: string;
-  description: string;
-  url?: string | null;
-  image_url: string;
-  streaming_url?: string | null;
-  capacity: number;
-  start_at: Date;
-  ends_at: Date;
-  venue_type: VenueType;
-  venue_id?: number | null;
-  invite_only?: boolean;
-  sponsors: Array<EventSponsorInput>;
-  canceled: boolean;
-  chapter_id: number;
-}
-
 export type IEventData = Pick<
   Event,
   keyof Omit<EventFormData, 'venue_id' | 'sponsors' | 'chapter_id'> | 'id'
@@ -142,44 +144,6 @@ export interface EventFormProps {
   chapterId: number;
   loadingText: string;
 }
-
-export const getAllowedSponsorTypes = (
-  sponsorData: SponsorsQuery,
-  sponsorTypes: EventSponsorTypeInput[],
-  watchSponsorsArray: EventSponsorInput[],
-  sponsorFieldId: number,
-) =>
-  sponsorTypes.filter(
-    ({ type }) =>
-      getAllowedSponsorsForType(
-        sponsorData,
-        type,
-        watchSponsorsArray,
-        sponsorFieldId,
-      ).length,
-  );
-
-export const getAllowedSponsorsForType = (
-  sponsorData: SponsorsQuery,
-  sponsorType: string,
-  watchSponsorsArray: EventSponsorInput[],
-  sponsorFieldId?: number,
-) =>
-  sponsorData.sponsors.filter(
-    (sponsor) =>
-      sponsor.type === sponsorType &&
-      !isSponsorSelectedElsewhere(sponsor, watchSponsorsArray, sponsorFieldId),
-  );
-
-export const getAllowedSponsors = (
-  sponsorData: SponsorsQuery,
-  watchSponsorsArray: EventSponsorInput[],
-  sponsorFieldId?: number,
-) =>
-  sponsorData.sponsors.filter(
-    (sponsor) =>
-      !isSponsorSelectedElsewhere(sponsor, watchSponsorsArray, sponsorFieldId),
-  );
 
 const getSelectedFieldIdForSponsor = (
   sponsor: EventSponsorInput,
@@ -203,6 +167,44 @@ const isSponsorSelectedElsewhere = (
     (sponsorFieldId === undefined || selectedFieldId !== sponsorFieldId)
   );
 };
+
+export const getAllowedSponsorsForType = (
+  sponsorData: SponsorsQuery,
+  sponsorType: string,
+  watchSponsorsArray: EventSponsorInput[],
+  sponsorFieldId?: number,
+) =>
+  sponsorData.sponsors.filter(
+    (sponsor) =>
+      sponsor.type === sponsorType &&
+      !isSponsorSelectedElsewhere(sponsor, watchSponsorsArray, sponsorFieldId),
+  );
+
+export const getAllowedSponsorTypes = (
+  sponsorData: SponsorsQuery,
+  sponsorTypes: EventSponsorTypeInput[],
+  watchSponsorsArray: EventSponsorInput[],
+  sponsorFieldId: number,
+) =>
+  sponsorTypes.filter(
+    ({ type }) =>
+      getAllowedSponsorsForType(
+        sponsorData,
+        type,
+        watchSponsorsArray,
+        sponsorFieldId,
+      ).length,
+  );
+
+export const getAllowedSponsors = (
+  sponsorData: SponsorsQuery,
+  watchSponsorsArray: EventSponsorInput[],
+  sponsorFieldId?: number,
+) =>
+  sponsorData.sponsors.filter(
+    (sponsor) =>
+      !isSponsorSelectedElsewhere(sponsor, watchSponsorsArray, sponsorFieldId),
+  );
 
 export const parseEventData = (data: EventFormData) => {
   // It's ugly, but we can't rely on TS to check that chapter_id is absent, so

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -29,6 +29,10 @@ const httpLink = createHttpLink({
   credentials: 'include',
 });
 
+function isServerError(err?: NetworkError): err is ServerError {
+  return !(err == null) && 'result' in err && 'statusCode' in err;
+}
+
 const errorLink = onError(({ networkError }) => {
   if (isServerError(networkError)) {
     if (networkError.statusCode === 401) {
@@ -44,10 +48,6 @@ const errorLink = onError(({ networkError }) => {
     }
   }
 });
-
-function isServerError(err?: NetworkError): err is ServerError {
-  return !(err == null) && 'result' in err && 'statusCode' in err;
-}
 
 const client = new ApolloClient({
   link: from([errorLink, httpLink]),

--- a/cypress/e2e/dashboard/chapters/[chapterId]/chapterId-index.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/chapterId-index.cy.ts
@@ -25,6 +25,51 @@ const eventData = {
   invite_only: false,
 };
 
+function createEventViaUI(chapterId) {
+  cy.visit(`/dashboard/chapters/${chapterId}`);
+  cy.get(`a[href="/dashboard/chapters/${chapterId}/new-event"]`).click();
+  cy.findByRole('textbox', { name: 'Event title' }).type(testEvent.name);
+  cy.findByRole('textbox', { name: 'Description' }).type(testEvent.description);
+  cy.findByRole('textbox', { name: 'Event Image Url' }).type(
+    testEvent.image_url,
+  );
+  // cy.findByRole('textbox', { name: 'Url' }).type(testEvent.url);
+  cy.findByRole('spinbutton', { name: 'Capacity' }).type(testEvent.capacity);
+
+  cy.findByLabelText(/^Start at/)
+    .clear()
+    .type(testEvent.start_at)
+    .type('{esc}');
+  cy.findByLabelText(/^End at/)
+    .clear()
+    .type(testEvent.ends_at)
+    .type('{esc}');
+
+  // TODO: figure out why cypress thinks this is covered.
+  // cy.findByRole('checkbox', { name: 'Invite only' }).click();
+  cy.get('[data-cy="invite-only-checkbox"]').click();
+  // TODO: I thought <select> would be a listbox - does it matter that it's a
+  // combobox?
+  cy.findByRole('combobox', { name: 'Venue' })
+    .as('venueSelect')
+    .select(testEvent.venue_id);
+  cy.get('@venueSelect')
+    .find(`option[value=${testEvent.venue_id}]`)
+    .invoke('text')
+    .as('venueTitle');
+  cy.findByRole('textbox', { name: 'Streaming URL' }).type(
+    testEvent.streaming_url,
+  );
+  cy.findByRole('button', { name: 'Add Sponsor' }).click();
+
+  cy.findByRole('form', { name: 'Add event' })
+    .findByRole('button', {
+      name: 'Add event',
+    })
+    .click();
+  cy.location('pathname').should('match', /^\/dashboard\/events\/\d+$/);
+}
+
 describe('chapter dashboard', () => {
   beforeEach(() => {
     cy.task('seedDb');
@@ -103,51 +148,4 @@ describe('chapter dashboard', () => {
       cy.contains(eventData.name).should('not.exist');
     });
   });
-
-  function createEventViaUI(chapterId) {
-    cy.visit(`/dashboard/chapters/${chapterId}`);
-    cy.get(`a[href="/dashboard/chapters/${chapterId}/new-event"]`).click();
-    cy.findByRole('textbox', { name: 'Event title' }).type(testEvent.name);
-    cy.findByRole('textbox', { name: 'Description' }).type(
-      testEvent.description,
-    );
-    cy.findByRole('textbox', { name: 'Event Image Url' }).type(
-      testEvent.image_url,
-    );
-    // cy.findByRole('textbox', { name: 'Url' }).type(testEvent.url);
-    cy.findByRole('spinbutton', { name: 'Capacity' }).type(testEvent.capacity);
-
-    cy.findByLabelText(/^Start at/)
-      .clear()
-      .type(testEvent.start_at)
-      .type('{esc}');
-    cy.findByLabelText(/^End at/)
-      .clear()
-      .type(testEvent.ends_at)
-      .type('{esc}');
-
-    // TODO: figure out why cypress thinks this is covered.
-    // cy.findByRole('checkbox', { name: 'Invite only' }).click();
-    cy.get('[data-cy="invite-only-checkbox"]').click();
-    // TODO: I thought <select> would be a listbox - does it matter that it's a
-    // combobox?
-    cy.findByRole('combobox', { name: 'Venue' })
-      .as('venueSelect')
-      .select(testEvent.venue_id);
-    cy.get('@venueSelect')
-      .find(`option[value=${testEvent.venue_id}]`)
-      .invoke('text')
-      .as('venueTitle');
-    cy.findByRole('textbox', { name: 'Streaming URL' }).type(
-      testEvent.streaming_url,
-    );
-    cy.findByRole('button', { name: 'Add Sponsor' }).click();
-
-    cy.findByRole('form', { name: 'Add event' })
-      .findByRole('button', {
-        name: 'Add event',
-      })
-      .click();
-    cy.location('pathname').should('match', /^\/dashboard\/events\/\d+$/);
-  }
 });

--- a/cypress/e2e/dashboard/chapters/users.cy.ts
+++ b/cypress/e2e/dashboard/chapters/users.cy.ts
@@ -94,6 +94,18 @@ describe('Chapter Users dashboard', () => {
     );
   });
 
+  function initializeBanVariables() {
+    // We don't want to interact with the instance owner here
+    cy.findAllByRole('row').not(':contains("The Owner")').as('rows');
+    cy.get('@rows').filter(':contains("member")').as('members');
+    cy.get('@rows').filter(':contains("administrator")').as('administrators');
+    cy.get('@members')
+      .not(':contains("Unban")')
+      .not(':contains("Banned")')
+      .first()
+      .as('firstUnbannedMember');
+  }
+
   it('administrator can ban user from chapter', () => {
     cy.visit(`/dashboard/chapters/${chapterId}/users`);
 
@@ -136,18 +148,6 @@ describe('Chapter Users dashboard', () => {
       .findByRole('button', { name: 'Unban' })
       .should('not.exist');
   });
-
-  function initializeBanVariables() {
-    // We don't want to interact with the instance owner here
-    cy.findAllByRole('row').not(':contains("The Owner")').as('rows');
-    cy.get('@rows').filter(':contains("member")').as('members');
-    cy.get('@rows').filter(':contains("administrator")').as('administrators');
-    cy.get('@members')
-      .not(':contains("Unban")')
-      .not(':contains("Banned")')
-      .first()
-      .as('firstUnbannedMember');
-  }
 
   it("admins of other chapters should NOT be able to ban (or unban) that chapter's users", () => {
     cy.login('admin@of.chapter.two');

--- a/cypress/e2e/dashboard/events/[eventId].cy.ts
+++ b/cypress/e2e/dashboard/events/[eventId].cy.ts
@@ -1,6 +1,14 @@
 import { EventUsers } from '../../../../cypress.config';
 import { expectToBeRejected } from '../../../support/util';
 
+const setUsernameAlias = (usersAlias: string) =>
+  cy
+    .get(usersAlias)
+    .find('[data-cy=username]')
+    .first()
+    .invoke('text')
+    .as('userName');
+
 describe('event dashboard', () => {
   beforeEach(() => {
     cy.task('seedDb');
@@ -111,11 +119,3 @@ describe('event dashboard', () => {
     });
   });
 });
-
-const setUsernameAlias = (usersAlias: string) =>
-  cy
-    .get(usersAlias)
-    .find('[data-cy=username]')
-    .first()
-    .invoke('text')
-    .as('userName');

--- a/cypress/e2e/dashboard/pages-needing-permission.cy.ts
+++ b/cypress/e2e/dashboard/pages-needing-permission.cy.ts
@@ -4,6 +4,50 @@ const bannedChapter = 1;
 const bannedEvent = 1;
 const bannedVenue = 1;
 
+function visitBannedDashboards() {
+  cy.visit(`/dashboard/chapters/${bannedChapter}`);
+  cy.get('[data-cy=loading-error]').should('be.visible');
+  cy.contains(deniedText);
+
+  cy.visit(`/dashboard/chapters/${bannedChapter}/edit`);
+  cy.get('[data-cy=loading-error]').should('be.visible');
+  cy.contains(deniedText);
+
+  cy.visit(`/dashboard/events/${bannedEvent}`);
+  cy.get('[data-cy=loading-error]').should('be.visible');
+  cy.contains(deniedText);
+
+  cy.visit(`/dashboard/events/${bannedEvent}/edit`);
+  cy.get('[data-cy=loading-error]').should('be.visible');
+  cy.contains(deniedText);
+
+  cy.visit(`/dashboard/venues/${bannedVenue}`);
+  cy.get('[data-cy=loading-error]').should('be.visible');
+  cy.contains(deniedText);
+
+  cy.visit(`/dashboard/chapters/${bannedChapter}/venues/${bannedVenue}/edit`);
+  cy.get('[data-cy=loading-error]').should('be.visible');
+  cy.contains(deniedText);
+
+  cy.visit(`/dashboard/chapters/${bannedChapter}/users`);
+  cy.get('[data-cy=loading-error]').should('be.visible');
+  cy.contains(deniedText);
+
+  cy.visit(`/dashboard/sponsors/1/edit`);
+  cy.get('[data-cy=loading-error]').should('be.visible');
+  cy.contains(deniedText);
+}
+
+function visitNonMemberDashboards() {
+  cy.visit(`/dashboard/sponsors`);
+  cy.get('[data-cy=loading-error]').should('be.visible');
+  cy.contains(deniedText);
+
+  cy.visit(`/dashboard/sponsors/1`);
+  cy.get('[data-cy=loading-error]').should('be.visible');
+  cy.contains(deniedText);
+}
+
 describe('all dashboards', () => {
   it('they should be forbidden to the admin banned from that chapter', () => {
     cy.login('banned@chapter.admin');
@@ -17,48 +61,4 @@ describe('all dashboards', () => {
     visitBannedDashboards();
     visitNonMemberDashboards();
   });
-
-  function visitBannedDashboards() {
-    cy.visit(`/dashboard/chapters/${bannedChapter}`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-    cy.contains(deniedText);
-
-    cy.visit(`/dashboard/chapters/${bannedChapter}/edit`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-    cy.contains(deniedText);
-
-    cy.visit(`/dashboard/events/${bannedEvent}`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-    cy.contains(deniedText);
-
-    cy.visit(`/dashboard/events/${bannedEvent}/edit`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-    cy.contains(deniedText);
-
-    cy.visit(`/dashboard/venues/${bannedVenue}`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-    cy.contains(deniedText);
-
-    cy.visit(`/dashboard/chapters/${bannedChapter}/venues/${bannedVenue}/edit`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-    cy.contains(deniedText);
-
-    cy.visit(`/dashboard/chapters/${bannedChapter}/users`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-    cy.contains(deniedText);
-
-    cy.visit(`/dashboard/sponsors/1/edit`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-    cy.contains(deniedText);
-  }
-
-  function visitNonMemberDashboards() {
-    cy.visit(`/dashboard/sponsors`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-    cy.contains(deniedText);
-
-    cy.visit(`/dashboard/sponsors/1`);
-    cy.get('[data-cy=loading-error]').should('be.visible');
-    cy.contains(deniedText);
-  }
 });

--- a/scripts/postInstall.js
+++ b/scripts/postInstall.js
@@ -8,8 +8,6 @@ console.log('--------------------------');
 const CHAPTER_REMOTE = 'freeCodeCamp/chapter.git';
 let IS_ERROR = false;
 
-setup();
-
 function setup() {
   try {
     const rows = execSync('git remote -v', {
@@ -53,3 +51,5 @@ function setup() {
     );
   }
 }
+
+setup();

--- a/server/prisma/generator/init.ts
+++ b/server/prisma/generator/init.ts
@@ -4,25 +4,6 @@ import createEventRoles from './factories/eventRoles.factory';
 import createInstanceRoles from './factories/instanceRoles.factory';
 import { createRsvpTypes } from './factories/rsvps.factory';
 
-const myArgs = process.argv.slice(2);
-if (myArgs.length === 1 && myArgs[0] === '--execute') {
-  // First truncate any existing tables. This is necessary in testing, because
-  // the database needs to be initialized before use. However, if we recreate
-  // the schema, cached queries targetting the old schema will fail with ERROR:
-  // cached plan must not change result type.
-  truncateTables().then(() => {
-    createRoles();
-    createRsvpTypes();
-  });
-} else if (myArgs.length === 0) {
-  // do nothing, it's just being imported and will be called by the importing script
-} else {
-  console.error(`--To execute:
-    node init.ts --execute
---All other arguments are invalid
-`);
-}
-
 export async function truncateTables() {
   const tablenames = await prisma.$queryRaw<
     Array<{ tablename: string }>
@@ -51,6 +32,25 @@ export async function createRoles() {
     eventRoles,
     chapterRoles,
   };
+}
+
+const myArgs = process.argv.slice(2);
+if (myArgs.length === 1 && myArgs[0] === '--execute') {
+  // First truncate any existing tables. This is necessary in testing, because
+  // the database needs to be initialized before use. However, if we recreate
+  // the schema, cached queries targetting the old schema will fail with ERROR:
+  // cached plan must not change result type.
+  truncateTables().then(() => {
+    createRoles();
+    createRsvpTypes();
+  });
+} else if (myArgs.length === 0) {
+  // do nothing, it's just being imported and will be called by the importing script
+} else {
+  console.error(`--To execute:
+    node init.ts --execute
+--All other arguments are invalid
+`);
 }
 
 export default createRoles;

--- a/server/reminders/reminders.ts
+++ b/server/reminders/reminders.ts
@@ -28,18 +28,6 @@ const timeFormatter = new Intl.DateTimeFormat('en-us', {
 
 type LockCheck = (reminder: Reminder) => Promise<{ hasLock: boolean }>;
 
-const processReminders = async (reminders: Reminder[], lock: LockCheck) =>
-  await Promise.all(
-    reminders.map(async (reminder) => {
-      const { hasLock } = await lock(reminder);
-      if (!hasLock) {
-        return;
-      }
-      await sendEmailForReminder(reminder);
-      await deleteReminder(reminder);
-    }),
-  );
-
 interface ReminderMessageData {
   event: Reminder['event_user']['event'];
   user: Reminder['event_user']['user'];
@@ -121,6 +109,18 @@ const sendEmailForReminder = async (reminder: Reminder) => {
     htmlEmail: email,
   }).sendEmail();
 };
+
+const processReminders = async (reminders: Reminder[], lock: LockCheck) =>
+  await Promise.all(
+    reminders.map(async (reminder) => {
+      const { hasLock } = await lock(reminder);
+      if (!hasLock) {
+        return;
+      }
+      await sendEmailForReminder(reminder);
+      await deleteReminder(reminder);
+    }),
+  );
 
 (async () => {
   const date = new Date();

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -65,6 +65,30 @@ export const main = async (app: Express) => {
     }),
   );
 
+  async function findUser(email: string) {
+    return await prisma.users.findUnique({
+      where: {
+        email,
+      },
+    });
+  }
+
+  // TODO: use the register resolver instead? Or just delete it? Probably
+  // delete.
+  async function createUser(email: string) {
+    return prisma.users.create({
+      data: {
+        name: 'place holder',
+        email,
+        instance_role: {
+          connect: {
+            name: 'member',
+          },
+        },
+      },
+    });
+  }
+
   app.post('/login', checkJwt, (req, res, next) => {
     const token = getBearerToken(req);
     if (token) {
@@ -99,30 +123,6 @@ export const main = async (app: Express) => {
       next('no bearer token');
     }
   });
-
-  async function findUser(email: string) {
-    return await prisma.users.findUnique({
-      where: {
-        email,
-      },
-    });
-  }
-
-  // TODO: use the register resolver instead? Or just delete it? Probably
-  // delete.
-  async function createUser(email: string) {
-    return prisma.users.create({
-      data: {
-        name: 'place holder',
-        email,
-        instance_role: {
-          connect: {
-            name: 'member',
-          },
-        },
-      },
-    });
-  }
 
   // no need to check for identity provider's token on logout
   app.delete('/logout', (req, res, next) => {

--- a/server/src/authorization/index.ts
+++ b/server/src/authorization/index.ts
@@ -8,28 +8,6 @@ import type { Events, User, Venues } from '../controllers/Auth/middleware';
 // constrained to be a Record<string, any>, basically.
 type VariableValues = GraphQLResolveInfo['variableValues'];
 
-/** authorizationChecker allows or denies access to fields and resolvers based
- * on a user's role. It cannot affect what is returned by a resolver, it just
- * determines if the resolver is called or not. For fine-grained control, the
- * resolver itself must modify the response based on the user's roles */
-export const authorizationChecker: AuthChecker<
-  ResolverCtx | Required<ResolverCtx>
-> = ({ context, info: { variableValues } }, requiredPermissions): boolean => {
-  if (!hasUserEventsAndVenues(context)) return false;
-
-  if (requiredPermissions.length !== 1) return false;
-  const requiredPermission = requiredPermissions[0];
-
-  if (isAllowedByInstanceRole(context, requiredPermission)) return true;
-  if (isBannedFromChapter(context, variableValues)) return false;
-  if (isAllowedByChapterRole(context, requiredPermission, variableValues))
-    return true;
-  if (isAllowedByEventRole(context, requiredPermission, variableValues))
-    return true;
-
-  return false;
-};
-
 function hasUserEventsAndVenues(
   ctx: ResolverCtx | Required<ResolverCtx>,
 ): ctx is Required<ResolverCtx> {
@@ -40,23 +18,20 @@ function hasUserEventsAndVenues(
   );
 }
 
-function isAllowedByChapterRole(
-  { user, events, venues }: Required<ResolverCtx>,
+function hasNecessaryPermission(
   requiredPermission: string,
-  variableValues: VariableValues,
+  ownedPermissions: string[],
 ): boolean {
-  const chapterId = getRelatedChapterId({ events, venues }, variableValues);
-  if (chapterId === null) return false;
-  const userChapterPermissions = getUserPermissionsForChapter(user, chapterId);
-  return hasNecessaryPermission(requiredPermission, userChapterPermissions);
+  return ownedPermissions.includes(requiredPermission);
 }
 
-function isAllowedByInstanceRole(
-  { user }: Required<ResolverCtx>,
-  requiredPermission: string,
-): boolean {
-  const userInstancePermissions = getUserPermissionsForInstance(user);
-  return hasNecessaryPermission(requiredPermission, userInstancePermissions);
+function getUserPermissionsForChapter(user: User, chapterId: number): string[] {
+  const role = user.user_chapters.find((role) => role.chapter_id === chapterId);
+  return role
+    ? role.chapter_role.chapter_role_permissions.map(
+        (x) => x.chapter_permission.name,
+      )
+    : [];
 }
 
 // a request may be associate with a specific chapter directly (if the request
@@ -82,13 +57,15 @@ function getRelatedChapterId(
   return null;
 }
 
-function isAllowedByEventRole(
-  { user }: Required<ResolverCtx>,
+function isAllowedByChapterRole(
+  { user, events, venues }: Required<ResolverCtx>,
   requiredPermission: string,
-  info: VariableValues,
+  variableValues: VariableValues,
 ): boolean {
-  const userEventPermissions = getUserPermissionsForEvent(user, info);
-  return hasNecessaryPermission(requiredPermission, userEventPermissions);
+  const chapterId = getRelatedChapterId({ events, venues }, variableValues);
+  if (chapterId === null) return false;
+  const userChapterPermissions = getUserPermissionsForChapter(user, chapterId);
+  return hasNecessaryPermission(requiredPermission, userChapterPermissions);
 }
 
 function getUserPermissionsForInstance(user: User): string[] {
@@ -97,13 +74,12 @@ function getUserPermissionsForInstance(user: User): string[] {
   );
 }
 
-function getUserPermissionsForChapter(user: User, chapterId: number): string[] {
-  const role = user.user_chapters.find((role) => role.chapter_id === chapterId);
-  return role
-    ? role.chapter_role.chapter_role_permissions.map(
-        (x) => x.chapter_permission.name,
-      )
-    : [];
+function isAllowedByInstanceRole(
+  { user }: Required<ResolverCtx>,
+  requiredPermission: string,
+): boolean {
+  const userInstancePermissions = getUserPermissionsForInstance(user);
+  return hasNecessaryPermission(requiredPermission, userInstancePermissions);
 }
 
 function getUserPermissionsForEvent(
@@ -116,6 +92,15 @@ function getUserPermissionsForEvent(
   return role
     ? role.event_role.event_role_permissions.map((x) => x.event_permission.name)
     : [];
+}
+
+function isAllowedByEventRole(
+  { user }: Required<ResolverCtx>,
+  requiredPermission: string,
+  info: VariableValues,
+): boolean {
+  const userEventPermissions = getUserPermissionsForEvent(user, info);
+  return hasNecessaryPermission(requiredPermission, userEventPermissions);
 }
 
 function isBannedFromChapter(
@@ -132,9 +117,24 @@ function isBannedFromChapter(
   return bannedFromChapter;
 }
 
-function hasNecessaryPermission(
-  requiredPermission: string,
-  ownedPermissions: string[],
-): boolean {
-  return ownedPermissions.includes(requiredPermission);
-}
+/** authorizationChecker allows or denies access to fields and resolvers based
+ * on a user's role. It cannot affect what is returned by a resolver, it just
+ * determines if the resolver is called or not. For fine-grained control, the
+ * resolver itself must modify the response based on the user's roles */
+export const authorizationChecker: AuthChecker<
+  ResolverCtx | Required<ResolverCtx>
+> = ({ context, info: { variableValues } }, requiredPermissions): boolean => {
+  if (!hasUserEventsAndVenues(context)) return false;
+
+  if (requiredPermissions.length !== 1) return false;
+  const requiredPermission = requiredPermissions[0];
+
+  if (isAllowedByInstanceRole(context, requiredPermission)) return true;
+  if (isBannedFromChapter(context, variableValues)) return false;
+  if (isAllowedByChapterRole(context, requiredPermission, variableValues))
+    return true;
+  if (isAllowedByEventRole(context, requiredPermission, variableValues))
+    return true;
+
+  return false;
+};

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -44,5 +44,5 @@ export const getConfig = <T extends keyof Environment>(
 
 export const getEnv = () => getConfig('NODE_ENV', 'development');
 export const isDev = () => getEnv() === 'development';
-export const isProd = () => !isDev() && !isTest();
 export const isTest = () => getEnv() === 'test';
+export const isProd = () => !isDev() && !isTest();

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -185,6 +185,15 @@ ${venueDetails}`;
 };
 
 const getUpdateData = (data: EventInputs, event: EventWithUsers) => {
+  const getVenueData = (data: EventInputs, event: EventWithUsers) => ({
+    streaming_url: isOnline(event.venue_type)
+      ? data.streaming_url ?? event.streaming_url
+      : null,
+    venue: isPhysical(event.venue_type)
+      ? { connect: { id: data.venue_id } }
+      : { disconnect: true },
+  });
+
   const update = {
     invite_only: data.invite_only ?? event.invite_only,
     name: data.name ?? event.name,
@@ -199,15 +208,6 @@ const getUpdateData = (data: EventInputs, event: EventWithUsers) => {
   };
   return update;
 };
-
-const getVenueData = (data: EventInputs, event: EventWithUsers) => ({
-  streaming_url: isOnline(event.venue_type)
-    ? data.streaming_url ?? event.streaming_url
-    : null,
-  venue: isPhysical(event.venue_type)
-    ? { connect: { id: data.venue_id } }
-    : { disconnect: true },
-});
 
 const chapterUserInclude = {
   include: {

--- a/server/src/services/Reminders.ts
+++ b/server/src/services/Reminders.ts
@@ -1,8 +1,26 @@
+import { Prisma } from '@prisma/client';
+
 import { prisma } from '../prisma';
 
-export type Reminder = Awaited<
-  ReturnType<typeof getRemindersOlderThanDate>
->[number];
+const reminderIncludes = {
+  include: {
+    event_user: {
+      include: {
+        user: true,
+        event: {
+          include: {
+            venue: true,
+            chapter: true,
+          },
+        },
+      },
+    },
+  },
+};
+
+export type Reminder = Prisma.event_remindersGetPayload<
+  typeof reminderIncludes
+>;
 
 export interface ReminderData {
   eventId: number;
@@ -39,20 +57,6 @@ export const deleteReminder = async (reminder: Reminder) =>
 export const deleteEventReminders = async (eventId: number) =>
   await prisma.event_reminders.deleteMany({ where: { event_id: eventId } });
 
-const reminderIncludes = {
-  event_user: {
-    include: {
-      user: true,
-      event: {
-        include: {
-          venue: true,
-          chapter: true,
-        },
-      },
-    },
-  },
-};
-
 export const updateRemindAt = async ({
   eventId,
   remindAt,
@@ -67,7 +71,7 @@ export const updateRemindAt = async ({
 
 export const getRemindersOlderThanDate = async (date: Date) =>
   await prisma.event_reminders.findMany({
-    include: reminderIncludes,
+    ...reminderIncludes,
     where: {
       remind_at: {
         lte: date,
@@ -81,7 +85,7 @@ export const getRemindersOlderThanDate = async (date: Date) =>
 
 export const getOldReminders = async (date: Date) =>
   await prisma.event_reminders.findMany({
-    include: reminderIncludes,
+    ...reminderIncludes,
     where: {
       notifying: true,
       updated_at: {


### PR DESCRIPTION
This avoids an annoying class of bugs:

f()
var a = 'defined'
function f() { // does something with a }

f looks as if it should be able to use a, but hoisting means that's not always the case.

This is quite relevant for our code, since we often need to useEffect before a conditional return, but rely on variables that are only guaranteed to be defined after it.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
