### PR TITLE
feat: chapter name on users page

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -1098,6 +1098,7 @@ export type DashboardChapterUsersQuery = {
   __typename?: 'Query';
   dashboardChapter: {
     __typename?: 'ChapterWithRelations';
+    name: string;
     chapter_users: Array<{
       __typename?: 'ChapterUserWithRelations';
       subscribed: boolean;
@@ -2802,6 +2803,7 @@ export type DashboardChaptersQueryResult = Apollo.QueryResult<
 export const DashboardChapterUsersDocument = gql`
   query dashboardChapterUsers($chapterId: Int!) {
     dashboardChapter(id: $chapterId) {
+      name
       chapter_users {
         user {
           id

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -153,7 +153,9 @@ export const ChapterUsersPage: NextPageWithLayout = () => {
       )}
       <VStack>
         <Flex w="full" justify="space-between">
-          <Heading id="page-heading">Chapter Users</Heading>
+          <Heading id="page-heading">
+            {data.dashboardChapter.name} Users
+          </Heading>
         </Flex>
         <Box display={{ base: 'none', lg: 'block' }} width={'100%'}>
           <DataTable

--- a/client/src/modules/dashboard/Chapters/graphql/queries.ts
+++ b/client/src/modules/dashboard/Chapters/graphql/queries.ts
@@ -61,6 +61,7 @@ export const DASHBOARD_CHAPTERS = gql`
 export const DASHBOARD_CHAPTER_USERS = gql`
   query dashboardChapterUsers($chapterId: Int!) {
     dashboardChapter(id: $chapterId) {
+      name
       chapter_users {
         user {
           id

--- a/cypress/e2e/dashboard/chapters/users.cy.ts
+++ b/cypress/e2e/dashboard/chapters/users.cy.ts
@@ -24,7 +24,7 @@ describe('Chapter Users dashboard', () => {
   });
   it('should have a table of users', () => {
     cy.visit(`/dashboard/chapters/${chapterId}/users`);
-    cy.findByRole('table', { name: 'Chapter Users' }).should('be.visible');
+    cy.findByRole('table', { name: /Users$/ }).should('be.visible');
     cy.findByRole('columnheader', { name: 'name' }).should('be.visible');
     cy.findByRole('columnheader', { name: 'actions' }).should('be.visible');
   });


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #1892

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
Added the ability for the chapter name to be displayed on the `/dashboard/chapters/{id}/users` page, accessible on `ChapterUsersPage.tsx` via `data.dashboardChapter.name`.