### PR TITLE
fix: rename special prop

### DIFF
--- a/client/src/modules/dashboard/Events/components/DatePicker.tsx
+++ b/client/src/modules/dashboard/Events/components/DatePicker.tsx
@@ -8,8 +8,8 @@ import { Input } from '../../../../components/Form/Input';
 interface DatePickerProps {
   date: Date;
   error: string;
+  field: string;
   isRequired: boolean;
-  key: string;
   label: string;
   loading: boolean;
   onChange: (date: Date | null) => void;
@@ -18,8 +18,8 @@ interface DatePickerProps {
 const DatePicker = ({
   date,
   error,
+  field,
   isRequired,
-  key,
   label,
   loading,
   onChange,
@@ -34,8 +34,8 @@ const DatePicker = ({
       dateFormat="MMMM d, yyyy h:mm aa"
       customInput={
         <Input
-          id={`${key}_trigger`}
-          name={key}
+          id={`${field}_trigger`}
+          name={field}
           error={error}
           label={`${label}${isRequired ? ' (Required)' : ''}`}
           isDisabled={loading}

--- a/client/src/modules/dashboard/Events/components/EventDatesForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventDatesForm.tsx
@@ -30,10 +30,10 @@ const EventDatesForm: React.FC<EventDatesFormProps> = ({
   const [endError, setEndError] = useState('');
 
   const onDatePickerChange = useCallback(
-    (key: string, setDate: (date: React.SetStateAction<Date>) => void) => {
+    (field: string, setDate: (date: React.SetStateAction<Date>) => void) => {
       return (date: Date | null) => {
         if (!date) return;
-        setValue(key, date, { shouldDirty: true });
+        setValue(field, date, { shouldDirty: true });
         setDate(date);
       };
     },
@@ -57,8 +57,8 @@ const EventDatesForm: React.FC<EventDatesFormProps> = ({
   const startDateProps = {
     date: startDate,
     error: startError,
+    field: 'start_at',
     isRequired: true,
-    key: 'start_at',
     label: 'Start at',
     loading,
     onChange: onDatePickerChange('start_at', setStartDate),
@@ -66,7 +66,7 @@ const EventDatesForm: React.FC<EventDatesFormProps> = ({
   const endDateProps = {
     date: endDate,
     error: endError,
-    key: 'ends_at',
+    field: 'ends_at',
     isRequired: true,
     label: 'End at',
     loading,


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Fixes warning generated by using `key` as a prop. https://reactjs.org/warnings/special-props.html

<details>
<summary>Warning</summary>

```
Warning: DatePicker: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://reactjs.org/link/special-props)
DatePicker@webpack-internal:///./src/modules/dashboard/Events/components/DatePicker.tsx:21:14
div
withEmotionCache/<@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66
FormControl2@webpack-internal:///../node_modules/@chakra-ui/form-control/dist/index.esm.js:136:88
EventDatesForm@webpack-internal:///./src/modules/dashboard/Events/components/EventDatesForm.tsx:37:16
div
withEmotionCache/<@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66
Stack<@webpack-internal:///../node_modules/@chakra-ui/layout/dist/index.esm.js:725:7
VStack
form
Form@webpack-internal:///./src/components/Form/Form.tsx:20:18
FormProvider@webpack-internal:///../node_modules/react-hook-form/dist/index.esm.mjs:141:35
EventForm@webpack-internal:///./src/modules/dashboard/Events/components/EventForm.tsx:59:18
NewEventPage@webpack-internal:///./src/modules/dashboard/Events/pages/NewEventPage.tsx:49:77
div
Layout@webpack-internal:///./src/modules/dashboard/shared/components/Layout.tsx:68:18
div
withEmotionCache/<@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66
PageLayout@webpack-internal:///./src/components/PageLayout/index.tsx:22:18
ConfirmContextProvider@webpack-internal:///../node_modules/chakra-confirm/dist/chakra-confirm.esm.js:223:18
AuthContextProvider@webpack-internal:///./src/modules/auth/store/index.tsx:45:18
ConditionalWrap@webpack-internal:///./src/pages/_app.tsx:90:14
EnvironmentProvider@webpack-internal:///../node_modules/@chakra-ui/react-env/dist/index.esm.js:121:54
ColorModeProvider@webpack-internal:///../node_modules/@chakra-ui/provider/node_modules/@chakra-ui/color-mode/dist/index.esm.js:166:7
ThemeProvider@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:96:64
ThemeProvider@webpack-internal:///../node_modules/@chakra-ui/provider/node_modules/@chakra-ui/system/dist/index.esm.js:112:44
ChakraProvider@webpack-internal:///../node_modules/@chakra-ui/provider/dist/index.esm.js:28:7
ChakraProvider@webpack-internal:///../node_modules/@chakra-ui/react/dist/index.esm.js:244:24
ApolloProvider@webpack-internal:///../node_modules/@apollo/client/react/context/ApolloProvider.js:12:18
CustomApp@webpack-internal:///./src/pages/_app.tsx:141:19
ErrorBoundary@webpack-internal:///../node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:20742
ReactDevOverlay@webpack-internal:///../node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:23633
Container@webpack-internal:///../node_modules/next/dist/client/index.js:111:20
AppContainer@webpack-internal:///../node_modules/next/dist/client/index.js:296:18
Root@webpack-internal:///../node_modules/next/dist/client/index.js:504:19
```

</details>