### PR TITLE
fix: administrators abusing their permissions

### DIFF
--- a/common/authorization.ts
+++ b/common/authorization.ts
@@ -75,19 +75,27 @@ function getRelatedChapterId(
 ): number | null {
   const { chapterId, eventId, venueId } = variableValues;
 
-  if (chapterId) return chapterId;
-
-  if (eventId) {
-    const event = events.find(({ id }) => id === eventId);
-    if (event) return event.chapter_id;
+  function inferId(
+    id: number,
+    data: { id: number; chapter_id: number }[],
+  ): number | null {
+    const target = data.find((x) => x.id === id);
+    return target ? target.chapter_id : null;
   }
 
-  if (venueId) {
-    const venue = venues.find(({ id }) => id === venueId);
-    if (venue) return venue.chapter_id;
-  }
+  // We're using 'undefined' when the id should not be inferred, leaving 'null'
+  // to indicate that we've failed to infer the id (and so the request is
+  // invalid)
+  const inferredFromEvent = eventId ? inferId(eventId, events) : undefined;
+  const inferredFromVenue = venueId ? inferId(venueId, venues) : undefined;
 
-  return null;
+  const chapterIds = [inferredFromEvent, inferredFromVenue, chapterId].filter(
+    (x) => typeof x !== 'undefined',
+  );
+
+  return chapterIds.length && chapterIds.every((x) => x === chapterIds[0])
+    ? chapterIds[0]
+    : null;
 }
 
 function isAllowedByChapterRole(

--- a/server/tests/authorization.test.ts
+++ b/server/tests/authorization.test.ts
@@ -39,7 +39,7 @@ const resolverDataWithEventsAndVenues = merge(baseResolverData, {
 
 describe('authorizationChecker', () => {
   describe('when user is NOT banned', () => {
-    it('should return false if user is undefined', () => {
+    it('should reject if user is undefined', () => {
       const result = authorizationChecker(resolverDataWithEventsAndVenues, [
         'some-permission',
       ]);
@@ -47,7 +47,7 @@ describe('authorizationChecker', () => {
       expect(result).toBe(false);
     });
 
-    it('should return false if user is defined, but events or venue is not', () => {
+    it('should reject if user is defined, but events or venue is not', () => {
       const resolverData = merge(baseResolverData, {
         context: { user: userWithInstanceRole },
       });
@@ -69,7 +69,7 @@ describe('authorizationChecker', () => {
       ).toBe(false);
     });
 
-    it('should return true if the events and venues properties exist, but are empty arrays', () => {
+    it('should authorize if the events and venues properties exist, but are empty arrays', () => {
       const resolverData = merge(baseResolverData, {
         context: { user: userWithInstanceRole, events: [], venues: [] },
       });
@@ -79,7 +79,7 @@ describe('authorizationChecker', () => {
       );
     });
 
-    it('should return true if a user has an instance role granting permission', () => {
+    it('should authorize if a user has an instance role granting permission', () => {
       const resolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user: userWithInstanceRole },
       });
@@ -89,7 +89,7 @@ describe('authorizationChecker', () => {
       );
     });
 
-    it('should return false if a user does not have an instance role granting permission', () => {
+    it('should reject if a user does not have an instance role granting permission', () => {
       const resolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user: userWithInstanceRole },
       });
@@ -99,7 +99,7 @@ describe('authorizationChecker', () => {
       ).toBe(false);
     });
 
-    it('should return true if a user has a chapter role granting permission', () => {
+    it('should authorize if a user has a chapter role granting permission', () => {
       const resolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user: userWithRoleForChapterOne },
         info: {
@@ -112,7 +112,7 @@ describe('authorizationChecker', () => {
       );
     });
 
-    it('should return true if a user has a chapter role granting permission and the chapter is inferred from the event', () => {
+    it('should authorize if a user has a chapter role granting permission and the chapter is inferred from the event', () => {
       const resolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user: userWithRoleForChapterOne },
         info: {
@@ -125,7 +125,7 @@ describe('authorizationChecker', () => {
       );
     });
 
-    it('should return true if a user has a chapter role granting permission and the chapter is inferred from the venue', () => {
+    it('should authorize if a user has a chapter role granting permission and the chapter is inferred from the venue', () => {
       const resolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user: userWithRoleForChapterOne },
         info: {
@@ -138,7 +138,7 @@ describe('authorizationChecker', () => {
       );
     });
 
-    it('should return false if a user has a role for a chapter but a different chapter is inferred', () => {
+    it('should reject if a user has a role for a chapter but a different chapter is inferred', () => {
       const resolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user: userWithRoleForChapterOne },
         info: {
@@ -152,7 +152,7 @@ describe('authorizationChecker', () => {
       );
     });
 
-    it('should return false if a user only has a chapter role granting permission for another chapter', () => {
+    it('should reject if a user only has a chapter role granting permission for another chapter', () => {
       const resolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user: userWithRoleForChapterOne },
         info: {
@@ -165,7 +165,7 @@ describe('authorizationChecker', () => {
       );
     });
 
-    it('should return true if a user has an event role granting permission', () => {
+    it('should authorize if a user has an event role granting permission', () => {
       const resolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user: userWithRoleForEventOne },
         info: {
@@ -178,7 +178,7 @@ describe('authorizationChecker', () => {
       );
     });
 
-    it('should return false if a user only has an event role granting permission for another event', () => {
+    it('should reject if a user only has an event role granting permission for another event', () => {
       const eventTwoUserResolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user: userWithRoleForEventOne },
         info: {
@@ -191,7 +191,7 @@ describe('authorizationChecker', () => {
       ).toBe(false);
     });
 
-    it('should return false if the event is in a chapter for which the user has no role', () => {
+    it('should reject if the event is in a chapter for which the user has no role', () => {
       const user = merge(userWithRoleForChapterOne, {
         user_events: chapterTwoEventUser,
       });
@@ -206,7 +206,7 @@ describe('authorizationChecker', () => {
       );
     });
 
-    it('should return true if a user has a chapter role, even if they do not have an event role', () => {
+    it('should authorize if a user has a chapter role, even if they do not have an event role', () => {
       const user = userWithRoleForChapterOne;
       const resolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user },
@@ -219,7 +219,7 @@ describe('authorizationChecker', () => {
       );
     });
 
-    it('should return false unless the number of required permissions is 1', () => {
+    it('should reject unless the number of required permissions is 1', () => {
       expect.assertions(4);
       const resolverData = merge(resolverDataWithEventsAndVenues, {
         context: { user: userWithInstanceRole },
@@ -242,7 +242,7 @@ describe('authorizationChecker', () => {
   });
 
   describe('when user is banned', () => {
-    it('should return true if a user has an instance role and a chapter ban', () => {
+    it('should authorize if a user has an instance role and a chapter ban', () => {
       const user = merge(userWithInstanceRole, {
         user_bans: userBansChapterOne,
       });
@@ -254,7 +254,7 @@ describe('authorizationChecker', () => {
         true,
       );
     });
-    it('should return false if a user has a chapter role and a ban for that chapter', () => {
+    it('should reject if a user has a chapter role and a ban for that chapter', () => {
       const user = merge(userWithRoleForChapterOne, {
         user_bans: userBansChapterOne,
       });
@@ -269,7 +269,7 @@ describe('authorizationChecker', () => {
         false,
       );
     });
-    it('should return true if a user has a chapter role for one chapter, but is banned from a different one', () => {
+    it('should authorize if a user has a chapter role for one chapter, but is banned from a different one', () => {
       const user = merge(userWithRoleForChapterOne, {
         user_bans: userBansChapterTwo,
       });
@@ -284,7 +284,7 @@ describe('authorizationChecker', () => {
         true,
       );
     });
-    it('should return false if a user has an event role and a ban for the owning chapter', () => {
+    it('should reject if a user has an event role and a ban for the owning chapter', () => {
       const user = merge(userWithRoleForEventOne, {
         user_bans: userBansChapterOne,
       });
@@ -299,7 +299,7 @@ describe('authorizationChecker', () => {
         false,
       );
     });
-    it('should return true if a user has an event role and a ban for another chapter', () => {
+    it('should authorize if a user has an event role and a ban for another chapter', () => {
       const user = merge(userWithRoleForEventOne, {
         user_bans: userBansChapterTwo,
       });

--- a/server/tests/fixtures/users.ts
+++ b/server/tests/fixtures/users.ts
@@ -108,6 +108,37 @@ export const userWithRoleForChapterOne: User = merge(baseUser, {
   ],
 });
 
+export const userWithRoleForChaptersOneAndTwo: User = merge(baseUser, {
+  user_chapters: [
+    {
+      chapter_role: {
+        name: 'some-role',
+        chapter_role_permissions: [
+          {
+            chapter_permission: {
+              name: 'some-permission',
+            },
+          },
+        ],
+      },
+      chapter_id: 1,
+    },
+    {
+      chapter_role: {
+        name: 'some-role',
+        chapter_role_permissions: [
+          {
+            chapter_permission: {
+              name: 'some-permission',
+            },
+          },
+        ],
+      },
+      chapter_id: 2,
+    },
+  ],
+});
+
 export const userWithRoleForEventOne: User = merge(baseUser, {
   user_events: [
     {


### PR DESCRIPTION
- refactor: rename tests
- fix: stop admin using permission in other chapters

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

The authorization checker was too willing to believe the incoming request.  Users could abuse the fact that they could pass in spurious `variableValues` with a request to fool the checker into using the wrong credentials.

For example, an administrator of chapter 1 sends an `updateEvent` request targeting event 2 in chapter 2. If they sent `{ eventId: 2, chapterId: 1 }` the checker would accept that this was a request to chapter 1, confirm that the administrator is allowed to update events in chapter 1 and authorize the request.

This PR prevents this by making the checker find all possible `chapterId`s.  If they are identical (and the user has the permission) the request is authorized, otherwise it is rejected.

The `{ eventId: 2, chapterId: 1 }` request has two `chapterId`s, 1 and 2, so it will be rejected.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
