### PR TITLE
fix: function component cannot be given refs

### DIFF
--- a/client/src/components/Avatar.tsx
+++ b/client/src/components/Avatar.tsx
@@ -11,15 +11,18 @@ interface AvatarProps extends ChakraAvatarProps {
   };
 }
 
-const Avatar = ({ user: { name, image_url }, ...avatarProps }: AvatarProps) => {
-  return (
-    <ChakraAvatar
-      name={name}
-      src={image_url ?? ''}
-      backgroundColor={image_url ? 'transparent' : undefined}
-      {...avatarProps}
-    />
-  );
-};
+const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>(
+  ({ user: { name, image_url }, ...avatarProps }: AvatarProps, ref) => {
+    return (
+      <ChakraAvatar
+        ref={ref}
+        name={name}
+        src={image_url ?? ''}
+        backgroundColor={image_url ? 'transparent' : undefined}
+        {...avatarProps}
+      />
+    );
+  },
+);
 
 export default Avatar;


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Fixes _Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?_ as recommended in nextjs documentation - https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-functional-component

<details>

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `ForwardRef(LinkComponent)`.
Avatar@webpack-internal:///./src/components/Avatar.tsx:25:19
LinkComponent@webpack-internal:///../node_modules/next/dist/client/link.js:109:19
nav
withEmotionCache/<@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66
Stack<@webpack-internal:///../node_modules/@chakra-ui/layout/dist/index.esm.js:725:7
HStack
header
withEmotionCache/<@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66
Flex2@webpack-internal:///../node_modules/@chakra-ui/layout/dist/index.esm.js:273:77
_c
Header@webpack-internal:///./src/components/PageLayout/Header.tsx:105:70
PageLayout@webpack-internal:///./src/components/PageLayout/index.tsx:20:18
ConfirmContextProvider@webpack-internal:///../node_modules/chakra-confirm/dist/chakra-confirm.esm.js:223:18
AuthContextProvider@webpack-internal:///./src/modules/auth/store/index.tsx:45:18
ConditionalWrap@webpack-internal:///./src/pages/_app.tsx:90:14
EnvironmentProvider@webpack-internal:///../node_modules/@chakra-ui/react-env/dist/index.esm.js:121:54
ColorModeProvider@webpack-internal:///../node_modules/@chakra-ui/provider/node_modules/@chakra-ui/color-mode/dist/index.esm.js:166:7
ThemeProvider@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:96:64
ThemeProvider@webpack-internal:///../node_modules/@chakra-ui/provider/node_modules/@chakra-ui/system/dist/index.esm.js:112:44
ChakraProvider@webpack-internal:///../node_modules/@chakra-ui/provider/dist/index.esm.js:28:7
ChakraProvider@webpack-internal:///../node_modules/@chakra-ui/react/dist/index.esm.js:244:24
ApolloProvider@webpack-internal:///../node_modules/@apollo/client/react/context/ApolloProvider.js:12:18
CustomApp@webpack-internal:///./src/pages/_app.tsx:141:19
ErrorBoundary@webpack-internal:///../node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:20742
ReactDevOverlay@webpack-internal:///../node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:23633
Container@webpack-internal:///../node_modules/next/dist/client/index.js:111:20
AppContainer@webpack-internal:///../node_modules/next/dist/client/index.js:296:18
Root@webpack-internal:///../node_modules/next/dist/client/index.js:504:19
```
</details>