### PR TITLE
fix(test): flaky events-index tests

### DIFF
--- a/client/src/modules/dashboard/Events/pages/EventsPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventsPage.tsx
@@ -21,7 +21,7 @@ export const EventsPage: NextPageWithLayout = () => {
     return <DashboardLoading loading={isLoading} error={error} />;
 
   return (
-    <VStack>
+    <VStack data-cy="events-dashboard">
       <Flex w="full" justify="space-between">
         <Heading id="page-heading">Events</Heading>
         {!!user?.admined_chapters.length && (

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -208,8 +208,7 @@ describe('spec needing owner', () => {
     cy.findByRole('link', { name: 'Events' }).click();
     cy.contains('Loading...');
     cy.wait('@GQLevents');
-    cy.url().should('include', '/events');
-    cy.get('#page-heading').contains('Events');
+    cy.get('[data-cy="events-dashboard"]').should('be.visible');
 
     cy.get<string>('@eventTitle').then((eventTitle) => {
       cy.findByRole('link', { name: eventTitle }).click();
@@ -225,7 +224,7 @@ describe('spec needing owner', () => {
       })
       .click();
 
-    cy.get('#page-heading').contains('Events');
+    cy.get('[data-cy="events-dashboard"]').should('be.visible');
     cy.get('@eventTitle').then((eventTitle) => {
       cy.findByRole('link', { name: `${eventTitle}${titleAddon}` });
     });
@@ -247,7 +246,7 @@ describe('spec needing owner', () => {
     cy.findByRole('link', { name: 'Events' }).click();
     cy.contains('Loading...');
     cy.wait('@GQLevents');
-    cy.get('#page-heading').contains('Events');
+    cy.get('[data-cy="events-dashboard"]').should('be.visible');
     cy.get<string>('@eventTitle').then((eventTitle) => {
       cy.findByRole('link', { name: eventTitle }).click();
     });
@@ -255,7 +254,7 @@ describe('spec needing owner', () => {
     cy.findByRole('button', { name: 'Delete' }).click();
     cy.findByRole('button', { name: 'Delete' }).click();
 
-    cy.get('#page-heading').contains('Events');
+    cy.get('[data-cy="events-dashboard"]').should('be.visible');
     cy.get<string>('@eventTitle').then((eventTitle) => {
       cy.contains(eventTitle).should('not.exist');
     });


### PR DESCRIPTION
It was tricky to reproduce, but I believe the problem was that Cypress
was finding the tab before navigation happened, but at that point it did
not contain the text Events, so the test fails.

That's my best guess, anyway.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->


<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
