### PR TITLE
fix: add sronly text describing dashboard links

### DIFF
--- a/client/src/modules/dashboard/shared/components/Layout.tsx
+++ b/client/src/modules/dashboard/shared/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { HStack } from '@chakra-ui/layout';
+import { HStack, Text } from '@chakra-ui/layout';
 import { LinkButton } from 'chakra-next-link';
 import { useRouter } from 'next/router';
 import NextError from 'next/error';
@@ -65,7 +65,10 @@ export const Layout = ({
                 router.pathname.startsWith(item.link) ? 'blue' : 'gray'
               }
             >
-              {item.text}
+              {item.text}{' '}
+              <Text srOnly as="span">
+                Dashboard
+              </Text>
             </LinkButton>
           ))}
       </HStack>

--- a/cypress/e2e/dashboard/chapters/chapters-index.cy.ts
+++ b/cypress/e2e/dashboard/chapters/chapters-index.cy.ts
@@ -39,7 +39,7 @@ describe('chapters dashboard', () => {
     cy.get('[data-cy="chapter-dash-heading"]').should('be.visible');
     cy.get('[data-cy="dashboard-tabs"]')
       .find('a[aria-current="page"]')
-      .should('have.text', 'Chapters');
+      .should('have.text', 'Chapters Dashboard');
   });
 
   it('should have a table with links to view, create and edit chapters', () => {

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -28,7 +28,7 @@ describe('spec needing owner', () => {
   it('should be the active dashboard link', () => {
     cy.visit('/dashboard/');
     cy.get('a[href="/dashboard/events"]').click();
-    cy.get('a[aria-current="page"]').should('have.text', 'Events');
+    cy.get('a[aria-current="page"]').should('have.text', 'Events Dashboard');
   });
 
   it('should have a table with links to view and edit events', () => {

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -101,6 +101,7 @@ describe('spec needing owner', () => {
 
     cy.findByRole('link', { name: 'Events Dashboard' }).click();
     cy.contains('Loading...');
+    cy.location('pathname').should('match', /^\/dashboard\/events$/);
     cy.wait('@GQLdashboardEvents');
     cy.get('[data-cy="events-dashboard"]').should('be.visible');
 
@@ -141,6 +142,7 @@ describe('spec needing owner', () => {
     cy.findByRole('menuitem', { name: 'Dashboard' }).click();
     cy.findByRole('link', { name: 'Events Dashboard' }).click();
     cy.contains('Loading...');
+    cy.location('pathname').should('match', /^\/dashboard\/events$/);
     cy.wait('@GQLdashboardEvents');
     cy.get('[data-cy="events-dashboard"]').should('be.visible');
     cy.get<string>('@eventTitle').then((eventTitle) => {

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -99,7 +99,7 @@ describe('spec needing owner', () => {
     cy.get('button[aria-label="Options"]').click();
     cy.findByRole('menuitem', { name: 'Dashboard' }).click();
 
-    cy.findByRole('link', { name: 'Events' }).click();
+    cy.findByRole('link', { name: 'Events Dashboard' }).click();
     cy.contains('Loading...');
     cy.wait('@GQLdashboardEvents');
     cy.get('[data-cy="events-dashboard"]').should('be.visible');
@@ -139,7 +139,7 @@ describe('spec needing owner', () => {
 
     cy.get('button[aria-label="Options"]').click();
     cy.findByRole('menuitem', { name: 'Dashboard' }).click();
-    cy.findByRole('link', { name: 'Events' }).click();
+    cy.findByRole('link', { name: 'Events Dashboard' }).click();
     cy.contains('Loading...');
     cy.wait('@GQLdashboardEvents');
     cy.get('[data-cy="events-dashboard"]').should('be.visible');

--- a/cypress/e2e/dashboard/venues.cy.ts
+++ b/cypress/e2e/dashboard/venues.cy.ts
@@ -19,7 +19,7 @@ describe('venues dashboard', () => {
     cy.visit('/dashboard/');
     cy.get('a[aria-current="page"]').should('not.exist');
     cy.get('a[href="/dashboard/venues"]').click();
-    cy.get('a[aria-current="page"]').should('have.text', 'Venues');
+    cy.get('a[aria-current="page"]').should('have.text', 'Venues Dashboard');
   });
 
   it('should have a table with links to view and edit venues', () => {


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

I spotted this because https://github.com/freeCodeCamp/chapter/pull/2064 and https://github.com/freeCodeCamp/chapter/pull/2000 were failing, but I think it's better a11y this way.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
