### PR TITLE
feat: move the Alert from the main content section

### DIFF
--- a/client/src/components/PageLayout/index.tsx
+++ b/client/src/components/PageLayout/index.tsx
@@ -15,16 +15,16 @@ const PageLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <Header />
+      <Alert status="error">
+        <AlertIcon />
+        <AlertTitle> This is a testing site. </AlertTitle>
+        <AlertDescription>
+          This is a testing site for freeCodeCamp staff members and Chapter
+          maintainers. Be mindful that your data will be deleted periodically.
+        </AlertDescription>
+      </Alert>
       <SkipNavContent />
       <Box px={[4, 4, 8, 16]} id="main-content">
-        <Alert status="error">
-          <AlertIcon />
-          <AlertTitle> This is a testing site. </AlertTitle>
-          <AlertDescription>
-            This is a testing site for freeCodeCamp staff members and Chapter
-            maintainers. Be mindful that your data will be deleted periodically.
-          </AlertDescription>
-        </Alert>
         {children}
       </Box>
       <Footer />


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

It's embarrassing how long it took for me to notice this, but alert can be skipped for people who are using the skip to content button. Because the alert isn't related to the main content of the website, sorry about that, should have noticed it sooner.

This will affect #2000 because people who will press "jump to content" will skip "know more about our policy", but they do expect to skip it and jump to chapters/events and navigate it  

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
