### PR TITLE
fix: don't send new event invite to users banned from chapter

### DIFF
--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -935,7 +935,12 @@ ${unsubscribeOptions}`,
       where: { id },
       include: {
         venue: true,
-        chapter: { include: { chapter_users: { include: { user: true } } } },
+        chapter: {
+          include: {
+            chapter_users: { include: { user: true } },
+            user_bans: true,
+          },
+        },
         event_users: {
           include: { rsvp: true, user: true },
           where: { subscribed: true },
@@ -948,10 +953,17 @@ ${unsubscribeOptions}`,
       subscribed: boolean;
     }
 
+    const bannedUserIds = new Set(
+      event.chapter.user_bans.map(({ user_id }) => user_id),
+    );
+
     const users: User[] = [];
     if (emailGroups.includes('interested')) {
       const interestedUsers =
-        event.chapter.chapter_users?.filter((user) => user.subscribed) ?? [];
+        event.chapter.chapter_users?.filter(
+          ({ subscribed, user_id }) =>
+            !bannedUserIds.has(user_id) && subscribed,
+        ) ?? [];
 
       users.push(...interestedUsers);
     }


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Prevents sending new event invite to chapter users that are banned.