### PR TITLE
chore: unify form submitting

### DIFF
--- a/client/src/hooks/useDisableWhileSubmitting.ts
+++ b/client/src/hooks/useDisableWhileSubmitting.ts
@@ -1,0 +1,32 @@
+import { useToast } from '@chakra-ui/react';
+import { useState } from 'react';
+
+export const useDisableWhileSubmitting = <T>({
+  onSubmit,
+  enableOnSuccess = false,
+}: {
+  onSubmit: (x: T) => Promise<void>;
+  enableOnSuccess?: boolean;
+}) => {
+  const [loading, setLoading] = useState(false);
+  const toast = useToast();
+  return {
+    loading,
+    disableWhileSubmitting: async (data: T) => {
+      setLoading(true);
+      try {
+        await onSubmit(data);
+      } catch (err) {
+        toast({
+          title: 'Something went wrong.',
+          status: 'error',
+        });
+        console.error(err);
+        setLoading(false);
+      }
+      if (enableOnSuccess) {
+        setLoading(false);
+      }
+    },
+  };
+};

--- a/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
+++ b/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@chakra-ui/react';
 import React from 'react';
 import { useForm } from 'react-hook-form';
+
 import { Input } from '../../../../components/Form/Input';
 import { TextArea } from '../../../../components/Form/TextArea';
 import { Form } from '../../../../components/Form/Form';
@@ -8,9 +9,9 @@ import type {
   DashboardChapterQuery,
   CreateChapterInputs,
 } from '../../../../generated/graphql';
