### PR TITLE
fix: migrate permission names

### DIFF
--- a/server/prisma/migrations/20221116090943_update_permissions/migration.sql
+++ b/server/prisma/migrations/20221116090943_update_permissions/migration.sql
@@ -14,3 +14,44 @@ UPDATE instance_permissions SET name = 'event-subscription-manage' WHERE name = 
 
 UPDATE chapter_permissions SET name = 'event-subscription-manage' WHERE name = 'event-subscriptions-manage';
 
+-- Add new instance permission (sponsor-view) to owner role
+
+INSERT INTO instance_role_permissions (instance_role_id, instance_permission_id, created_at, updated_at)
+VALUES (
+  (SELECT id FROM instance_roles WHERE name = 'owner'),
+  (SELECT id FROM instance_permissions WHERE name = 'sponsor-view'),
+  NOW(),
+  NOW()
+) ON CONFLICT DO NOTHING;
+
+-- Add new instance role (chapter_administrator)
+
+INSERT INTO instance_roles (name, created_at, updated_at)
+VALUES ('chapter_administrator', NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+-- Add permissions (chapter-join, chapter-subscription-manage, sponsor-view) for new instance role (chapter_administrator)
+
+INSERT INTO instance_role_permissions (instance_role_id, instance_permission_id, created_at, updated_at)
+VALUES (
+  (SELECT id FROM instance_roles WHERE name = 'chapter_administrator'),
+  (SELECT id FROM instance_permissions WHERE name = 'chapter-subscription-manage'),
+  NOW(),
+  NOW()
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO instance_role_permissions (instance_role_id, instance_permission_id, created_at, updated_at)
+VALUES (
+  (SELECT id FROM instance_roles WHERE name = 'chapter_administrator'),
+  (SELECT id FROM instance_permissions WHERE name = 'chapter-join'),
+  NOW(),
+  NOW()
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO instance_role_permissions (instance_role_id, instance_permission_id, created_at, updated_at)
+VALUES (
+  (SELECT id FROM instance_roles WHERE name = 'chapter_administrator'),
+  (SELECT id FROM instance_permissions WHERE name = 'sponsor-view'),
+  NOW(),
+  NOW()
+) ON CONFLICT DO NOTHING;

--- a/server/prisma/migrations/20221116090943_update_permissions/migration.sql
+++ b/server/prisma/migrations/20221116090943_update_permissions/migration.sql
@@ -1,0 +1,16 @@
+-- Add new instance permission
+
+INSERT INTO instance_permissions (name, created_at, updated_at)
+VALUES ('sponsor-view', NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+-- Update existing instance permissions
+
+UPDATE instance_permissions SET name = 'chapter-subscription-manage' WHERE name = 'chapter-subscriptions-manage';
+UPDATE instance_permissions SET name = 'sponsor-manage' WHERE name = 'sponsors-manage';
+UPDATE instance_permissions SET name = 'event-subscription-manage' WHERE name = 'event-subscriptions-manage';
+
+-- Update existing chapter permissions
+
+UPDATE chapter_permissions SET name = 'event-subscription-manage' WHERE name = 'event-subscriptions-manage';
+

--- a/server/prisma/migrations/20221116090943_update_permissions/migration.sql
+++ b/server/prisma/migrations/20221116090943_update_permissions/migration.sql
@@ -4,6 +4,23 @@ INSERT INTO instance_permissions (name, created_at, updated_at)
 VALUES ('sponsor-view', NOW(), NOW())
 ON CONFLICT DO NOTHING;
 
+-- Add instance permissions, chapter-subscriptions-manage, chapter-join and
+-- event-subscriptions-manage, if they don't exist (when testing migration in
+-- CI, they won't)
+
+INSERT INTO instance_permissions (name, created_at, updated_at)
+VALUES 
+    ('chapter-subscriptions-manage', NOW(), NOW()),
+    ('chapter-join', NOW(), NOW()),
+    ('event-subscriptions-manage', NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+-- Add instance role owner, if it doesn't exist (it won't in CI)
+
+INSERT INTO instance_roles (name, created_at, updated_at)
+VALUES ('owner', NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
 -- Update existing instance permissions
 
 UPDATE instance_permissions SET name = 'chapter-subscription-manage' WHERE name = 'chapter-subscriptions-manage';


### PR DESCRIPTION
#1620 added and modified permissions. Since this has to be reflected in
live databases, it should be a migration.

It's a weird migration because it does not modify the schema, it
modifies data. Something we may want to avoid in future (if possible)

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #1898

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
