### PR TITLE
feat: add delete chapter button to edit page

### DIFF
--- a/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
+++ b/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@chakra-ui/react';
+import { Button, HStack } from '@chakra-ui/react';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -10,6 +10,7 @@ import type {
   CreateChapterInputs,
 } from '../../../../generated/graphql';
 import { useDisableWhileSubmitting } from '../../../../hooks/useDisableWhileSubmitting';
+import { DeleteChapterButton } from './DeleteChapterButton';
 
 interface ChapterFormProps {
   onSubmit: (data: CreateChapterInputs) => Promise<void>;
@@ -150,18 +151,22 @@ const ChapterForm: React.FC<ChapterFormProps> = (props) => {
           />
         ),
       )}
-      <Button
-        mt="6"
-        width="100%"
-        variant="solid"
-        colorScheme="blue"
-        type="submit"
-        isDisabled={!isDirty || loading}
-        isLoading={loading}
-        loadingText={loadingText}
-      >
-        {submitText}
-      </Button>
+      <HStack gap="1em" width="100%">
+        <Button
+          width="100%"
+          variant="solid"
+          colorScheme="blue"
+          type="submit"
+          isDisabled={!isDirty || loading}
+          isLoading={loading}
+          loadingText={loadingText}
+        >
+          {submitText}
+        </Button>
+        {chapter?.id && (
+          <DeleteChapterButton width="100%" chapterId={chapter.id} />
+        )}
+      </HStack>
     </Form>
   );
 };

