### PR TITLE
fix: move key prop to outer element

### DIFF
--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -13,7 +13,7 @@ import { useConfirm, useConfirmDelete } from 'chakra-confirm';
 import { DataTable } from 'chakra-data-table';
 import NextError from 'next/error';
 import { useRouter } from 'next/router';
-import React, { ReactElement } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 
 import {
   useConfirmRsvpMutation,
@@ -214,11 +214,10 @@ export const EventPage: NextPageWithLayout = () => {
               )
             : [];
           return (
-            <>
+            <Fragment key={title.toLowerCase()}>
               <Box
                 display={{ base: 'none', lg: 'block' }}
                 width="100%"
-                key={title.toLowerCase()}
                 data-cy={title.toLowerCase()}
               >
                 <DataTable
@@ -307,7 +306,7 @@ export const EventPage: NextPageWithLayout = () => {
                   </HStack>
                 ))}
               </Box>
-            </>
+            </Fragment>
           );
         })}
       </Box>


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Fixes console warning _Each child in a list should have a unique "key" prop_ by moving `key` prop to the outer element.
- Short syntax doesn't allow adding props, so changing it to `Fragment` was needed.