### PR TITLE
fix: bound cache to prevent DoS

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -212,6 +212,9 @@ export const main = async (app: Express) => {
       venues: req.venues,
     }),
     csrfPrevention: true,
+    // To prevent DoS via filling up the cache, we limit its size
+    // https://www.apollographql.com/docs/apollo-server/v3/performance/cache-backends#ensuring-a-bounded-cache
+    cache: 'bounded',
   });
 
   await server.start();


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

> Persisted queries are enabled and are using an unbounded cache. Your server is vulnerable to denial of service attacks via memory exhaustion. Set `cache: "bounded"` or `persistedQueries: false` in your ApolloServer constructor, or see https://go.apollo.dev/s/cache-backends for other alternatives.

has been showing up in the logs and this should fix the underlying issue. 

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
