### PR TITLE
refactor: improve consistency in variable naming

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -2887,14 +2887,14 @@
             "description": null,
             "args": [
               {
-                "name": "roleName",
+                "name": "id",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "String",
+                    "name": "Int",
                     "ofType": null
                   }
                 },
@@ -2903,14 +2903,14 @@
                 "deprecationReason": null
               },
               {
-                "name": "userId",
+                "name": "roleName",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "String",
                     "ofType": null
                   }
                 },
@@ -3280,7 +3280,7 @@
             "description": null,
             "args": [
               {
-                "name": "chapterId",
+                "name": "_onlyUsedForAuth",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -3296,7 +3296,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "venueId",
+                "name": "id",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -3907,7 +3907,7 @@
             "description": null,
             "args": [
               {
-                "name": "chapterId",
+                "name": "_onlyUsedForAuth",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -3939,7 +3939,7 @@
                 "deprecationReason": null
               },
               {
-                "name": "venueId",
+                "name": "id",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -4259,7 +4259,7 @@
             "description": null,
             "args": [
               {
-                "name": "eventId",
+                "name": "id",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",
@@ -4321,7 +4321,7 @@
             "description": null,
             "args": [
               {
-                "name": "eventId",
+                "name": "id",
                 "description": null,
                 "type": {
                   "kind": "NON_NULL",

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -317,8 +317,8 @@ export type MutationChangeChapterUserRoleArgs = {
 };
 
 export type MutationChangeInstanceUserRoleArgs = {
+  id: Scalars['Int'];
   roleName: Scalars['String'];
-  userId: Scalars['Int'];
 };
 
 export type MutationConfirmRsvpArgs = {
@@ -358,8 +358,8 @@ export type MutationDeleteRsvpArgs = {
 };
 
 export type MutationDeleteVenueArgs = {
-  chapterId: Scalars['Int'];
-  venueId: Scalars['Int'];
+  _onlyUsedForAuth: Scalars['Int'];
+  id: Scalars['Int'];
 };
 
 export type MutationJoinChapterArgs = {
@@ -425,9 +425,9 @@ export type MutationUpdateSponsorArgs = {
 };
 
 export type MutationUpdateVenueArgs = {
-  chapterId: Scalars['Int'];
+  _onlyUsedForAuth: Scalars['Int'];
   data: VenueInputs;
-  venueId: Scalars['Int'];
+  id: Scalars['Int'];
 };
 
 export type PaginatedEventsWithTotal = {
@@ -483,7 +483,7 @@ export type QueryDashboardChapterArgs = {
 };
 
 export type QueryDashboardEventArgs = {
-  eventId: Scalars['Int'];
+  id: Scalars['Int'];
 };
 
 export type QueryDashboardSponsorArgs = {
@@ -491,7 +491,7 @@ export type QueryDashboardSponsorArgs = {
 };
 
 export type QueryEventArgs = {
-  eventId: Scalars['Int'];
+  id: Scalars['Int'];
 };
 
 export type QueryEventsArgs = {
@@ -3023,7 +3023,7 @@ export type EventsQueryResult = Apollo.QueryResult<
 >;
 export const DashboardEventDocument = gql`
   query dashboardEvent($eventId: Int!) {
-    dashboardEvent(eventId: $eventId) {
+    dashboardEvent(id: $eventId) {
       id
       name
       description
@@ -3488,7 +3488,7 @@ export type SponsorWithEventsQueryResult = Apollo.QueryResult<
 >;
 export const ChangeInstanceUserRoleDocument = gql`
   mutation changeInstanceUserRole($roleName: String!, $userId: Int!) {
-    changeInstanceUserRole(roleName: $roleName, userId: $userId) {
+    changeInstanceUserRole(roleName: $roleName, id: $userId) {
       instance_role {
         name
       }
@@ -3710,7 +3710,7 @@ export type CreateVenueMutationOptions = Apollo.BaseMutationOptions<
 >;
 export const UpdateVenueDocument = gql`
   mutation updateVenue($venueId: Int!, $chapterId: Int!, $data: VenueInputs!) {
-    updateVenue(venueId: $venueId, chapterId: $chapterId, data: $data) {
+    updateVenue(id: $venueId, _onlyUsedForAuth: $chapterId, data: $data) {
       id
       name
       street_address
@@ -4171,7 +4171,7 @@ export type PaginatedEventsWithTotalQueryResult = Apollo.QueryResult<
 >;
 export const EventDocument = gql`
   query event($eventId: Int!) {
-    event(eventId: $eventId) {
+    event(id: $eventId) {
       id
       name
       description

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -23,7 +23,7 @@ export const EVENTS = gql`
 
 export const DASHBOARD_EVENT = gql`
   query dashboardEvent($eventId: Int!) {
-    dashboardEvent(eventId: $eventId) {
+    dashboardEvent(id: $eventId) {
       id
       name
       description

--- a/client/src/modules/dashboard/Users/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Users/graphql/mutations.ts
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client';
 
 export const changeInstanceUserRole = gql`
   mutation changeInstanceUserRole($roleName: String!, $userId: Int!) {
-    changeInstanceUserRole(roleName: $roleName, userId: $userId) {
+    changeInstanceUserRole(roleName: $roleName, id: $userId) {
       instance_role {
         name
       }

--- a/client/src/modules/dashboard/Venues/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Venues/graphql/mutations.ts
@@ -18,7 +18,7 @@ export const createVenue = gql`
 
 export const updateVenue = gql`
   mutation updateVenue($venueId: Int!, $chapterId: Int!, $data: VenueInputs!) {
-    updateVenue(venueId: $venueId, chapterId: $chapterId, data: $data) {
+    updateVenue(id: $venueId, _onlyUsedForAuth: $chapterId, data: $data) {
       id
       name
       street_address

--- a/client/src/modules/events/graphql/queries.ts
+++ b/client/src/modules/events/graphql/queries.ts
@@ -24,7 +24,7 @@ export const DATA_PAGINATED_EVENTS_TOTAL_QUERY = gql`
 
 export const EVENT = gql`
   query event($eventId: Int!) {
-    event(eventId: $eventId) {
+    event(id: $eventId) {
       id
       name
       description

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -408,7 +408,7 @@ Cypress.Commands.add(
         data,
       },
       query: `mutation updateVenue($chapterId: Int!, $venueId: Int!, $data: VenueInputs!) {
-      updateVenue(chapterId: $chapterId, venueId: $venueId, data: $data) {
+      updateVenue(_onlyUsedForAuth: $chapterId, id: $venueId, data: $data) {
         id
       }
     }`,
@@ -438,7 +438,7 @@ const deleteVenue = (
       venueId,
     },
     query: `mutation deleteVenue($chapterId: Int!, $venueId: Int!) {
-    deleteVenue(chapterId: $chapterId, venueId: $venueId) {
+    deleteVenue(_onlyUsedForAuth: $chapterId, id: $venueId) {
       id
     }
   }`,
@@ -643,7 +643,7 @@ const changeInstanceUserRole = (
     operationName: 'changeInstanceUserRole',
     variables: { roleName, userId },
     query: `mutation changeInstanceUserRole($roleName: String!, $userId: Int!) {
-      changeInstanceUserRole(roleName: $roleName, userId: $userId) {
+      changeInstanceUserRole(roleName: $roleName, id: $userId) {
         instance_role {
           name
         }

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -330,10 +330,10 @@ export class EventResolver {
   @Authorized(Permission.EventEdit)
   @Query(() => EventWithRelations, { nullable: true })
   async dashboardEvent(
-    @Arg('eventId', () => Int) eventId: number,
+    @Arg('id', () => Int) id: number,
   ): Promise<EventWithRelations | null> {
     return await prisma.events.findUnique({
-      where: { id: eventId },
+      where: { id },
       include: {
         chapter: true,
         venue: true,
@@ -357,10 +357,10 @@ export class EventResolver {
   // TODO: Check we need all the returned data
   @Query(() => EventWithRelations, { nullable: true })
   async event(
-    @Arg('eventId', () => Int) eventId: number,
+    @Arg('id', () => Int) id: number,
   ): Promise<EventWithRelations | null> {
     return await prisma.events.findUnique({
-      where: { id: eventId },
+      where: { id },
       include: {
         chapter: true,
         venue: true,

--- a/server/src/controllers/Users/resolver.ts
+++ b/server/src/controllers/Users/resolver.ts
@@ -43,10 +43,10 @@ export class UsersResolver {
   @Mutation(() => UserWithInstanceRole)
   async changeInstanceUserRole(
     @Arg('roleName', () => String) newRole: string,
-    @Arg('userId', () => Int) userId: number,
+    @Arg('id', () => Int) id: number,
   ): Promise<UserWithInstanceRole> {
     const user = await prisma.users.findUniqueOrThrow({
-      where: { id: userId },
+      where: { id },
       include: {
         ...instanceRoleInclude,
         user_chapters: { include: { chapter_role: true } },
@@ -68,7 +68,7 @@ export class UsersResolver {
           },
         },
       },
-      where: { id: userId },
+      where: { id },
       include: instanceRoleInclude,
     });
   }

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -62,8 +62,8 @@ export class VenueResolver {
   @Authorized(Permission.VenueEdit)
   @Mutation(() => Venue)
   updateVenue(
-    @Arg('venueId', () => Int) id: number,
-    @Arg('chapterId', () => Int) _onlyUsedForAuth: number,
+    @Arg('id', () => Int) id: number,
+    @Arg('_onlyUsedForAuth', () => Int) _onlyUsedForAuth: number,
     @Arg('data') data: VenueInputs,
   ): Promise<Venue | null> {
     const venueData: Prisma.venuesUpdateInput = data;
@@ -76,8 +76,8 @@ export class VenueResolver {
   @Authorized(Permission.VenueDelete)
   @Mutation(() => Venue)
   async deleteVenue(
-    @Arg('venueId', () => Int) id: number,
-    @Arg('chapterId', () => Int) _onlyUsedForAuth: number,
+    @Arg('id', () => Int) id: number,
+    @Arg('_onlyUsedForAuth', () => Int) _onlyUsedForAuth: number,
   ): Promise<{ id: number }> {
     // TODO: handle deletion of non-existent venue
     return await prisma.venues.delete({


### PR DESCRIPTION
The idea is that if 'id' is clear from context (i.e. the event query's
id is obviously event.id), then we should use that, but otherwise we
should be more explicit.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #XXXXX

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
