### PR TITLE
chore: use expectNoErrors util

### DIFF
--- a/cypress/e2e/dashboard/chapters/[chapterId]/chapterId-index.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/chapterId-index.cy.ts
@@ -1,4 +1,4 @@
-import { expectToBeRejected } from '../../../../support/util';
+import { expectNoErrors, expectToBeRejected } from '../../../../support/util';
 import type { ChapterMembers } from '../../../../../cypress.config';
 import { VenueType } from '../../../../../client/src/generated/graphql';
 
@@ -144,9 +144,7 @@ describe('chapter dashboard', () => {
       ...eventData,
       name: 'Created by Admin',
     }).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.errors).not.to.exist;
-
+      expectNoErrors(response);
       cy.visit(`/dashboard/events/`);
       cy.contains('Created by Admin');
       cy.contains(eventData.name).should('not.exist');

--- a/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
+++ b/cypress/e2e/dashboard/chapters/[chapterId]/edit.cy.ts
@@ -1,4 +1,4 @@
-import { expectToBeRejected } from '../../../../support/util';
+import { expectNoErrors, expectToBeRejected } from '../../../../support/util';
 
 const chapterData = {
   name: 'New Chapter Name',
@@ -66,9 +66,7 @@ describe('chapter edit dashboard', () => {
     // back to owner
     cy.login();
     cy.updateChapter(chapterId, chapterData).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.errors).not.to.exist;
-
+      expectNoErrors(response);
       cy.visit(`/dashboard/chapters/${chapterId}`);
       cy.contains(chapterData.name);
     });
@@ -82,9 +80,6 @@ describe('chapter edit dashboard', () => {
     });
 
     cy.login();
-    cy.deleteChapter(chapterId).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.errors).not.to.exist;
-    });
+    cy.deleteChapter(chapterId).then(expectNoErrors);
   });
 });

--- a/cypress/e2e/dashboard/chapters/chapters-index.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapters-index.cy.ts
@@ -1,4 +1,4 @@
-import { expectToBeRejected } from '../../../support/util';
+import { expectNoErrors, expectToBeRejected } from '../../../support/util';
 
 const chapterData = {
   name: 'Name goes here',
@@ -102,23 +102,17 @@ describe('chapters dashboard', () => {
     const chapterId = 1;
 
     cy.createChapter(chapterData).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.errors).not.to.exist;
-
+      expectNoErrors(response);
       cy.visit(`/dashboard/chapters/${chapterId}`);
       cy.contains(chapterData.name);
     });
     cy.createVenue({ chapterId }, venueData).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.errors).not.to.exist;
-
+      expectNoErrors(response);
       cy.visit(`/dashboard/venues/`);
       cy.contains(venueData.name);
     });
     cy.createEvent(chapterId, eventData).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.errors).not.to.exist;
-
+      expectNoErrors(response);
       cy.visit(`/dashboard/events/`);
       cy.contains(eventData.name);
     });
@@ -137,9 +131,7 @@ describe('chapters dashboard', () => {
     cy.login();
 
     cy.createChapter(chapterData).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.errors).not.to.exist;
-
+      expectNoErrors(response);
       cy.visit(`/dashboard/chapters/${response.body.data.createChapter.id}`);
       cy.contains(chapterData.name);
     });

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -1,7 +1,7 @@
 import add from 'date-fns/add';
 import { VenueType } from '../../../../client/src/generated/graphql';
 import { EventUsers } from '../../../../cypress.config';
-import { expectToBeRejected } from '../../../support/util';
+import { expectNoErrors, expectToBeRejected } from '../../../support/util';
 
 const eventOneData = {
   name: 'Homer Simpson',
@@ -226,9 +226,7 @@ describe('events dashboard', () => {
   it('chapter admin should be allowed to edit event, but nobody else', () => {
     const eventId = 1;
 
-    cy.updateEvent(eventId, eventOneData).then((response) => {
-      expect(response.body.errors).not.to.exist;
-    });
+    cy.updateEvent(eventId, eventOneData).then(expectNoErrors);
     // newly registered user (without a chapter_users record)
     cy.login('test@user.org');
     cy.updateEvent(eventId, eventOneData).then(expectToBeRejected);
@@ -250,16 +248,12 @@ describe('events dashboard', () => {
 
     // admin of chapter 1
     cy.login('admin@of.chapter.one');
-    cy.deleteEvent(eventId).then((response) => {
-      expect(response.body.errors).not.to.exist;
-    });
+    cy.deleteEvent(eventId).then(expectNoErrors);
   });
 
   it('chapter admin should be allowed to send email to attendees', () => {
     const eventId = 1;
-    cy.sendEventInvite(eventId, ['confirmed']).then((response) => {
-      expect(response.body.errors).not.to.exist;
-    });
+    cy.sendEventInvite(eventId, ['confirmed']).then(expectNoErrors);
 
     cy.login('test@user.org');
     cy.sendEventInvite(eventId, ['confirmed']).then(expectToBeRejected);


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Adds usage of `expectNoErrors` cypress util where applicable.