### PR TITLE
fix(ui): Add padding to user welcome message

### DIFF
--- a/client/src/modules/home/index.tsx
+++ b/client/src/modules/home/index.tsx
@@ -22,7 +22,11 @@ type User = NonNullable<AuthContextType['user']>;
 
 const Welcome = ({ user }: { user: User }) => {
   return (
-    <Flex alignItems={'center'} justifyContent="space-between">
+    <Flex
+      alignItems={'center'}
+      justifyContent="space-between"
+      paddingTop="20px"
+    >
       <Heading as="h1">Welcome, {getNameText(user.name)}</Heading>
       {!user.name && (
         <Text>

--- a/client/src/modules/home/index.tsx
+++ b/client/src/modules/home/index.tsx
@@ -25,7 +25,7 @@ const Welcome = ({ user }: { user: User }) => {
     <Flex
       alignItems={'center'}
       justifyContent="space-between"
-      paddingTop="20px"
+      marginTop="20px"
     >
       <Heading as="h1">Welcome, {getNameText(user.name)}</Heading>
       {!user.name && (

--- a/client/src/modules/home/index.tsx
+++ b/client/src/modules/home/index.tsx
@@ -22,11 +22,7 @@ type User = NonNullable<AuthContextType['user']>;
 
 const Welcome = ({ user }: { user: User }) => {
   return (
-    <Flex
-      alignItems={'center'}
-      justifyContent="space-between"
-      marginTop="20px"
-    >
+    <Flex alignItems={'center'} justifyContent="space-between" marginTop="20px">
       <Heading as="h1">Welcome, {getNameText(user.name)}</Heading>
       {!user.name && (
         <Text>
@@ -75,7 +71,9 @@ const Home = () => {
       {user ? (
         <Welcome user={user} />
       ) : (
-        <Heading as="h1">Welcome to Chapter</Heading>
+        <Heading as="h1" marginTop="20px">
+          Welcome to Chapter
+        </Heading>
       )}
       <Grid templateColumns="repeat(2, 1fr)" gap={10} mt="5">
         <GridItem colSpan={{ base: 2, xl: 1 }}>


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #1884 

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
This change adds padding to the top of welcome message when a user logins to the platform. Before, the welcome message did not have much separation between it and the header, so by adding more space the welcome message no longer looks cramped to the top.

How it looked before the change:
![201352290-352c650b-bad9-4d71-a3b9-b82ef360a09d](https://user-images.githubusercontent.com/59752837/205663810-30c87ea4-684f-41bd-a246-0f6f4ed52fa8.png)

How it looks after the change:
<img width="1145" alt="Screen Shot 2022-12-04 at 1 58 19 PM" src="https://user-images.githubusercontent.com/59752837/205663851-782efb88-0c35-4d85-897e-5fe75b5d93b8.png">
