### PR TITLE
fix: base64 encode ical before using sendgrid

### DIFF
--- a/server/src/services/MailerService.ts
+++ b/server/src/services/MailerService.ts
@@ -13,6 +13,10 @@ export interface MailerData {
   iCalEvent?: string;
 }
 
+function btoa(str: string): string {
+  return Buffer.from(str).toString('base64');
+}
+
 // @todo add ourEmail, emailUsername, emailPassword, and emailService as
 // environment variables when they become available. Temporary placeholders
 // provided until updated info available.
@@ -96,7 +100,7 @@ export default class MailerService {
       ? {
           filename: 'calendar.ics',
           name: 'calendar.ics',
-          content: this.iCalEvent,
+          content: btoa(this.iCalEvent),
           disposition: 'attachment',
           type: 'text/calendar; method=REQUEST',
         }


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

The [sendgrid api](https://docs.sendgrid.com/api-reference/mail-send/mail-send#body) requires attachments to be base64 encoded.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
