### PR TITLE
fix: render only when ready

### DIFF
--- a/client/src/hooks/useParam.ts
+++ b/client/src/hooks/useParam.ts
@@ -1,24 +1,9 @@
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
 
 export const useParam = (key = 'id') => {
   const router = useRouter();
-  const [isReady, setReady] = useState(false);
-  const [param, setParam] = useState(-1);
+
   const val = router.query[key];
-
-  useEffect(() => {
-    if (router.isReady) {
-      setReady(true);
-      if (val) {
-        if (Array.isArray(val)) {
-          setParam(parseInt(val[0]));
-        } else {
-          setParam(parseInt(val));
-        }
-      }
-    }
-  }, [router.isReady]);
-
-  return { param, isReady };
+  const firstVal = Array.isArray(val) ? val[0] : val;
+  return firstVal ? { param: parseInt(firstVal) } : { param: -1 };
 };

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -13,7 +13,7 @@ import {
 import { CheckIcon } from '@chakra-ui/icons';
 import { NextPage } from 'next';
 import NextError from 'next/error';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { useConfirm } from 'chakra-confirm';
 import { CHAPTER_USER } from '../graphql/queries';
@@ -21,11 +21,11 @@ import { useAuth } from '../../auth/store';
 import { Loading } from 'components/Loading';
 import { EventCard } from 'components/EventCard';
 import {
-  useChapterLazyQuery,
-  useChapterUserLazyQuery,
   useJoinChapterMutation,
   useToggleChapterSubscriptionMutation,
   ChapterUserQuery,
+  useChapterQuery,
+  useChapterUserQuery,
 } from 'generated/graphql';
 import { useParam } from 'hooks/useParam';
 
@@ -63,29 +63,20 @@ const SubscriptionWidget = ({
 };
 
 export const ChapterPage: NextPage = () => {
-  const { param: chapterId, isReady } = useParam('chapterId');
+  const { param: chapterId } = useParam('chapterId');
   const { isLoggedIn } = useAuth();
 
-  const [getChapter, { loading, error, data }] = useChapterLazyQuery({
+  const { loading, error, data } = useChapterQuery({
     variables: { chapterId },
   });
 
   const confirm = useConfirm();
   const toast = useToast();
 
-  const [
-    getChapterUsers,
-    { loading: loadingChapterUser, data: dataChapterUser },
-  ] = useChapterUserLazyQuery({
-    variables: { chapterId },
-  });
-
-  useEffect(() => {
-    if (isReady) {
-      getChapter();
-      getChapterUsers();
-    }
-  }, [isReady]);
+  const { loading: loadingChapterUser, data: dataChapterUser } =
+    useChapterUserQuery({
+      variables: { chapterId },
+    });
 
   const refetch = {
     refetchQueries: [{ query: CHAPTER_USER, variables: { chapterId } }],
@@ -136,7 +127,9 @@ export const ChapterPage: NextPage = () => {
     }
   };
 
-  const isLoading = loading || !isReady || !data;
+  const isLoading = loading || !data;
+
+  console.log(data, isLoading);
   if (isLoading || error) return <Loading loading={isLoading} error={error} />;
   if (!data.chapter)
     return <NextError statusCode={404} title="Chapter not found" />;

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -128,8 +128,6 @@ export const ChapterPage: NextPage = () => {
   };
 
   const isLoading = loading || !data;
-
-  console.log(data, isLoading);
   if (isLoading || error) return <Loading loading={isLoading} error={error} />;
   if (!data.chapter)
     return <NextError statusCode={404} title="Chapter not found" />;

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -12,15 +12,15 @@ import {
 } from '@chakra-ui/react';
 import { DataTable } from 'chakra-data-table';
 import NextError from 'next/error';
-import React, { ReactElement, useEffect, useMemo, useState } from 'react';
+import React, { ReactElement, useMemo, useState } from 'react';
 
 import { useConfirm } from 'chakra-confirm';
 import {
   useBanUserMutation,
-  useDashboardChapterUsersLazyQuery,
   useChapterRolesQuery,
   useChangeChapterUserRoleMutation,
   useUnbanUserMutation,
+  useDashboardChapterUsersQuery,
 } from '../../../../../generated/graphql';
 import { DashboardLoading } from '../../../shared/components/DashboardLoading';
 import { Layout } from '../../../shared/components/Layout';
@@ -33,16 +33,11 @@ import { DASHBOARD_CHAPTER_USERS } from '../../../../chapters/graphql/queries';
 import { NextPageWithLayout } from '../../../../../pages/_app';
 
 export const ChapterUsersPage: NextPageWithLayout = () => {
-  const { param: chapterId, isReady } = useParam('id');
+  const { param: chapterId } = useParam('id');
 
-  const [getChapterUsers, { loading, error, data }] =
-    useDashboardChapterUsersLazyQuery({
-      variables: { chapterId },
-    });
-
-  useEffect(() => {
-    if (isReady) getChapterUsers();
-  }, [isReady]);
+  const { loading, error, data } = useDashboardChapterUsersQuery({
+    variables: { chapterId },
+  });
 
   const { data: chapterRoles } = useChapterRolesQuery();
   const modalProps = useDisclosure();
@@ -131,7 +126,7 @@ export const ChapterUsersPage: NextPageWithLayout = () => {
     [data?.dashboardChapter?.chapter_users, data?.dashboardChapter?.user_bans],
   );
 
-  const isLoading = loading || !isReady || !data;
+  const isLoading = loading || !data;
   if (isLoading || error) return <DashboardLoading error={error} />;
   if (!data.dashboardChapter)
     return <NextError statusCode={404} title="Chapter not found" />;

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Heading, HStack } from '@chakra-ui/react';
 import NextError from 'next/error';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement } from 'react';
 
 import { useConfirmDelete } from 'chakra-confirm';
 import { LinkButton } from 'chakra-next-link';
@@ -10,7 +10,7 @@ import { SharePopOver } from '../../../../components/SharePopOver';
 import { Card } from '../../../../components/Card';
 import ProgressCardContent from '../../../../components/ProgressCardContent';
 import {
-  useDashboardChapterLazyQuery,
+  useDashboardChapterQuery,
   useDeleteChapterMutation,
 } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
@@ -26,7 +26,7 @@ import { DATA_PAGINATED_EVENTS_TOTAL_QUERY } from '../../../events/graphql/queri
 import { NextPageWithLayout } from '../../../../pages/_app';
 
 export const ChapterPage: NextPageWithLayout = () => {
-  const { param: chapterId, isReady } = useParam('id');
+  const { param: chapterId } = useParam('id');
 
   const confirmDelete = useConfirmDelete();
 
@@ -43,13 +43,9 @@ export const ChapterPage: NextPageWithLayout = () => {
     ],
   });
 
-  const [getChapter, { loading, error, data }] = useDashboardChapterLazyQuery({
+  const { loading, error, data } = useDashboardChapterQuery({
     variables: { chapterId },
   });
-
-  useEffect(() => {
-    if (isReady) getChapter();
-  }, [isReady]);
 
   const router = useRouter();
 
@@ -63,7 +59,7 @@ export const ChapterPage: NextPageWithLayout = () => {
     router.push('/dashboard/chapters');
   };
 
-  const isLoading = loading || !isReady || !data;
+  const isLoading = loading || !data;
   if (isLoading || error) return <DashboardLoading error={error} />;
   if (!data.dashboardChapter)
     return <NextError statusCode={404} title="Chapter not found" />;

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -1,9 +1,9 @@
 import { useRouter } from 'next/router';
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 import {
   CreateChapterInputs,
-  useDashboardChapterLazyQuery,
+  useDashboardChapterQuery,
   useUpdateChapterMutation,
 } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
@@ -17,15 +17,11 @@ export const EditChapterPage: NextPageWithLayout = () => {
   const router = useRouter();
   const [loadingUpdate, setLoadingUpdate] = useState(false);
 
-  const { param: chapterId, isReady } = useParam('id');
+  const { param: chapterId } = useParam('id');
 
-  const [getChapter, { loading, error, data }] = useDashboardChapterLazyQuery({
+  const { loading, error, data } = useDashboardChapterQuery({
     variables: { chapterId },
   });
-
-  useEffect(() => {
-    if (isReady) getChapter();
-  }, [isReady]);
 
   const [updateChapter] = useUpdateChapterMutation({
     refetchQueries: [{ query: CHAPTERS }],
@@ -45,7 +41,7 @@ export const EditChapterPage: NextPageWithLayout = () => {
     }
   };
 
-  const isLoading = loading || !isReady || !data;
+  const isLoading = loading || !data;
   if (isLoading || error) return <DashboardLoading error={error} />;
 
   return (

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -1,10 +1,10 @@
 import NextError from 'next/error';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useToast } from '@chakra-ui/react';
 
 import {
-  useDashboardEventLazyQuery,
+  useDashboardEventQuery,
   useUpdateEventMutation,
 } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
@@ -20,15 +20,11 @@ import { NextPageWithLayout } from '../../../../pages/_app';
 export const EditEventPage: NextPageWithLayout = () => {
   const router = useRouter();
   const [loadingUpdate, setLoadingUpdate] = useState<boolean>(false);
-  const { param: eventId, isReady } = useParam();
+  const { param: eventId } = useParam();
 
-  const [getEvent, { loading, error, data }] = useDashboardEventLazyQuery({
+  const { loading, error, data } = useDashboardEventQuery({
     variables: { eventId: eventId },
   });
-
-  useEffect(() => {
-    if (isReady) getEvent();
-  }, [isReady]);
 
   const toast = useToast();
 
@@ -69,7 +65,7 @@ export const EditEventPage: NextPageWithLayout = () => {
     }
   };
 
-  const isLoading = loading || !isReady || !data;
+  const isLoading = loading || !data;
   if (isLoading || error) return <DashboardLoading error={error} />;
   if (!data.dashboardEvent)
     return <NextError statusCode={404} title="Event not found" />;

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -12,11 +12,11 @@ import { useConfirm, useConfirmDelete } from 'chakra-confirm';
 import { DataTable } from 'chakra-data-table';
 import NextError from 'next/error';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement } from 'react';
 
 import {
   useConfirmRsvpMutation,
-  useDashboardEventLazyQuery,
+  useDashboardEventQuery,
   useDeleteRsvpMutation,
   MutationConfirmRsvpArgs,
   MutationDeleteRsvpArgs,
@@ -41,16 +41,11 @@ const args = (eventId: number) => ({
 
 export const EventPage: NextPageWithLayout = () => {
   const router = useRouter();
-  const { param: eventId, isReady } = useParam('id');
+  const { param: eventId } = useParam('id');
 
-  const [getEvent, { loading, error, data }] = useDashboardEventLazyQuery({
+  const { loading, error, data } = useDashboardEventQuery({
     variables: { eventId },
   });
-
-  useEffect(() => {
-    if (isReady) getEvent();
-  }, [isReady]);
-
   const [confirmRsvpFn] = useConfirmRsvpMutation(args(eventId));
   const [removeRsvpFn] = useDeleteRsvpMutation(args(eventId));
 
@@ -71,7 +66,7 @@ export const EventPage: NextPageWithLayout = () => {
       if (ok) removeRsvpFn({ variables: { eventId, userId } });
     };
 
-  const isLoading = loading || !isReady || !data;
+  const isLoading = loading || !data;
   if (isLoading || error) return <DashboardLoading error={error} />;
   if (!data.dashboardEvent)
     return <NextError statusCode={404} title="Event not found" />;

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -5,7 +5,6 @@ import {
   useCreateEventMutation,
   useSendEventInviteMutation,
 } from '../../../../generated/graphql';
-import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import { Layout } from '../../shared/components/Layout';
 import EventForm from '../components/EventForm';
 import { EventFormData, parseEventData } from '../components/EventFormUtils';
@@ -16,7 +15,7 @@ import { useParam } from '../../../../hooks/useParam';
 import { NextPageWithLayout } from '../../../../pages/_app';
 
 export const NewEventPage: NextPageWithLayout = () => {
-  const { param: chapterId, isReady } = useParam('id');
+  const { param: chapterId } = useParam('id');
   const router = useRouter();
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -52,20 +51,14 @@ export const NewEventPage: NextPageWithLayout = () => {
     }
   };
 
-  if (!isReady) return <DashboardLoading />;
-
   return (
-    <>
-      {isReady && (
-        <EventForm
-          loading={loading}
-          onSubmit={onSubmit}
-          submitText={'Add event'}
-          loadingText={'Adding Event'}
-          chapterId={chapterId}
-        />
-      )}
-    </>
+    <EventForm
+      loading={loading}
+      onSubmit={onSubmit}
+      submitText={'Add event'}
+      loadingText={'Adding Event'}
+      chapterId={chapterId}
+    />
   );
 };
 

--- a/client/src/modules/dashboard/Sponsors/pages/EditSponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/EditSponsorPage.tsx
@@ -1,6 +1,6 @@
 import NextError from 'next/error';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 import { useParam } from '../../../../hooks/useParam';
 import { Sponsors } from '../../Events/graphql/queries';
@@ -9,7 +9,7 @@ import SponsorForm, { SponsorFormData } from '../components/SponsorForm';
 import { DASHBOARD_SPONSOR } from '../graphql/queries';
 import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import {
-  useDashboardSponsorLazyQuery,
+  useDashboardSponsorQuery,
   useUpdateSponsorMutation,
 } from '../../../../generated/graphql';
 import { NextPageWithLayout } from '../../../../pages/_app';
@@ -17,23 +17,20 @@ import { NextPageWithLayout } from '../../../../pages/_app';
 const EditSponsorPage: NextPageWithLayout = () => {
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const { param: sponsorId, isReady } = useParam('id');
-  const [getSponsor, { loading: sponsorLoading, error, data }] =
-    useDashboardSponsorLazyQuery({
-      variables: { sponsorId },
-    });
+  const { param: sponsorId } = useParam('id');
+  const {
+    loading: sponsorLoading,
+    error,
+    data,
+  } = useDashboardSponsorQuery({
+    variables: { sponsorId },
+  });
   const [updateSponsor] = useUpdateSponsorMutation({
     refetchQueries: [
       { query: DASHBOARD_SPONSOR, variables: { id: sponsorId } },
       { query: Sponsors },
     ],
   });
-
-  useEffect(() => {
-    if (isReady) {
-      getSponsor();
-    }
-  }, [isReady]);
 
   const onSubmit = async (data: SponsorFormData) => {
     setLoading(true);
@@ -52,7 +49,7 @@ const EditSponsorPage: NextPageWithLayout = () => {
     }
   };
 
-  const isLoading = sponsorLoading || !isReady || !data;
+  const isLoading = sponsorLoading || !data;
   if (isLoading || error) return <DashboardLoading error={error} />;
   if (!data.dashboardSponsor)
     return <NextError statusCode={404} title="Sponsor not found" />;

--- a/client/src/modules/dashboard/Sponsors/pages/SponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/SponsorPage.tsx
@@ -1,10 +1,10 @@
 import { Flex, Heading, Link, Text } from '@chakra-ui/layout';
 import NextError from 'next/error';
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Card } from '../../../../components/Card';
 import ProgressCardContent from '../../../../components/ProgressCardContent';
-import { useSponsorWithEventsLazyQuery } from '../../../../generated/graphql';
+import { useSponsorWithEventsQuery } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
 import styles from '../../../../styles/Page.module.css';
 import { Layout } from '../../shared/components/Layout';
@@ -13,19 +13,13 @@ import { EventList } from '../../shared/components/EventList';
 import { NextPageWithLayout } from '../../../../pages/_app';
 
 export const SponsorPage: NextPageWithLayout = () => {
-  const { param: sponsorId, isReady } = useParam('id');
-  const [getSponsor, { loading, error, data }] = useSponsorWithEventsLazyQuery({
+  const { param: sponsorId } = useParam('id');
+  const { loading, error, data } = useSponsorWithEventsQuery({
     variables: { sponsorId },
   });
   const { sponsorWithEvents: sponsor } = data ?? {};
 
-  useEffect(() => {
-    if (isReady) {
-      getSponsor();
-    }
-  }, [isReady]);
-
-  const isLoading = loading || !isReady || !data;
+  const isLoading = loading || !data;
   if (isLoading || error) return <DashboardLoading error={error} />;
   if (!sponsor) return <NextError statusCode={404} title="Sponsor not found" />;
 

--- a/client/src/modules/dashboard/Venues/pages/ChapterNewVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/ChapterNewVenuePage.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement } from 'react';
 
-import { useChapterLazyQuery } from '../../../../generated/graphql';
+import { useChapterQuery } from '../../../../generated/graphql';
 import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import { Layout } from '../../shared/components/Layout';
 import VenueForm from '../components/VenueForm';
@@ -9,19 +9,15 @@ import { NextPageWithLayout } from '../../../../pages/_app';
 import { useSubmitVenue } from '../utils';
 
 export const ChapterNewVenuePage: NextPageWithLayout = () => {
-  const { param: chapterId, isReady } = useParam('id');
+  const { param: chapterId } = useParam('id');
 
-  const [getChapter, { data, error }] = useChapterLazyQuery();
-
-  useEffect(() => {
-    if (isReady) {
-      getChapter({ variables: { chapterId } });
-    }
-  }, [isReady]);
+  const { loading, data, error } = useChapterQuery({
+    variables: { chapterId },
+  });
 
   const onSubmit = useSubmitVenue();
 
-  const isLoading = !data || !isReady;
+  const isLoading = loading || !data;
 
   if (isLoading || error) return <DashboardLoading error={error} />;
 

--- a/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
@@ -1,11 +1,11 @@
 import { useRouter } from 'next/router';
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement } from 'react';
 import NextError from 'next/error';
 
 import {
-  useVenueLazyQuery,
+  useVenueQuery,
   useUpdateVenueMutation,
-  useChapterLazyQuery,
+  useChapterQuery,
 } from '../../../../generated/graphql';
 
 import { DashboardLoading } from '../../shared/components/DashboardLoading';
@@ -17,26 +17,16 @@ import { NextPageWithLayout } from '../../../../pages/_app';
 
 export const EditVenuePage: NextPageWithLayout = () => {
   const router = useRouter();
-  const { param: venueId, isReady: isVenueIdReady } = useParam('venueId');
-  const { param: chapterId, isReady: isChapterIdReady } = useParam('id');
+  const { param: venueId } = useParam('venueId');
+  const { param: chapterId } = useParam('id');
 
-  const [getChapter, { data: chapterData, error: chapterError }] =
-    useChapterLazyQuery({
-      variables: { chapterId },
-    });
-
-  const [getVenue, { data: venueData, error: venueError }] = useVenueLazyQuery({
-    variables: { venueId },
+  const { data: chapterData, error: chapterError } = useChapterQuery({
+    variables: { chapterId },
   });
 
-  const isReady = isVenueIdReady && isChapterIdReady;
-
-  useEffect(() => {
-    if (isReady) {
-      getVenue();
-      getChapter();
-    }
-  }, [isReady]);
+  const { data: venueData, error: venueError } = useVenueQuery({
+    variables: { venueId },
+  });
 
   const [updateVenue] = useUpdateVenueMutation({
     refetchQueries: [{ query: VENUES }],

--- a/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
@@ -1,10 +1,10 @@
 import { Heading, Text } from '@chakra-ui/layout';
 import NextError from 'next/error';
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Card } from '../../../../components/Card';
 import ProgressCardContent from '../../../../components/ProgressCardContent';
-import { useVenueLazyQuery } from '../../../../generated/graphql';
+import { useVenueQuery } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
 import getLocationString from '../../../../util/getLocationString';
 import styles from '../../../../styles/Page.module.css';
@@ -14,17 +14,13 @@ import { Layout } from '../../shared/components/Layout';
 import { NextPageWithLayout } from '../../../../pages/_app';
 
 export const VenuePage: NextPageWithLayout = () => {
-  const { param: venueId, isReady } = useParam('id');
+  const { param: venueId } = useParam('id');
 
-  const [getVenue, { loading, error, data }] = useVenueLazyQuery({
+  const { loading, error, data } = useVenueQuery({
     variables: { venueId },
   });
 
-  useEffect(() => {
-    if (isReady) getVenue();
-  }, [isReady]);
-
-  const isLoading = loading || !isReady || !data;
+  const isLoading = loading || !data;
   if (isLoading || error) return <DashboardLoading error={error} />;
   if (!data.venue)
     return <NextError statusCode={404} title="Venue not found" />;

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -26,7 +26,7 @@ import { EVENT } from '../graphql/queries';
 import { DASHBOARD_EVENT } from '../../dashboard/Events/graphql/queries';
 import {
   useCancelRsvpMutation,
-  useEventLazyQuery,
+  useEventQuery,
   useJoinChapterMutation,
   useRsvpToEventMutation,
   useSubscribeToEventMutation,
@@ -36,7 +36,7 @@ import { useParam } from 'hooks/useParam';
 import { useLogin } from 'hooks/useAuth';
 
 export const EventPage: NextPage = () => {
-  const { param: eventId, isReady } = useParam('eventId');
+  const { param: eventId } = useParam('eventId');
   const router = useRouter();
   const { user } = useAuth();
   const login = useLogin();
@@ -54,13 +54,9 @@ export const EventPage: NextPage = () => {
   const [subscribeToEvent] = useSubscribeToEventMutation(refetch);
   const [unsubscribeFromEvent] = useUnsubscribeFromEventMutation(refetch);
 
-  const [getEvent, { loading, error, data }] = useEventLazyQuery({
+  const { loading, error, data } = useEventQuery({
     variables: { eventId },
   });
-
-  useEffect(() => {
-    if (isReady) getEvent();
-  }, [isReady]);
 
   const toast = useToast();
   const confirm = useConfirm();


### PR DESCRIPTION
- fix: check isReady before rendering any page
- fix: update pages relying on isReady

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

There is a trade-off here.  All pages wait for `router.isReady` to be true before rendering, even if they don't need the router.  This makes pages like / and /chapters a little slower because they could have started rendering immediately, but now cannot.  However, when testing locally, I could see no difference between the two approaches.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
