### PR TITLE
feat: invite link shows join modal

### DIFF
--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -139,14 +139,13 @@ export const ChapterPage: NextPage = () => {
     }
   };
 
-  const isLoading = loading || !data;
+  const isLoading = loading || loadingChapterUser || !data;
 
-  const askUserToConfirm = router.query?.ask_to_confirm;
+  const askUserToConfirm = router.query?.ask_to_confirm && isLoggedIn;
+  const isNotAlreadyMember = !isLoading && !dataChapterUser;
   useEffect(() => {
-    if (askUserToConfirm && isLoggedIn) {
-      if (!dataChapterUser) joinChapter({ invited: true });
-    }
-  }, [askUserToConfirm, dataChapterUser, isLoggedIn]);
+    if (askUserToConfirm && isNotAlreadyMember) joinChapter({ invited: true });
+  }, [askUserToConfirm, isNotAlreadyMember]);
 
   if (isLoading || error) return <Loading loading={isLoading} error={error} />;
   if (!data.chapter)

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -86,8 +86,16 @@ export const ChapterPage: NextPage = () => {
   const [joinChapterFn] = useJoinChapterMutation(refetch);
   const [chapterSubscribeFn] = useToggleChapterSubscriptionMutation(refetch);
 
-  const joinChapter = async () => {
-    const ok = await confirm({ title: 'Join this chapter?' });
+  const joinChapter = async (options?: { invited?: boolean }) => {
+    const confirmOptions = options?.invited
+      ? {
+          title: 'You have been invited to this chapter',
+          body: 'Would you like to join?',
+        }
+      : {
+          title: 'Join this chapter?',
+        };
+    const ok = await confirm(confirmOptions);
     if (ok) {
       try {
         await joinChapterFn({ variables: { chapterId } });
@@ -134,7 +142,7 @@ export const ChapterPage: NextPage = () => {
   const askUserToConfirm = router.query?.ask_to_confirm;
   useEffect(() => {
     if (askUserToConfirm && isLoggedIn) {
-      if (!dataChapterUser) joinChapter();
+      if (!dataChapterUser) joinChapter({ invited: true });
     }
   }, [askUserToConfirm, dataChapterUser, isLoggedIn]);
 
@@ -178,7 +186,7 @@ export const ChapterPage: NextPage = () => {
               chapterSubscribe={chapterSubscribe}
             />
           ) : (
-            <Button colorScheme="blue" onClick={joinChapter}>
+            <Button colorScheme="blue" onClick={() => joinChapter()}>
               Join chapter
             </Button>
           ))}

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -13,7 +13,8 @@ import {
 import { CheckIcon } from '@chakra-ui/icons';
 import { NextPage } from 'next';
 import NextError from 'next/error';
-import React from 'react';
+import { useRouter } from 'next/router';
+import React, { useEffect } from 'react';
 
 import { useConfirm } from 'chakra-confirm';
 import { CHAPTER_USER } from '../graphql/queries';
@@ -64,6 +65,7 @@ const SubscriptionWidget = ({
 
 export const ChapterPage: NextPage = () => {
   const { param: chapterId } = useParam('chapterId');
+  const router = useRouter();
   const { isLoggedIn } = useAuth();
 
   const { loading, error, data } = useChapterQuery({
@@ -85,7 +87,7 @@ export const ChapterPage: NextPage = () => {
   const [chapterSubscribeFn] = useToggleChapterSubscriptionMutation(refetch);
 
   const joinChapter = async () => {
-    const ok = await confirm();
+    const ok = await confirm({ title: 'Join this chapter?' });
     if (ok) {
       try {
         await joinChapterFn({ variables: { chapterId } });
@@ -128,6 +130,14 @@ export const ChapterPage: NextPage = () => {
   };
 
   const isLoading = loading || !data;
+
+  const askUserToConfirm = router.query?.ask_to_confirm;
+  useEffect(() => {
+    if (askUserToConfirm && isLoggedIn) {
+      if (!dataChapterUser) joinChapter();
+    }
+  }, [askUserToConfirm, dataChapterUser, isLoggedIn]);
+
   if (isLoading || error) return <Loading loading={isLoading} error={error} />;
   if (!data.chapter)
     return <NextError statusCode={404} title="Chapter not found" />;

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -51,7 +51,9 @@ const SubscriptionWidget = ({
   return chapterUser.subscribed ? (
     <HStack>
       <CheckIcon />
-      <Text>{chapterUser.chapter_role.name} of the chapter</Text>
+      <Text data-cy="join-success">
+        {chapterUser.chapter_role.name} of the chapter
+      </Text>
       <Button onClick={() => chapterSubscribe(false)} size="md">
         Unsubscribe
       </Button>

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -98,7 +98,7 @@ export const ChapterPage: NextPageWithLayout = () => {
               Add new venue
             </LinkButton>
             <SharePopOver
-              link={`${process.env.NEXT_PUBLIC_CLIENT_URL}/chapters/${chapterId}?emaillink=true`}
+              link={`${process.env.NEXT_PUBLIC_CLIENT_URL}/chapters/${chapterId}?ask_to_confirm=true`}
               size="sm"
             />
 

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -70,7 +70,7 @@ const Actions: React.FC<ActionsProps> = ({
       </Button>
       <SharePopOver
         size={'sm'}
-        link={`${process.env.NEXT_PUBLIC_CLIENT_URL}/events/${event.id}?emaillink=true`}
+        link={`${process.env.NEXT_PUBLIC_CLIENT_URL}/events/${event.id}?ask_to_confirm=true`}
       />
     </HStack>
   );

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -68,7 +68,7 @@ export const EventPage: NextPage = () => {
   }, [data?.event]);
   const rsvpStatus = eventUser?.rsvp.name;
   const allDataLoaded = !!user && !!data;
-  const fromEmailInviteLink = router.query?.emaillink;
+  const askUserToConfirm = router.query?.ask_to_confirm;
   const shouldRsvp = !rsvpStatus || rsvpStatus === 'no';
 
   const chapterId = data?.event?.chapter.id;
@@ -136,14 +136,14 @@ export const EventPage: NextPage = () => {
   }
 
   useEffect(() => {
-    if (fromEmailInviteLink && allDataLoaded) {
+    if (askUserToConfirm && allDataLoaded) {
       if (shouldRsvp) {
         checkOnRsvp();
       } else {
         checkOnCancelRsvp();
       }
     }
-  }, [allDataLoaded, fromEmailInviteLink]);
+  }, [allDataLoaded, askUserToConfirm]);
 
   if (error || !data) return <Loading loading={loading} error={error} />;
   if (!data.event)

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -79,12 +79,21 @@ export const EventPage: NextPage = () => {
   // or by calling functions that rely on variables that aren't defined yet, so
   // we define everything before it's used.
 
-  async function onRsvp() {
+  async function onRsvp(options?: { invited?: boolean }) {
     if (!chapterId) {
       toast({ title: 'Something went wrong', status: 'error' });
       return;
     }
-    const ok = await confirm({ title: 'Are you sure you want to join this?' });
+
+    const confirmOptions = options?.invited
+      ? {
+          title: 'You have been invited to this event',
+          body: 'Would you like to attend?',
+        }
+      : {
+          title: 'Join this event?',
+        };
+    const ok = await confirm(confirmOptions);
 
     if (ok) {
       try {
@@ -124,9 +133,9 @@ export const EventPage: NextPage = () => {
   }
 
   // TODO: reimplment this the login modal with Auth0
-  async function checkOnRsvp() {
+  async function checkOnRsvp(options?: { invited?: boolean }) {
     if (!user) await login();
-    await onRsvp();
+    await onRsvp(options);
   }
 
   // TODO: reimplment this the login modal with Auth0
@@ -138,7 +147,7 @@ export const EventPage: NextPage = () => {
   useEffect(() => {
     if (askUserToConfirm && allDataLoaded) {
       if (shouldRsvp) {
-        checkOnRsvp();
+        checkOnRsvp({ invited: true });
       } else {
         checkOnCancelRsvp();
       }
@@ -257,7 +266,7 @@ export const EventPage: NextPage = () => {
         <Button
           data-cy="rsvp-button"
           colorScheme="blue"
-          onClick={checkOnRsvp}
+          onClick={() => checkOnRsvp()}
           paddingInline={'2'}
           paddingBlock={'1'}
         >

--- a/cypress/e2e/chapters/[chapterId].cy.ts
+++ b/cypress/e2e/chapters/[chapterId].cy.ts
@@ -43,6 +43,16 @@ describe('chapter page', () => {
     );
   });
 
+  it('is possible to join using the email links', () => {
+    cy.login('test@user.org');
+    cy.visit('/chapters/1?ask_to_confirm=true');
+    cy.contains('member of the chapter').should('not.exist');
+
+    cy.contains('You have been invited to this chapter');
+    cy.findByRole('button', { name: 'Confirm' }).click();
+    cy.get('[data-cy="join-success"]').should('be.visible');
+  });
+
   it('should reject joining and subscribing requests from non-members', () => {
     cy.joinChapter(chapterId, { withAuth: false }).then(expectToBeRejected);
     cy.toggleChapterSubscription(chapterId, { withAuth: false }).then(

--- a/cypress/e2e/chapters/[chapterId].cy.ts
+++ b/cypress/e2e/chapters/[chapterId].cy.ts
@@ -51,6 +51,11 @@ describe('chapter page', () => {
     cy.contains('You have been invited to this chapter');
     cy.findByRole('button', { name: 'Confirm' }).click();
     cy.get('[data-cy="join-success"]').should('be.visible');
+
+    // After joining, the modal should not trigger on reload.
+    cy.reload();
+    cy.get('[data-cy="join-success"]').should('be.visible');
+    cy.contains('You have been invited to this chapter').should('not.exist');
   });
 
   it('should reject joining and subscribing requests from non-members', () => {

--- a/cypress/e2e/events/[eventId].cy.ts
+++ b/cypress/e2e/events/[eventId].cy.ts
@@ -92,7 +92,7 @@ describe('event page', () => {
     cy.login('test@user.org');
     cy.visit('/events/1?ask_to_confirm=true');
 
-    cy.contains('Are you sure you want to join this?');
+    cy.contains('You have been invited to this event');
     cy.findByRole('button', { name: 'Confirm' }).click();
     cy.get('[data-cy="rsvp-success"]').should('be.visible');
     cy.findByRole('button', { name: 'Cancel' }).should('be.visible');

--- a/cypress/e2e/events/[eventId].cy.ts
+++ b/cypress/e2e/events/[eventId].cy.ts
@@ -79,7 +79,7 @@ describe('event page', () => {
     const chapterId = 1;
     cy.joinChapter(chapterId).then(() => {
       cy.rsvpToEvent({ eventId: 1, chapterId }).then(() => {
-        cy.visit('/events/1?emaillink=true');
+        cy.visit('/events/1?ask_to_confirm=true');
 
         cy.contains('Are you sure you want to cancel your RSVP?');
         cy.findByRole('button', { name: 'Confirm' }).click();
@@ -90,7 +90,7 @@ describe('event page', () => {
 
   it('is possible to join using the email links', () => {
     cy.login('test@user.org');
-    cy.visit('/events/1?emaillink=true');
+    cy.visit('/events/1?ask_to_confirm=true');
 
     cy.contains('Are you sure you want to join this?');
     cy.findByRole('button', { name: 'Confirm' }).click();

--- a/server/tests/Mailer.test.ts
+++ b/server/tests/Mailer.test.ts
@@ -18,7 +18,7 @@ DTSTAMP:20220403T072207Z
 DTSTART:20220325T234500Z
 DTEND:20220326T014500Z
 SUMMARY:Rolfson, Emmerich and Davis
-URL;VALUE=URI:http://localhost:3000/events/15?emaillink=true
+URL;VALUE=URI:http://localhost:3000/events/15?ask_to_confirm=true
 END:VEVENT
 END:VCALENDAR`;
 


### PR DESCRIPTION
- refactor: rename emaillink to ask_to_confirm
- feat: prompt user to join chapter
- fix: update the text to be a little more welcoming

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

There's some light refactoring/rewording around the margins, but the goal is to put the share buttons that @Sboonny created in https://github.com/freeCodeCamp/chapter/pull/1727 to good use.  Now both chapter and event pages trigger the confirm modal if you follow those links.

Ref https://github.com/freeCodeCamp/chapter/issues/1721

I'll leave the issue up for now, since it doesn't work properly for logged out users.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
