### PR TITLE
fix: make new chapters available for new events

### DIFF
--- a/client/src/modules/dashboard/Chapters/index.ts
+++ b/client/src/modules/dashboard/Chapters/index.ts
@@ -2,3 +2,4 @@ export { ChapterPage } from './pages/ChapterPage';
 export { ChaptersPage } from './pages/ChaptersPage';
 export { NewChapterPage } from './pages/NewChapterPage';
 export { EditChapterPage } from './pages/EditChapterPage';
+export { NewEventForChapterPage } from './pages/NewEventForChapterPage';

--- a/client/src/modules/dashboard/Chapters/pages/NewChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/NewChapterPage.tsx
@@ -10,12 +10,17 @@ import { DASHBOARD_CHAPTERS } from '../graphql/queries';
 import { Layout } from '../../shared/components/Layout';
 import ChapterForm from '../components/ChapterForm';
 import { NextPageWithLayout } from '../../../../pages/_app';
+import { meQuery } from 'modules/auth/graphql/queries';
 
 export const NewChapterPage: NextPageWithLayout = () => {
   const router = useRouter();
 
   const [createChapter] = useCreateChapterMutation({
-    refetchQueries: [{ query: CHAPTERS }, { query: DASHBOARD_CHAPTERS }],
+    refetchQueries: [
+      { query: CHAPTERS },
+      { query: DASHBOARD_CHAPTERS },
+      { query: meQuery },
+    ],
   });
 
   const toast = useToast();

--- a/client/src/modules/dashboard/Chapters/pages/NewEventForChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/NewEventForChapterPage.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { useParam } from '../../../../hooks/useParam';
+import { NextPageWithLayout } from '../../../../pages/_app';
+import { NewEventPage } from '../../Events/pages/NewEventPage';
+
+export const NewEventForChapterPage: NextPageWithLayout = () => {
+  const { param: chapterId } = useParam('id');
+
+  return <NewEventPage chapterId={chapterId} />;
+};

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -36,14 +36,17 @@ const EventForm: React.FC<EventFormProps> = (props) => {
     chapterId: initialChapterId,
     loadingText,
   } = props;
-  const isChaptersDropdownNeeded = initialChapterId === -1;
+  const isChaptersDropdownNeeded = typeof initialChapterId === 'undefined';
+
+  const queryOptions = isChaptersDropdownNeeded
+    ? { skip: true }
+    : { variables: { chapterId: initialChapterId } };
+
   const {
     loading: loadingChapter,
     error: errorChapter,
     data: dataChapter,
-  } = useChapterQuery({
-    variables: { chapterId: initialChapterId },
-  });
+  } = useChapterQuery(queryOptions);
 
   const sponsorQuery = useSponsorsQuery();
 

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -120,7 +120,7 @@ export interface EventFormProps {
   onSubmit: (data: EventFormData) => Promise<void>;
   data?: IEventData;
   submitText: string;
-  chapterId: number;
+  chapterId?: number;
   loadingText: string;
 }
 

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -13,11 +13,11 @@ import { EventFormData, parseEventData } from '../components/EventFormUtils';
 import { CHAPTER } from '../../../chapters/graphql/queries';
 import { DASHBOARD_EVENTS } from '../graphql/queries';
 import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
-import { useParam } from '../../../../hooks/useParam';
 import { NextPageWithLayout } from '../../../../pages/_app';
 
-export const NewEventPage: NextPageWithLayout = () => {
-  const { param: chapterId } = useParam('id');
+export const NewEventPage: NextPageWithLayout<{
+  chapterId?: number;
+}> = ({ chapterId }) => {
   const router = useRouter();
 
   const [createEvent] = useCreateEventMutation();

--- a/client/src/pages/dashboard/chapters/[id]/new-event.tsx
+++ b/client/src/pages/dashboard/chapters/[id]/new-event.tsx
@@ -1,2 +1,2 @@
-import { NewEventPage } from '../../../../modules/dashboard/Events';
-export default NewEventPage;
+import { NewEventForChapterPage } from '../../../../modules/dashboard/Chapters';
+export default NewEventForChapterPage;


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Without refetching the `meQuery`, EventChapterSelect only sees the admined_chapters of available _before_ any new chapters were created.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
