### PR TITLE
fix: use openssl1.1-compat to let prisma generate

### DIFF
--- a/client.Dockerfile
+++ b/client.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 as development
+FROM node:18.12 as development
 WORKDIR /usr/chapter/
 
 FROM development as build
@@ -22,7 +22,7 @@ COPY package*.json ./
 RUN npm ci -w=client --ignore-scripts
 RUN npm -w=client run build
 
-FROM node:18-alpine as production
+FROM node:18-alpine3.17 as production
 WORKDIR /usr/chapter/
 
 COPY --from=build /usr/chapter/client/.next ./client/.next

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 as development
+FROM node:18.12 as development
 WORKDIR /usr/chapter/
 
 RUN apt-get update && apt-get install netcat -y
@@ -13,7 +13,7 @@ COPY package*.json ./
 RUN npm ci -w=server --ignore-scripts --include-workspace-root
 RUN npm -w=server run build
 
-FROM node:18-alpine as production
+FROM node:18-alpine3.17 as production
 WORKDIR /usr/chapter/
 
 # Workaround for https://github.com/prisma/prisma/issues/16553 (prisma generate fails with openssl 3.0)

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -16,6 +16,9 @@ RUN npm -w=server run build
 FROM node:18-alpine as production
 WORKDIR /usr/chapter/
 
+# Workaround for https://github.com/prisma/prisma/issues/16553 (prisma generate fails with openssl 3.0)
+RUN apk add openssl1.1-compat
+
 COPY package*.json ./
 COPY server/package.json ./server/package.json
 RUN npm ci -w=server --ignore-scripts --include-workspace-root --omit=dev


### PR DESCRIPTION
Alpine now ships with openssl 3, but prisma generate requires version
1.1

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->


<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
