### PR TITLE
fix: stop logging missing sessions

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -129,10 +129,9 @@ export const main = async (app: Express) => {
 
   // no need to check for identity provider's token on logout
   app.delete('/logout', (req, res, next) => {
-    if (!req.session) return next('session not found');
-
-    const id = req.session.id;
+    const id = req.session?.id;
     req.session = null;
+    if (!id) return res.end();
 
     prisma.sessions
       .delete({ where: { id } })

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -26,7 +26,7 @@ import {
   venues,
 } from './controllers/Auth/middleware';
 import { checkJwt } from './controllers/Auth/check-jwt';
-import { prisma } from './prisma';
+import { prisma, RECORD_MISSING } from './prisma';
 import { getBearerToken } from './util/sessions';
 import { fetchUserInfo } from './util/auth0';
 import { getGoogleAuthUrl, requestTokens } from './services/Google';
@@ -142,12 +142,11 @@ export const main = async (app: Express) => {
         });
       })
       .catch((err) => {
-        // TODO: what to do when the request to delete the session fails? This
-        // should only happen if the session is malformed or doesn't exist.
         res.status(400).send({
           message: 'unable to destroy session',
         });
-        next(err);
+        // Missing sessions can happen and there's no need to log when they do.
+        if (err.code !== RECORD_MISSING) next(err);
       });
   });
 

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -11,12 +11,10 @@ import {
 import { Prisma } from '@prisma/client';
 
 import { ResolverCtx } from '../../common-types/gql';
-import { prisma } from '../../prisma';
+import { prisma, UNIQUE_CONSTRAINT_FAILED } from '../../prisma';
 import { ChapterUser, UserBan } from '../../graphql-types';
 import { Permission } from '../../../../common/permissions';
 import { getInstanceRoleName } from '../../util/chapterAdministrator';
-
-const UNIQUE_CONSTRAINT_FAILED_CODE = 'P2002';
 
 const chapterUsersInclude = {
   chapter_role: {
@@ -66,7 +64,7 @@ export class ChapterUserResolver {
     } catch (e) {
       if (
         !(e instanceof Prisma.PrismaClientKnownRequestError) ||
-        e.code !== UNIQUE_CONSTRAINT_FAILED_CODE
+        e.code !== UNIQUE_CONSTRAINT_FAILED
       ) {
         throw e;
       }

--- a/server/src/prisma.ts
+++ b/server/src/prisma.ts
@@ -5,5 +5,6 @@ import './config';
 
 export const prisma = new PrismaClient();
 
+/* Prisma error codes: https://www.prisma.io/docs/reference/api-reference/error-reference#error-codes */
 export const RECORD_MISSING = 'P2025';
 export const UNIQUE_CONSTRAINT_FAILED = 'P2002';

--- a/server/src/prisma.ts
+++ b/server/src/prisma.ts
@@ -4,3 +4,6 @@ import { PrismaClient } from '@prisma/client';
 import './config';
 
 export const prisma = new PrismaClient();
+
+export const RECORD_MISSING = 'P2025';
+export const UNIQUE_CONSTRAINT_FAILED = 'P2002';


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Whenever the session is invalid, the only thing we can usefully do is delete the session.  This can happen for a variety of reasons (i.e. the user deletes their cookies or logs out from multiple tabs or browsers), none of which we need to log.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
