### PR TITLE
fix: <a> cannot appear as a descendant of <a>

### DIFF
--- a/client/src/modules/dashboard/Calendar/pages/Calendar.tsx
+++ b/client/src/modules/dashboard/Calendar/pages/Calendar.tsx
@@ -43,8 +43,7 @@ export const Calendar: NextPageWithLayout = () => {
             </p>
           </Flex>
           <LinkButton
-            as="a"
-            href={new URL('/authenticate-with-google', serverUrl).href}
+            nextAs={new URL('/authenticate-with-google', serverUrl).href}
             fontWeight="600"
             background={'gray.85'}
             color={'gray.10'}


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Fixes warning caused by `LinkButton` nesting `<a>` within `<a>`.

<details>
<summary>Warning</summary>

```
Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
a
withEmotionCache/<@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66
Button<@webpack-internal:///../node_modules/@chakra-ui/button/dist/index.esm.js:108:17
a
LinkingComponent@webpack-internal:///../node_modules/chakra-next-link/dist/chakra-next-link.esm.js:60:12
LinkButton@webpack-internal:///../node_modules/chakra-next-link/dist/chakra-next-link.esm.js:147:16
Calendar@webpack-internal:///./src/modules/dashboard/Calendar/pages/Calendar.tsx:35:70
div
Layout@webpack-internal:///./src/modules/dashboard/shared/components/Layout.tsx:68:18
div
withEmotionCache/<@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:57:66
PageLayout@webpack-internal:///./src/components/PageLayout/index.tsx:22:18
ConfirmContextProvider@webpack-internal:///../node_modules/chakra-confirm/dist/chakra-confirm.esm.js:223:18
AuthContextProvider@webpack-internal:///./src/modules/auth/store/index.tsx:45:18
ConditionalWrap@webpack-internal:///./src/pages/_app.tsx:90:14
EnvironmentProvider@webpack-internal:///../node_modules/@chakra-ui/react-env/dist/index.esm.js:121:54
ColorModeProvider@webpack-internal:///../node_modules/@chakra-ui/provider/node_modules/@chakra-ui/color-mode/dist/index.esm.js:166:7
ThemeProvider@webpack-internal:///../node_modules/@emotion/react/dist/emotion-element-6a883da9.browser.esm.js:96:64
ThemeProvider@webpack-internal:///../node_modules/@chakra-ui/provider/node_modules/@chakra-ui/system/dist/index.esm.js:112:44
ChakraProvider@webpack-internal:///../node_modules/@chakra-ui/provider/dist/index.esm.js:28:7
ChakraProvider@webpack-internal:///../node_modules/@chakra-ui/react/dist/index.esm.js:244:24
ApolloProvider@webpack-internal:///../node_modules/@apollo/client/react/context/ApolloProvider.js:12:18
CustomApp@webpack-internal:///./src/pages/_app.tsx:141:19
ErrorBoundary@webpack-internal:///../node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:20742
ReactDevOverlay@webpack-internal:///../node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:8:23633
Container@webpack-internal:///../node_modules/next/dist/client/index.js:111:20
AppContainer@webpack-internal:///../node_modules/next/dist/client/index.js:296:18
Root@webpack-internal:///../node_modules/next/dist/client/index.js:504:19 next-dev.js:20:25
```

</details>