### PR TITLE
fix(gitpod): nc command is missing

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,7 +16,9 @@ tasks:
       export COOKIE_DOMAIN=gitpod.io
       nvm install lts/gallium && nvm alias default lts/gallium
     # the rest, get persisted, so we can save time and use init:
-    init: npm ci
+    init: |
+      sudo apt-get update && sudo apt-get install netcat -y
+      npm ci
     command: |
       npm run db:reset
       npm run both


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Installs netcat on gitpod. Currently the `wait-for` is exiting with error `nc command is missing!`.