### PR TITLE
fix: redact secrets inside strings

### DIFF
--- a/server/src/util/redact-secrets.ts
+++ b/server/src/util/redact-secrets.ts
@@ -13,11 +13,27 @@ function errorToObject(err: Error) {
   return obj;
 }
 
-const secrets = ['Authorization', 'access_token', 'refresh_token', 'email'];
+const secrets = [
+  'Authorization',
+  'access_token',
+  'refresh_token',
+  'email',
+  'client_secret',
+  'client_id',
+];
+
+function redactString(str: string) {
+  return secrets.reduce(
+    (prev, secret) =>
+      prev.replace(new RegExp(`${secret}=[^&]+`, 'g'), `${secret}=***`),
+    str,
+  );
+}
 
 export const redactSecrets = (input: any): any => {
   const object = input instanceof Error ? errorToObject(input) : input;
-  return cloneDeepWith((_value, key: string) => {
+  return cloneDeepWith((value, key: string) => {
     if (key && secrets.includes(key)) return '***';
+    if (typeof value === 'string') return redactString(value);
   }, object);
 };

--- a/server/tests/fixtures/objects-with-secrets.ts
+++ b/server/tests/fixtures/objects-with-secrets.ts
@@ -134,6 +134,65 @@ export const fullResponse = {
   errors: [{ domain: 'global', reason: 'notFound', message: 'Not Found' }],
 };
 
+export const invalidGrant = {
+  stack: 'Error: invalid_grant\n',
+  message: 'invalid_grant',
+  response: {
+    config: {
+      method: 'POST',
+      url: 'https://oauth2.googleapis.com/token',
+      data: 'refresh_token=someaccesstoken&client_id=123-456id.apps.googleusercontent.com&client_secret=someaccesstoken&grant_type=refresh_token',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': 'google-api-nodejs-client/7.14.1',
+        'x-goog-api-client': 'gl-node/16.18.0 auth/7.14.1',
+        Accept: 'application/json',
+      },
+      paramsSerializer: [],
+      body: 'refresh_token=someaccesstoken&client_id=123-456id.apps.googleusercontent.com&client_secret=someaccesstoken&grant_type=refresh_token',
+      validateStatus: [],
+      responseType: 'json',
+    },
+    data: { error: 'invalid_grant', error_description: 'Bad Request' },
+    headers: {
+      'alt-svc':
+        'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"',
+      'cache-control': 'no-cache, no-store, max-age=0, must-revalidate',
+      connection: 'close',
+      'content-encoding': 'gzip',
+      'content-type': 'application/json; charset=utf-8',
+      date: 'Fri, 11 Nov 2022 10:14:49 GMT',
+      expires: 'Mon, 01 Jan 1990 00:00:00 GMT',
+      pragma: 'no-cache',
+      server: 'scaffolding on HTTPServer2',
+      'transfer-encoding': 'chunked',
+      vary: 'Origin, X-Origin, Referer',
+      'x-content-type-options': 'nosniff',
+      'x-frame-options': 'SAMEORIGIN',
+      'x-xss-protection': '0',
+    },
+    status: 400,
+    statusText: 'Bad Request',
+    request: { responseURL: 'https://oauth2.googleapis.com/token' },
+  },
+  config: {
+    method: 'POST',
+    url: 'https://oauth2.googleapis.com/token',
+    data: 'refresh_token=someaccesstoken&client_id=123-456id.apps.googleusercontent.com&client_secret=someaccesstoken&grant_type=refresh_token',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': 'google-api-nodejs-client/7.14.1',
+      'x-goog-api-client': 'gl-node/16.18.0 auth/7.14.1',
+      Accept: 'application/json',
+    },
+    paramsSerializer: [],
+    body: 'refresh_token=someaccesstoken&client_id=123-456id.apps.googleusercontent.com&client_secret=someaccesstoken&grant_type=refresh_token',
+    validateStatus: [],
+    responseType: 'json',
+  },
+  code: '400',
+};
+
 export const circularObject: Record<string, unknown> = {};
 circularObject.circularRef = circularObject;
 

--- a/server/tests/redact-secrets.test.ts
+++ b/server/tests/redact-secrets.test.ts
@@ -8,6 +8,7 @@ import {
   redactedCircularObjectWithSecret,
   nestedObject,
   redactedNestedObject,
+  invalidGrant,
 } from './fixtures/objects-with-secrets';
 
 describe('redactSecrets', () => {
@@ -60,6 +61,17 @@ describe('redactSecrets', () => {
     });
   });
 
+  it('redacts inside text', () => {
+    const obj = {
+      prop: 'refresh_token=1%2F%2Fabc123&client_id=123-456id.apps.googleusercontent.com&something_else=123&refresh_token=1%2F%2Fabc123&client_secret=1234567890&grant_type=refresh_token',
+    };
+    const expected = {
+      prop: 'refresh_token=***&client_id=***&something_else=123&refresh_token=***&client_secret=***&grant_type=refresh_token',
+    };
+
+    expect(redactSecrets(obj)).toEqual(expected);
+  });
+
   it('redacts secrets in nested objects', () => {
     expect(redactSecrets(nestedObject)).toEqual(redactedNestedObject);
   });
@@ -76,6 +88,12 @@ describe('redactSecrets', () => {
 
   it('handles a full response object', () => {
     expect(JSON.stringify(redactSecrets(fullResponse))).not.toMatch(
+      'someaccesstoken',
+    );
+  });
+
+  it('handles an invalid grant', () => {
+    expect(JSON.stringify(redactSecrets(invalidGrant))).not.toMatch(
       'someaccesstoken',
     );
   });


### PR DESCRIPTION
Secrets can appear in the form

{ body: 'secret=value&another=secret' }

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->



<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
