### PR TITLE
feat: warn admin when leaving chapter

### DIFF
--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -147,7 +147,21 @@ export const ChapterPage: NextPage = () => {
   const onLeaveChapter = async () => {
     const ok = await confirm({
       title: 'Are you sure you want to leave this chapter?',
-      body: "Leaving will cancel your attendance at all of this chapter's events.",
+      body: (
+        <>
+          Leaving will cancel your attendance at all of this chapter&apos;s
+          events.
+          {dataChapterUser?.chapterUser?.chapter_role.name ===
+            'administrator' && (
+            <>
+              <br />
+              <br />
+              Note: This will remove record of your chapter role as well.
+              Joining chapter again will give you member role.
+            </>
+          )}
+        </>
+      ),
     });
     if (ok) {
       try {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #1869

---

- Adds warning about leaving chapter by administrator.