--- a/client/src/modules/dashboard/Chapters/components/DeleteChapterButton.tsx
+++ b/client/src/modules/dashboard/Chapters/components/DeleteChapterButton.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useConfirmDelete } from 'chakra-confirm';
+import { useRouter } from 'next/router';
+import { Button } from '@chakra-ui/button';
+
+import { CHAPTERS } from '../../../chapters/graphql/queries';
+import { DASHBOARD_CHAPTERS } from '../graphql/queries';
+import { DASHBOARD_EVENTS } from '../../Events/graphql/queries';
+import { DASHBOARD_VENUES } from '../../Venues/graphql/queries';
+import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
+import { DATA_PAGINATED_EVENTS_TOTAL_QUERY } from '../../../events/graphql/queries';
+import { useAuth } from '../../../../modules/auth/store';
+import { checkPermission } from '../../../../util/check-permission';
+import { Permission } from '../../../../../../common/permissions';
+import { useDeleteChapterMutation } from '../../../../generated/graphql';
+
+export const DeleteChapterButton = ({ chapterId }: { chapterId: number }) => {
+  const { user } = useAuth();
+  const router = useRouter();
+  const confirmDelete = useConfirmDelete();
+
+  const [deleteChapter] = useDeleteChapterMutation({
+    refetchQueries: [
+      { query: CHAPTERS },
+      { query: DASHBOARD_CHAPTERS },
+      { query: DASHBOARD_EVENTS },
+      { query: DASHBOARD_VENUES },
+      {
+        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+        variables: { offset: 0, limit: 5 },
+      },
+      { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
+    ],
+  });
+
+  const clickDelete = async () => {
+    const ok = await confirmDelete({
+      body: 'Are you sure you want to delete this chapter? All information related to chapter will be deleted, including events and venues from this chapter. Chapter deletion cannot be reversed.',
+      buttonText: 'Delete Chapter',
+    });
+    if (!ok) return;
+    deleteChapter({ variables: { chapterId } });
+    router.push('/dashboard/chapters');
+  };
+
+  return (
+    <>
+      {checkPermission(user, Permission.ChapterDelete, { chapterId }) && (
+        <Button colorScheme="red" size="sm" onClick={clickDelete}>
+          Delete Chapter
+        </Button>
+      )}
+    </>
+  );
+};

--- a/client/src/modules/dashboard/Chapters/components/DeleteChapterButton.tsx
+++ b/client/src/modules/dashboard/Chapters/components/DeleteChapterButton.tsx
@@ -14,7 +14,15 @@ import { checkPermission } from '../../../../util/check-permission';
 import { Permission } from '../../../../../../common/permissions';
 import { useDeleteChapterMutation } from '../../../../generated/graphql';
 
-export const DeleteChapterButton = ({ chapterId }: { chapterId: number }) => {
+export const DeleteChapterButton = ({
+  chapterId,
+  size,
+  width,
+}: {
+  chapterId: number;
+  size?: string;
+  width?: string;
+}) => {
   const { user } = useAuth();
   const router = useRouter();
   const confirmDelete = useConfirmDelete();
@@ -46,7 +54,12 @@ export const DeleteChapterButton = ({ chapterId }: { chapterId: number }) => {
   return (
     <>
       {checkPermission(user, Permission.ChapterDelete, { chapterId }) && (
-        <Button colorScheme="red" size="sm" onClick={clickDelete}>
+        <Button
+          colorScheme="red"
+          size={size}
+          width={width}
+          onClick={clickDelete}
+        >
           Delete Chapter
         </Button>
       )}

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -1,69 +1,31 @@
-import { Box, Button, Heading, HStack } from '@chakra-ui/react';
+import { Box, Heading, HStack } from '@chakra-ui/react';
 import NextError from 'next/error';
-import { useRouter } from 'next/router';
 import React, { ReactElement, useMemo } from 'react';
 
-import { useConfirmDelete } from 'chakra-confirm';
 import { LinkButton } from 'chakra-next-link';
 
 import { SharePopOver } from '../../../../components/SharePopOver';
 import { Card } from '../../../../components/Card';
 import ProgressCardContent from '../../../../components/ProgressCardContent';
-import {
-  useDashboardChapterQuery,
-  useDeleteChapterMutation,
-} from '../../../../generated/graphql';
+import { useDashboardChapterQuery } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
 import styles from '../../../../styles/Page.module.css';
 import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import { EventList } from '../../shared/components/EventList';
 import { Layout } from '../../shared/components/Layout';
-import { CHAPTERS } from '../../../chapters/graphql/queries';
-import { DASHBOARD_CHAPTERS } from '../graphql/queries';
-import { DASHBOARD_EVENTS } from '../../Events/graphql/queries';
-import { DASHBOARD_VENUES } from '../../Venues/graphql/queries';
-import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
-import { DATA_PAGINATED_EVENTS_TOTAL_QUERY } from '../../../events/graphql/queries';
 import { NextPageWithLayout } from '../../../../pages/_app';
 import { useAuth } from '../../../../modules/auth/store';
 import { checkPermission } from '../../../../util/check-permission';
 import { Permission } from '../../../../../../common/permissions';
+import { DeleteChapterButton } from '../components/DeleteChapterButton';
 
 export const ChapterPage: NextPageWithLayout = () => {
   const { param: chapterId } = useParam('id');
   const { user, loadingUser } = useAuth();
 
-  const confirmDelete = useConfirmDelete();
-
-  const [deleteChapter] = useDeleteChapterMutation({
-    refetchQueries: [
-      { query: CHAPTERS },
-      { query: DASHBOARD_CHAPTERS },
-      { query: DASHBOARD_EVENTS },
-      { query: DASHBOARD_VENUES },
-      {
-        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-        variables: { offset: 0, limit: 5 },
-      },
-      { query: HOME_PAGE_QUERY, variables: { offset: 0, limit: 2 } },
-    ],
-  });
-
   const { loading, error, data } = useDashboardChapterQuery({
     variables: { chapterId },
   });
-
-  const router = useRouter();
-
-  const clickDelete = async () => {
-    const ok = await confirmDelete({
-      body: 'Are you sure you want to delete this chapter? All information related to chapter will be deleted, including events and venues from this chapter. Chapter deletion cannot be reversed.',
-      buttonText: 'Delete Chapter',
-    });
-    if (!ok) return;
-    deleteChapter({ variables: { chapterId } });
-    router.push('/dashboard/chapters');
-  };
 
   const actionLinks = [
     {
@@ -142,12 +104,7 @@ export const ChapterPage: NextPageWithLayout = () => {
               link={`${process.env.NEXT_PUBLIC_CLIENT_URL}/chapters/${chapterId}?ask_to_confirm=true`}
               size="sm"
             />
-
-            {checkPermission(user, Permission.ChapterDelete, { chapterId }) && (
-              <Button colorScheme="red" size="sm" onClick={clickDelete}>
-                Delete Chapter
-              </Button>
-            )}
+            <DeleteChapterButton chapterId={chapterId} />
           </HStack>
         </ProgressCardContent>
       </Card>

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -104,7 +104,7 @@ export const ChapterPage: NextPageWithLayout = () => {
               link={`${process.env.NEXT_PUBLIC_CLIENT_URL}/chapters/${chapterId}?ask_to_confirm=true`}
               size="sm"
             />
-            <DeleteChapterButton chapterId={chapterId} />
+            <DeleteChapterButton size="sm" chapterId={chapterId} />
           </HStack>
         </ProgressCardContent>
       </Card>

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -14,7 +14,6 @@ import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import { Layout } from '../../shared/components/Layout';
 import ChapterForm from '../components/ChapterForm';
 import { NextPageWithLayout } from '../../../../pages/_app';
-import { DeleteChapterButton } from '../components/DeleteChapterButton';
 
 export const EditChapterPage: NextPageWithLayout = () => {
   const router = useRouter();
@@ -55,7 +54,6 @@ export const EditChapterPage: NextPageWithLayout = () => {
         loadingText={'Saving Chapter Changes'}
         submitText={'Save Chapter Changes'}
       />
-      <DeleteChapterButton chapterId={chapterId} />
     </>
   );
 };

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -14,6 +14,7 @@ import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import { Layout } from '../../shared/components/Layout';
 import ChapterForm from '../components/ChapterForm';
 import { NextPageWithLayout } from '../../../../pages/_app';
+import { DeleteChapterButton } from '../components/DeleteChapterButton';
 
 export const EditChapterPage: NextPageWithLayout = () => {
   const router = useRouter();
@@ -47,12 +48,15 @@ export const EditChapterPage: NextPageWithLayout = () => {
   if (isLoading || error) return <DashboardLoading error={error} />;
 
   return (
-    <ChapterForm
-      data={data}
-      onSubmit={onSubmit}
-      loadingText={'Saving Chapter Changes'}
-      submitText={'Save Chapter Changes'}
-    />
+    <>
+      <ChapterForm
+        data={data}
+        onSubmit={onSubmit}
+        loadingText={'Saving Chapter Changes'}
+        submitText={'Save Chapter Changes'}
+      />
+      <DeleteChapterButton chapterId={chapterId} />
+    </>
   );
 };
 

--- a/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/EditChapterPage.tsx
@@ -47,14 +47,12 @@ export const EditChapterPage: NextPageWithLayout = () => {
   if (isLoading || error) return <DashboardLoading error={error} />;
 
   return (
-    <>
-      <ChapterForm
-        data={data}
-        onSubmit={onSubmit}
-        loadingText={'Saving Chapter Changes'}
-        submitText={'Save Chapter Changes'}
-      />
-    </>
+    <ChapterForm
+      data={data}
+      onSubmit={onSubmit}
+      loadingText={'Saving Chapter Changes'}
+      submitText={'Save Chapter Changes'}
+    />
   );
 };
 


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

While it is already possible to delete chapters by going to
/dashboard/chapters/[id] it's intuitively obvious that you should be
able to delete a chapter from the edit page.

We already have similar functionality for events, so this improves
consistency.

Thanks to @RafaelDavisH for the excellent feedback.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
