### PR TITLE
fix: display custom avatars of user in RSVPs and waitlist on events page

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -1456,7 +1456,12 @@ export type EventQuery = {
       __typename?: 'EventUser';
       subscribed: boolean;
       rsvp: { __typename?: 'Rsvp'; name: string };
-      user: { __typename?: 'User'; id: number; name: string };
+      user: {
+        __typename?: 'User';
+        id: number;
+        name: string;
+        image_url: string;
+      };
       event_role: {
         __typename?: 'EventRole';
         id: number;
@@ -4181,6 +4186,7 @@ export const EventDocument = gql`
         user {
           id
           name
+          image_url
         }
         event_role {
           id

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -1103,7 +1103,12 @@ export type DashboardEventQuery = {
       __typename?: 'EventUser';
       subscribed: boolean;
       rsvp: { __typename?: 'Rsvp'; name: string };
-      user: { __typename?: 'User'; id: number; name: string };
+      user: {
+        __typename?: 'User';
+        id: number;
+        name: string;
+        image_url?: string | null;
+      };
       event_role: {
         __typename?: 'EventRole';
         id: number;
@@ -1456,12 +1461,7 @@ export type EventQuery = {
       __typename?: 'EventUser';
       subscribed: boolean;
       rsvp: { __typename?: 'Rsvp'; name: string };
-      user: {
-        __typename?: 'User';
-        id: number;
-        name: string;
-        image_url: string;
-      };
+      user: { __typename?: 'User'; id: number; name: string };
       event_role: {
         __typename?: 'EventRole';
         id: number;
@@ -3040,6 +3040,7 @@ export const DashboardEventDocument = gql`
         user {
           id
           name
+          image_url
         }
         event_role {
           id
@@ -4186,7 +4187,6 @@ export const EventDocument = gql`
         user {
           id
           name
-          image_url
         }
         event_role {
           id

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -1461,7 +1461,12 @@ export type EventQuery = {
       __typename?: 'EventUser';
       subscribed: boolean;
       rsvp: { __typename?: 'Rsvp'; name: string };
-      user: { __typename?: 'User'; id: number; name: string };
+      user: {
+        __typename?: 'User';
+        id: number;
+        name: string;
+        image_url?: string | null;
+      };
       event_role: {
         __typename?: 'EventRole';
         id: number;
@@ -4187,6 +4192,7 @@ export const EventDocument = gql`
         user {
           id
           name
+          image_url
         }
         event_role {
           id

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -65,6 +65,7 @@ export const DASHBOARD_EVENT = gql`
         user {
           id
           name
+          image_url
         }
         event_role {
           id

--- a/client/src/modules/events/graphql/queries.ts
+++ b/client/src/modules/events/graphql/queries.ts
@@ -65,6 +65,7 @@ export const EVENT = gql`
         user {
           id
           name
+          image_url
         }
         event_role {
           id

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -336,7 +336,7 @@ export const EventPage: NextPage = () => {
         {rsvps.map(({ user }) => (
           <ListItem key={user.id} mb="2">
             <HStack>
-              <Avatar name={user.name} />
+              <Avatar name={user.name} src={user.image_url} />
               <Heading size="md">{user.name}</Heading>
             </HStack>
           </ListItem>
@@ -358,7 +358,7 @@ export const EventPage: NextPage = () => {
             {waitlist.map(({ user }) => (
               <ListItem key={user.id} mb="2">
                 <HStack>
-                  <Avatar name={user.name} />
+                  <Avatar name={user.name} src={user.image_url} />
                   <Heading size="md">{user.name}</Heading>
                 </HStack>
               </ListItem>

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -336,7 +336,7 @@ export const EventPage: NextPage = () => {
         {rsvps.map(({ user }) => (
           <ListItem key={user.id} mb="2">
             <HStack>
-              <Avatar name={user.name} src={user.image_url} />
+              <Avatar name={user.name} src={user.image_url ?? ''} />
               <Heading size="md">{user.name}</Heading>
             </HStack>
           </ListItem>
@@ -358,7 +358,7 @@ export const EventPage: NextPage = () => {
             {waitlist.map(({ user }) => (
               <ListItem key={user.id} mb="2">
                 <HStack>
-                  <Avatar name={user.name} src={user.image_url} />
+                  <Avatar name={user.name} src={user.image_url ?? ''} />
                   <Heading size="md">{user.name}</Heading>
                 </HStack>
               </ListItem>


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #1798

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
The RSVP and waitlist on the events page show a placeholder avatar as of now. The changes will pass an image URL (the relevant user's `image_url`) to the Avatar component and render the user's custom avatar. If it fails, the placeholder avatar will still be used as a fallback.

Open to any suggestions and reviews.