+import { useDisableWhileSubmitting } from '../../../../hooks/useDisableWhileSubmitting';
 
 interface ChapterFormProps {
-  loading: boolean;
   onSubmit: (data: CreateChapterInputs) => Promise<void>;
   data?: DashboardChapterQuery;
   submitText: string;
@@ -93,7 +94,7 @@ const fields: Fields[] = [
 ];
 
 const ChapterForm: React.FC<ChapterFormProps> = (props) => {
-  const { loading, onSubmit, data, submitText, loadingText } = props;
+  const { onSubmit, data, submitText, loadingText } = props;
   const chapter = data?.dashboardChapter;
 
   const defaultValues: CreateChapterInputs = {
@@ -115,8 +116,16 @@ const ChapterForm: React.FC<ChapterFormProps> = (props) => {
     defaultValues,
   });
 
+  const { loading, disableWhileSubmitting } =
+    useDisableWhileSubmitting<CreateChapterInputs>({
+      onSubmit,
+    });
+
   return (
-    <Form submitLabel={submitText} FormHandling={handleSubmit(onSubmit)}>
+    <Form
+      submitLabel={submitText}
+      FormHandling={handleSubmit(disableWhileSubmitting)}
+    >
       {fields.map(({ key, label, placeholder, required, type }) =>
         type == 'textarea' ? (
           <TextArea

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -1,5 +1,6 @@
+import { useToast } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 
 import {
   CreateChapterInputs,
@@ -15,8 +16,6 @@ import { NextPageWithLayout } from '../../../../pages/_app';
 
 export const EditChapterPage: NextPageWithLayout = () => {
   const router = useRouter();
-  const [loadingUpdate, setLoadingUpdate] = useState(false);
-
   const { param: chapterId } = useParam('id');
 
   const { loading, error, data } = useDashboardChapterQuery({
@@ -27,17 +26,19 @@ export const EditChapterPage: NextPageWithLayout = () => {
     refetchQueries: [{ query: CHAPTERS }],
   });
 
+  const toast = useToast();
+
   const onSubmit = async (data: CreateChapterInputs) => {
-    setLoadingUpdate(true);
-    try {
-      await updateChapter({
-        variables: { chapterId, data: { ...data } },
-      });
+    const { data: chapterData, errors } = await updateChapter({
+      variables: { chapterId, data: { ...data } },
+    });
+    if (errors) throw errors;
+    if (chapterData) {
       await router.push('/dashboard/chapters');
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setLoadingUpdate(false);
+      toast({
+        title: `Chapter "${chapterData.updateChapter.name}" updated successfully!`,
+        status: 'success',
+      });
     }
   };
 
@@ -47,7 +48,6 @@ export const EditChapterPage: NextPageWithLayout = () => {
   return (
     <ChapterForm
       data={data}
-      loading={loadingUpdate}
       onSubmit={onSubmit}
       loadingText={'Saving Chapter Changes'}
       submitText={'Save Chapter Changes'}

--- a/client/src/modules/dashboard/Chapters/pages/NewChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/NewChapterPage.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import { useToast } from '@chakra-ui/react';
+import React, { ReactElement } from 'react';
 import { useRouter } from 'next/router';
 import {
   CreateChapterInputs,
@@ -10,31 +11,33 @@ import ChapterForm from '../components/ChapterForm';
 import { NextPageWithLayout } from '../../../../pages/_app';
 
 export const NewChapterPage: NextPageWithLayout = () => {
-  const [loading, setLoading] = useState(false);
   const router = useRouter();
 
   const [createChapter] = useCreateChapterMutation({
     refetchQueries: [{ query: CHAPTERS }],
   });
 
+  const toast = useToast();
+
   const onSubmit = async (inputData: CreateChapterInputs) => {
-    setLoading(true);
-    try {
-      // ToDo: handle empty data differently
-      const { data } = await createChapter({
-        variables: { data: { ...inputData } },
+    // ToDo: handle empty data differently
+    const { data: chapterData, errors } = await createChapter({
+      variables: { data: { ...inputData } },
+    });
+    if (errors) throw errors;
+    if (chapterData) {
+      await router.replace(
+        `/dashboard/chapters/${chapterData.createChapter.id}/new-venue`,
+      );
+      toast({
+        title: `Chapter "${chapterData.createChapter.name}" created!`,
+        status: 'success',
       });
-      router.replace(`/dashboard/chapters/${data?.createChapter.id}/new-venue`);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setLoading(false);
     }
   };
 
   return (
     <ChapterForm
-      loading={loading}
       onSubmit={onSubmit}
       loadingText={'Adding Chapter'}
       submitText={'Add chapter'}

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from '../../../../components/Form/Input';
 import { TextArea } from '../../../../components/Form/TextArea';
 import { Form } from '../../../../components/Form/Form';
+import { useDisableWhileSubmitting } from '../../../../hooks/useDisableWhileSubmitting';
 import EventChapterSelect from './EventChapterSelect';
 import EventDatesForm from './EventDatesForm';
 import EventCancelButton from './EventCancelButton';
@@ -31,7 +32,6 @@ const EventForm: React.FC<EventFormProps> = (props) => {
   const {
     onSubmit,
     data,
-    loading,
     submitText,
     chapterId: initialChapterId,
     loadingText,
@@ -89,9 +89,17 @@ const EventForm: React.FC<EventFormProps> = (props) => {
     variables: { chapterId },
   });
 
+  const { loading, disableWhileSubmitting } =
+    useDisableWhileSubmitting<EventFormData>({
+      onSubmit,
+    });
+
   return (
     <FormProvider {...formMethods}>
-      <Form submitLabel={submitText} FormHandling={handleSubmit(onSubmit)}>
+      <Form
+        submitLabel={submitText}
+        FormHandling={handleSubmit(disableWhileSubmitting)}
+      >
         {!isChaptersDropdownNeeded || data ? (
           loadingChapter ? (
             <Text>Loading Chapter</Text>

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -117,8 +117,7 @@ export type IEventData = Pick<
 };
 
 export interface EventFormProps {
-  onSubmit: (data: EventFormData) => void;
-  loading: boolean;
+  onSubmit: (data: EventFormData) => Promise<void>;
   data?: IEventData;
   submitText: string;
   chapterId: number;

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -1,6 +1,6 @@
 import NextError from 'next/error';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 import { useToast } from '@chakra-ui/react';
 
 import {
@@ -19,7 +19,6 @@ import { NextPageWithLayout } from '../../../../pages/_app';
 
 export const EditEventPage: NextPageWithLayout = () => {
   const router = useRouter();
-  const [loadingUpdate, setLoadingUpdate] = useState<boolean>(false);
   const { param: eventId } = useParam();
 
   const { loading, error, data } = useDashboardEventQuery({
@@ -40,28 +39,18 @@ export const EditEventPage: NextPageWithLayout = () => {
   });
 
   const onSubmit = async (data: EventFormData) => {
-    setLoadingUpdate(true);
+    const { data: eventData, errors } = await updateEvent({
+      variables: { eventId, data: parseEventData(data) },
+    });
 
-    try {
-      const event = await updateEvent({
-        variables: { eventId, data: parseEventData(data) },
-      });
+    if (errors) throw errors;
 
-      if (event.data) {
-        await router.push('/dashboard/events');
-        toast({
-          title: `Event "${event.data.updateEvent.name}" updated successfuly!`,
-          status: 'success',
-        });
-      }
-    } catch (err) {
+    if (eventData) {
+      await router.push('/dashboard/events');
       toast({
-        title: 'Something went wrong.',
-        status: 'error',
+        title: `Event "${eventData.updateEvent.name}" updated successfully!`,
+        status: 'success',
       });
-      console.error(err);
-    } finally {
-      setLoadingUpdate(false);
     }
   };
 
@@ -84,7 +73,6 @@ export const EditEventPage: NextPageWithLayout = () => {
         sponsors: sponsorData || [],
         venue_id: data.dashboardEvent?.venue?.id,
       }}
-      loading={loadingUpdate}
       onSubmit={onSubmit}
       loadingText={'Saving Event Changes'}
       submitText={'Save Event Changes'}

--- a/client/src/modules/dashboard/Sponsors/components/SponsorForm.tsx
+++ b/client/src/modules/dashboard/Sponsors/components/SponsorForm.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import { useForm } from 'react-hook-form';
 import { VStack } from '@chakra-ui/layout';
 
+import { Form } from '../../../../components/Form/Form';
 import { Input } from '../../../../components/Form/Input';
-import styles from '../../../../styles/Form.module.css';
 import { DashboardSponsorQuery, Sponsor } from '../../../../generated/graphql';
 import { useDisableWhileSubmitting } from '../../../../hooks/useDisableWhileSubmitting';
 
@@ -71,9 +71,9 @@ const SponsorForm: React.FC<SponsorFormProps> = (props) => {
     });
 
   return (
-    <form
-      onSubmit={handleSubmit(disableWhileSubmitting)}
-      className={styles.form}
+    <Form
+      submitLabel={submitText}
+      FormHandling={handleSubmit(disableWhileSubmitting)}
     >
       <VStack gap={4}>
         {fields.map((field) => {
@@ -109,7 +109,7 @@ const SponsorForm: React.FC<SponsorFormProps> = (props) => {
           {submitText}
         </Button>
       </VStack>
-    </form>
+    </Form>
   );
 };
 

--- a/client/src/modules/dashboard/Sponsors/components/SponsorForm.tsx
+++ b/client/src/modules/dashboard/Sponsors/components/SponsorForm.tsx
@@ -8,6 +8,7 @@ import { VStack } from '@chakra-ui/layout';
 import { Input } from '../../../../components/Form/Input';
 import styles from '../../../../styles/Form.module.css';
 import { DashboardSponsorQuery, Sponsor } from '../../../../generated/graphql';
+import { useDisableWhileSubmitting } from '../../../../hooks/useDisableWhileSubmitting';
 
 export type SponsorFormData = Omit<
   Sponsor,
@@ -15,7 +16,6 @@ export type SponsorFormData = Omit<
 >;
 
 interface SponsorFormProps {
-  loading: boolean;
   onSubmit: (data: SponsorFormData) => Promise<void>;
   data?: DashboardSponsorQuery;
   submitText: string;
@@ -48,7 +48,7 @@ const fields: FormField[] = [
   },
 ];
 const SponsorForm: React.FC<SponsorFormProps> = (props) => {
-  const { loading, onSubmit, data, submitText, loadingText } = props;
+  const { onSubmit, data, submitText, loadingText } = props;
   const sponsor = data?.dashboardSponsor;
   const defaultValues: SponsorFormData = {
     name: sponsor?.name ?? '',
@@ -64,8 +64,17 @@ const SponsorForm: React.FC<SponsorFormProps> = (props) => {
   } = useForm({
     defaultValues,
   });
+
+  const { loading, disableWhileSubmitting } =
+    useDisableWhileSubmitting<SponsorFormData>({
+      onSubmit,
+    });
+
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+    <form
+      onSubmit={handleSubmit(disableWhileSubmitting)}
+      className={styles.form}
+    >
       <VStack gap={4}>
         {fields.map((field) => {
           return (

--- a/client/src/modules/dashboard/Sponsors/pages/EditSponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/EditSponsorPage.tsx
@@ -1,6 +1,7 @@
+import { useToast } from '@chakra-ui/react';
 import NextError from 'next/error';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 
 import { useParam } from '../../../../hooks/useParam';
 import { Sponsors } from '../../Events/graphql/queries';
@@ -15,7 +16,6 @@ import {
 import { NextPageWithLayout } from '../../../../pages/_app';
 
 const EditSponsorPage: NextPageWithLayout = () => {
-  const [loading, setLoading] = useState(false);
   const router = useRouter();
   const { param: sponsorId } = useParam('id');
   const {
@@ -32,20 +32,22 @@ const EditSponsorPage: NextPageWithLayout = () => {
     ],
   });
 
+  const toast = useToast();
+
   const onSubmit = async (data: SponsorFormData) => {
-    setLoading(true);
-    try {
-      updateSponsor({
-        variables: {
-          data,
-          updateSponsorId: sponsorId,
-        },
+    const { data: sponsorData, errors } = await updateSponsor({
+      variables: {
+        data,
+        updateSponsorId: sponsorId,
+      },
+    });
+    if (errors) throw errors;
+    if (sponsorData) {
+      await router.replace('/dashboard/sponsors');
+      toast({
+        title: `Sponsor "${sponsorData?.updateSponsor.name}" updated successfully!`,
+        status: 'success',
       });
-      router.replace('/dashboard/sponsors');
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -56,7 +58,6 @@ const EditSponsorPage: NextPageWithLayout = () => {
 
   return (
     <SponsorForm
-      loading={loading}
       onSubmit={onSubmit}
       data={data}
       submitText="Save Sponsor Changes"

--- a/client/src/modules/dashboard/Sponsors/pages/NewSponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/NewSponsorPage.tsx
@@ -1,6 +1,7 @@
+import { useToast } from '@chakra-ui/react';
 import NextError from 'next/error';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 
 import { Sponsors } from '../../Events/graphql/queries';
 import { Layout } from '../../shared/components/Layout';
@@ -13,7 +14,6 @@ import { Permission } from '../../../../../../common/permissions';
 import { useAuth } from 'modules/auth/store';
 
 const NewSponsorPage: NextPageWithLayout = () => {
-  const [loading, setLoading] = useState(false);
   const router = useRouter();
   const [createSponsor] = useCreateSponsorMutation({
     refetchQueries: [{ query: Sponsors }],
@@ -24,19 +24,22 @@ const NewSponsorPage: NextPageWithLayout = () => {
     user,
     Permission.SponsorManage,
   );
+
+  const toast = useToast();
   const onSubmit = async (data: SponsorFormData) => {
-    setLoading(true);
-    try {
-      createSponsor({
-        variables: {
-          data,
-        },
+    const { data: sponsorData, errors } = await createSponsor({
+      variables: {
+        data,
+      },
+    });
+
+    if (errors) throw errors;
+    if (sponsorData) {
+      await router.replace('/dashboard/sponsors');
+      toast({
+        title: `Sponsor "${sponsorData.createSponsor.name}" created!`,
+        status: 'success',
       });
-      router.replace('/dashboard/sponsors');
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setLoading(false);
     }
   };
 
@@ -46,7 +49,6 @@ const NewSponsorPage: NextPageWithLayout = () => {
 
   return (
     <SponsorForm
-      loading={loading}
       onSubmit={onSubmit}
       submitText="Add New Sponsor"
       loadingText="Adding New Sponsor"

--- a/client/src/modules/dashboard/Venues/components/VenueForm.tsx
+++ b/client/src/modules/dashboard/Venues/components/VenueForm.tsx
@@ -5,8 +5,9 @@ import {
   Heading,
   Select,
 } from '@chakra-ui/react';
-import React, { useState } from 'react';
+import React from 'react';
 import { useForm } from 'react-hook-form';
+
 import { Input } from '../../../../components/Form/Input';
 import type {
   VenueQuery,
@@ -14,6 +15,7 @@ import type {
   ChapterQuery,
 } from '../../../../generated/graphql';
 import { Form } from '../../../../components/Form/Form';
+import { useDisableWhileSubmitting } from '../../../../hooks/useDisableWhileSubmitting';
 
 export type VenueFormData = Required<VenueInputs> & { chapter_id: number };
 
@@ -127,7 +129,6 @@ const VenueForm: React.FC<VenueFormProps> = (props) => {
     adminedChapters = [],
   } = props;
 
-  const [loading, setLoading] = useState(false);
   const venue = data?.venue;
 
   const defaultChapterId = adminedChapters[0]?.id ?? chapterId;
@@ -143,15 +144,10 @@ const VenueForm: React.FC<VenueFormProps> = (props) => {
     defaultValues,
   });
 
-  const disableWhileSubmitting = async (data: VenueFormData) => {
-    setLoading(true);
-    try {
-      await onSubmit(data);
-    } catch (err) {
-      console.error(err);
-      setLoading(false);
-    }
-  };
+  const { loading, disableWhileSubmitting } =
+    useDisableWhileSubmitting<VenueFormData>({
+      onSubmit,
+    });
 
   return (
     <Form

--- a/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/EditVenuePage.tsx
@@ -1,3 +1,4 @@
+import { useToast } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import React, { ReactElement } from 'react';
 import NextError from 'next/error';
@@ -32,13 +33,15 @@ export const EditVenuePage: NextPageWithLayout = () => {
     refetchQueries: [{ query: VENUES }],
   });
 
+  const toast = useToast();
+
   const onSubmit = async (data: VenueFormData) => {
     const { chapter_id, ...updateData } = data;
 
     const latitude = parseFloat(String(data.latitude));
     const longitude = parseFloat(String(data.longitude));
 
-    const { errors } = await updateVenue({
+    const { data: venueData, errors } = await updateVenue({
       variables: {
         venueId,
         chapterId: chapter_id,
@@ -46,7 +49,13 @@ export const EditVenuePage: NextPageWithLayout = () => {
       },
     });
     if (errors) throw errors;
-    await router.push('/dashboard/venues');
+    if (venueData) {
+      await router.push('/dashboard/venues');
+      toast({
+        title: `Venue "${venueData?.updateVenue.name}" updated successfully!`,
+        status: 'success',
+      });
+    }
   };
 
   const hasLoaded = !!venueData && !!chapterData;

--- a/client/src/modules/dashboard/Venues/utils.ts
+++ b/client/src/modules/dashboard/Venues/utils.ts
@@ -1,4 +1,6 @@
+import { useToast } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
+
 import { useCreateVenueMutation } from '../../../generated/graphql';
 import { VenueFormData } from './components/VenueForm';
 import { VENUES } from './graphql/queries';
@@ -8,6 +10,7 @@ export const useSubmitVenue = () => {
     refetchQueries: [{ query: VENUES }],
   });
   const router = useRouter();
+  const toast = useToast();
 
   return async (data: VenueFormData) => {
     const { chapter_id, ...createData } = data;
@@ -24,7 +27,11 @@ export const useSubmitVenue = () => {
     // TODO: handle apollo errors centrally if possible
     if (errors) throw errors;
     if (venueData) {
-      router.replace(`/dashboard/venues/${venueData.createVenue.id}`);
+      await router.replace(`/dashboard/venues/${venueData.createVenue.id}`);
+      toast({
+        title: `Venue "${venueData.createVenue.name}" created!`,
+        status: 'success',
+      });
     }
   };
 };

--- a/client/src/modules/profiles/component/ProfileForm.tsx
+++ b/client/src/modules/profiles/component/ProfileForm.tsx
@@ -12,9 +12,9 @@ import { Input } from '../../../components/Form/Input';
 import { TextArea } from '../../../components/Form/TextArea';
 import { Form } from '../../../components/Form/Form';
 import { UpdateUserInputs } from '../../../generated/graphql';
+import { useDisableWhileSubmitting } from 'hooks/useDisableWhileSubmitting';
 
 interface ProfileFormProps {
-  loading: boolean;
   onSubmit: (data: UpdateUserInputs) => Promise<void>;
   data: UpdateUserInputs;
   submitText: string;
@@ -47,7 +47,7 @@ const fields: Fields[] = [
 ];
 
 export const ProfileForm: React.FC<ProfileFormProps> = (props) => {
-  const { loading, onSubmit, data, submitText, loadingText } = props;
+  const { onSubmit, data, submitText, loadingText } = props;
 
   const defaultValues: UpdateUserInputs = {
     ...data,
@@ -68,8 +68,17 @@ export const ProfileForm: React.FC<ProfileFormProps> = (props) => {
 
   const hasAutoSubscribe = watch('auto_subscribe');
 
+  const { loading, disableWhileSubmitting } =
+    useDisableWhileSubmitting<UpdateUserInputs>({
+      onSubmit,
+      enableOnSuccess: true,
+    });
+
   return (
-    <Form submitLabel={submitText} FormHandling={handleSubmit(onSubmit)}>
+    <Form
+      submitLabel={submitText}
+      FormHandling={handleSubmit(disableWhileSubmitting)}
+    >
       {fields.map(({ key, label, placeholder, required, type }) =>
         type == 'textarea' ? (
           <TextArea

--- a/client/src/modules/profiles/pages/userProfile.tsx
+++ b/client/src/modules/profiles/pages/userProfile.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Flex, Heading } from '@chakra-ui/react';
+import React from 'react';
+import { Flex, Heading, useToast } from '@chakra-ui/react';
 import { useConfirmDelete } from 'chakra-confirm';
 import { Link } from 'chakra-next-link';
 import { useRouter } from 'next/router';
@@ -17,7 +17,6 @@ import { ProfileForm } from '../component/ProfileForm';
 import { useLogout } from 'hooks/useAuth';
 
 export const UserProfilePage = () => {
-  const [loadingUpdate, setLoadingUpdate] = useState(false);
   const { user } = useAuth();
   const logout = useLogout();
   const router = useRouter();
@@ -31,20 +30,19 @@ export const UserProfilePage = () => {
     refetchQueries: [{ query: meQuery }],
   });
 
+  const toast = useToast();
+
   const submitUpdateMe = async (data: UpdateUserInputs) => {
     const name = data.name?.trim();
     const image_url = data.image_url;
-    setLoadingUpdate(true);
-    try {
-      await updateMe({
-        variables: {
-          data: { name, auto_subscribe: data.auto_subscribe, image_url },
-        },
-      });
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setLoadingUpdate(false);
+    const { data: userData, errors } = await updateMe({
+      variables: {
+        data: { name, auto_subscribe: data.auto_subscribe, image_url },
+      },
+    });
+    if (errors) throw errors;
+    if (userData) {
+      toast({ title: 'Profile saved!', status: 'success' });
     }
   };
 
@@ -82,7 +80,6 @@ export const UserProfilePage = () => {
           )}
 
           <ProfileForm
-            loading={loadingUpdate}
             onSubmit={submitUpdateMe}
             data={user}
             loadingText={'Saving Profile Changes'}


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #1241

---

- When submitting form gets disabled, on error and on success there are toast messages.
- A bit of experimentation while trying to unify form behavior when submitting.
- `useDisableWhileSubmitting` hook (if that's appropriate term here) requires `onSubmit` function and returns:
  - `loading` - to plug into form components to disable them while submitting.
  - `disableWhileSubmitting` - function to pass in place of `onSubmit`
- `disableWhileSubmitting` will handle setting `loading` and submitting with `onSubmit`. If there's error, it toasts message about it.
- Success toasts are handled in `onSubmit` functions.
