### PR TITLE
fix: refetch meQuery on profile save

### DIFF
--- a/client/src/modules/profiles/pages/userProfile.tsx
+++ b/client/src/modules/profiles/pages/userProfile.tsx
@@ -15,6 +15,7 @@ import {
   UserDownloadQuery,
 } from '../../../generated/graphql';
 import { getNameText } from '../../../components/UserName';
+import { meQuery } from '../../auth/graphql/queries';
 import { userProfileQuery } from '../graphql/queries';
 import { ProfileForm } from '../component/ProfileForm';
 import { useLogout } from '../../../hooks/useAuth';
@@ -46,7 +47,7 @@ export const UserProfilePage = () => {
   });
   const [deleteMe] = useDeleteMeMutation();
   const [updateMe] = useUpdateMeMutation({
-    refetchQueries: [{ query: userProfileQuery }],
+    refetchQueries: [{ query: meQuery }, { query: userProfileQuery }],
   });
 
   const toast = useToast();


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Saving profile changes triggers refetch of the meQuery - updates header initials, or picture.