### PR TITLE
chore: only retry cypress tests in run mode

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
   e2e: {
     projectId: 're65q6',
     baseUrl: 'http://localhost:3000',
-    retries: { runMode: 3, openMode: 3 },
+    retries: { runMode: 3, openMode: 0 },
     setupNodeEvents(on, config) {
       // `on` is used to hook into various events Cypress emits
       // `config` is the resolved Cypress config


### PR DESCRIPTION
It is rarely useful to try multiple times and, because you have to wait
for all tries to complete before 'time-travelling', multiple retries
are annoying.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->


<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
