### PR TITLE
feat: log in when confirming RSVP

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -3,16 +3,18 @@ import { useMeQuery } from 'generated/graphql';
 import { useSession } from 'hooks/useSession';
 
 export const useLogin = () => {
-  const { loginWithRedirect } = useAuth0();
+  const { loginWithPopup } = useAuth0();
   const { createSession } = useSession();
   const { refetch } = useMeQuery();
 
   const login = async () => {
     if (process.env.NEXT_PUBLIC_USE_AUTH0 !== 'false') {
-      return loginWithRedirect();
+      await loginWithPopup();
+      await createSession();
     } else {
       await createSession();
-      return await refetch();
+      // TODO: it should be possible to remove the refetch once dev login can persist isAuthenticated
+      await refetch();
     }
   };
 

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -107,6 +107,7 @@ export const EventPage: NextPage = () => {
     const ok = await confirm(confirmOptions);
 
     if (ok) {
+      if (!user) await login();
       try {
         await joinChapter({ variables: { chapterId } });
         await rsvpToEvent({
@@ -145,13 +146,11 @@ export const EventPage: NextPage = () => {
 
   // TODO: reimplment this the login modal with Auth0
   async function checkOnRsvp(options?: { invited?: boolean }) {
-    if (!user) await login();
     await onRsvp(options);
   }
 
   // TODO: reimplment this the login modal with Auth0
   async function checkOnCancelRsvp() {
-    if (!user) await login();
     await onCancelRsvp();
   }
 

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -107,7 +107,7 @@ export const EventPage: NextPage = () => {
     const ok = await confirm(confirmOptions);
 
     if (ok) {
-      if (!user) await login();
+      if (!isLoggedIn) await login();
       try {
         await joinChapter({ variables: { chapterId } });
         await rsvpToEvent({
@@ -131,6 +131,7 @@ export const EventPage: NextPage = () => {
     });
 
     if (ok) {
+      if (!isLoggedIn) await login();
       try {
         await cancelRsvp({
           variables: { eventId },

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -131,7 +131,6 @@ export const EventPage: NextPage = () => {
     });
 
     if (ok) {
-      if (!isLoggedIn) await login();
       try {
         await cancelRsvp({
           variables: { eventId },

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -77,14 +77,10 @@ export const ConditionalWrap = (props: ConditionalWrapProps) => {
 
 const Auth0Wrapper = (children: React.ReactNode) => {
   // TODO: create a module to handle environment variables
-  const router = useRouter();
   const domain = process.env.NEXT_PUBLIC_AUTH0_DOMAIN as string;
   const clientId = process.env.NEXT_PUBLIC_AUTH0_CLIENT_ID as string;
   const audience = process.env.NEXT_PUBLIC_AUTH0_AUDIENCE as string;
   const clientURL = process.env.NEXT_PUBLIC_CLIENT_URL as string;
-  const onRedirectCallback = () => {
-    router.replace('/policy');
-  };
   {
     /* TODO: Can we conditionally use window.location.origin for the redirectUri if
            we're in the browser? Or should we require site maintainers to supply it? */
@@ -94,7 +90,6 @@ const Auth0Wrapper = (children: React.ReactNode) => {
       domain={domain}
       clientId={clientId}
       redirectUri={clientURL}
-      onRedirectCallback={onRedirectCallback}
       audience={audience}
     >
       {children}


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes https://github.com/freeCodeCamp/chapter/issues/1924

The sequence of the logic was making people see a message for a second before login, here is video staging tester provided

https://user-images.githubusercontent.com/88248797/202520802-70b6b2b0-9b05-4afa-bf5c-f17f23a94766.mp4


<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
