### PR TITLE
chore: events resolver clean up

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -5182,55 +5182,6 @@
             "deprecationReason": null
           },
           {
-            "name": "events",
-            "description": null,
-            "args": [
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "showAll",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "EventWithRelations",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "instanceRoles",
             "description": null,
             "args": [],

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -2138,30 +2138,6 @@
         "description": null,
         "fields": [
           {
-            "name": "event_role_permissions",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "EventRolePermission",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "id",
             "description": null,
             "args": [],
@@ -2214,6 +2190,73 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EventPermission",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EventRoleWithPermissions",
+        "description": null,
+        "fields": [
+          {
+            "name": "event_role_permissions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EventRolePermission",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -2453,7 +2496,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "EventUserWithRole",
+        "name": "EventUserWithRolePermissions",
         "description": null,
         "fields": [
           {
@@ -2481,7 +2524,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "EventRole",
+                "name": "EventRoleWithPermissions",
                 "ofType": null
               }
             },
@@ -2514,6 +2557,113 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EventUserWithRsvpAndUser",
+        "description": null,
+        "fields": [
+          {
+            "name": "event_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rsvp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Rsvp",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subscribed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
                 "ofType": null
               }
             },
@@ -2767,7 +2917,290 @@
       },
       {
         "kind": "OBJECT",
-        "name": "EventWithRelations",
+        "name": "EventWithRelationsWithEventUser",
+        "description": null,
+        "fields": [
+          {
+            "name": "calendar_event_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canceled",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "capacity",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "chapter",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Chapter",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ends_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event_users",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EventUserWithRsvpAndUser",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "image_url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "invite_only",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sponsors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "EventSponsor",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "streaming_url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "venue",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Venue",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "venue_type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "VenueType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EventWithRelationsWithEventUserRelations",
         "description": null,
         "fields": [
           {
@@ -5028,7 +5461,7 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "EventWithRelations",
+              "name": "EventWithRelationsWithEventUserRelations",
               "ofType": null
             },
             "isDeprecated": false,
@@ -5151,7 +5584,7 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "EventWithRelations",
+              "name": "EventWithRelationsWithEventUser",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6466,7 +6899,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "EventRole",
+                "name": "EventRoleWithPermissions",
                 "ofType": null
               }
             },
@@ -7148,7 +7581,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "EventUserWithRole",
+                    "name": "EventUserWithRolePermissions",
                     "ofType": null
                   }
                 }

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -521,7 +521,6 @@ export type Query = {
   dashboardVenues: Array<VenueWithChapter>;
   event?: Maybe<EventWithRelations>;
   eventRoles: Array<EventRole>;
-  events: Array<EventWithRelations>;
   instanceRoles: Array<InstanceRole>;
   me?: Maybe<UserWithPermissions>;
   paginatedEvents: Array<EventWithChapter>;
@@ -565,11 +564,6 @@ export type QueryDashboardSponsorArgs = {
 
 export type QueryEventArgs = {
   id: Scalars['Int'];
-};
-
-export type QueryEventsArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  showAll?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type QueryPaginatedEventsArgs = {

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -208,7 +208,6 @@ export type EventPermission = {
 
 export type EventRole = {
   __typename?: 'EventRole';
-  event_role_permissions: Array<EventRolePermission>;
   id: Scalars['Int'];
   name: Scalars['String'];
 };
@@ -216,6 +215,13 @@ export type EventRole = {
 export type EventRolePermission = {
   __typename?: 'EventRolePermission';
   event_permission: EventPermission;
+};
+
+export type EventRoleWithPermissions = {
+  __typename?: 'EventRoleWithPermissions';
+  event_role_permissions: Array<EventRolePermission>;
+  id: Scalars['Int'];
+  name: Scalars['String'];
 };
 
 export type EventSponsor = {
@@ -242,12 +248,22 @@ export type EventUserWithRelations = {
   user_id: Scalars['Int'];
 };
 
-export type EventUserWithRole = {
-  __typename?: 'EventUserWithRole';
+export type EventUserWithRolePermissions = {
+  __typename?: 'EventUserWithRolePermissions';
   event_id: Scalars['Int'];
-  event_role: EventRole;
+  event_role: EventRoleWithPermissions;
   subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
+  user_id: Scalars['Int'];
+};
+
+export type EventUserWithRsvpAndUser = {
+  __typename?: 'EventUserWithRsvpAndUser';
+  event_id: Scalars['Int'];
+  rsvp: Rsvp;
+  subscribed: Scalars['Boolean'];
+  updated_at: Scalars['DateTime'];
+  user: User;
   user_id: Scalars['Int'];
 };
 
@@ -269,8 +285,29 @@ export type EventWithChapter = {
   venue_type: VenueType;
 };
 
-export type EventWithRelations = {
-  __typename?: 'EventWithRelations';
+export type EventWithRelationsWithEventUser = {
+  __typename?: 'EventWithRelationsWithEventUser';
+  calendar_event_id?: Maybe<Scalars['String']>;
+  canceled: Scalars['Boolean'];
+  capacity: Scalars['Int'];
+  chapter: Chapter;
+  description: Scalars['String'];
+  ends_at: Scalars['DateTime'];
+  event_users: Array<EventUserWithRsvpAndUser>;
+  id: Scalars['Int'];
+  image_url: Scalars['String'];
+  invite_only: Scalars['Boolean'];
+  name: Scalars['String'];
+  sponsors: Array<EventSponsor>;
+  start_at: Scalars['DateTime'];
+  streaming_url?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']>;
+  venue?: Maybe<Venue>;
+  venue_type: VenueType;
+};
+
+export type EventWithRelationsWithEventUserRelations = {
+  __typename?: 'EventWithRelationsWithEventUserRelations';
   calendar_event_id?: Maybe<Scalars['String']>;
   canceled: Scalars['Boolean'];
   capacity: Scalars['Int'];
@@ -515,11 +552,11 @@ export type Query = {
   chapters: Array<ChapterCardRelations>;
   dashboardChapter: ChapterWithRelations;
   dashboardChapters: Array<ChapterWithEvents>;
-  dashboardEvent?: Maybe<EventWithRelations>;
+  dashboardEvent?: Maybe<EventWithRelationsWithEventUserRelations>;
   dashboardEvents: Array<EventWithVenue>;
   dashboardSponsor: Sponsor;
   dashboardVenues: Array<VenueWithChapter>;
-  event?: Maybe<EventWithRelations>;
+  event?: Maybe<EventWithRelationsWithEventUser>;
   eventRoles: Array<EventRole>;
   instanceRoles: Array<InstanceRole>;
   me?: Maybe<UserWithPermissions>;
@@ -688,7 +725,7 @@ export type UserEvent = {
   __typename?: 'UserEvent';
   event: Event;
   event_id: Scalars['Int'];
-  event_role: EventRole;
+  event_role: EventRoleWithPermissions;
   rsvp: Rsvp;
   subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
@@ -740,7 +777,7 @@ export type UserWithPermissions = {
   name: Scalars['String'];
   user_bans: Array<UserBan>;
   user_chapters: Array<ChapterUserWithRole>;
-  user_events: Array<EventUserWithRole>;
+  user_events: Array<EventUserWithRolePermissions>;
 };
 
 export type Venue = {
@@ -867,10 +904,11 @@ export type MeQuery = {
       };
     }>;
     user_events: Array<{
-      __typename?: 'EventUserWithRole';
+      __typename?: 'EventUserWithRolePermissions';
       event_id: number;
+      subscribed: boolean;
       event_role: {
-        __typename?: 'EventRole';
+        __typename?: 'EventRoleWithPermissions';
         event_role_permissions: Array<{
           __typename?: 'EventRolePermission';
           event_permission: { __typename?: 'EventPermission'; name: string };
@@ -1299,7 +1337,7 @@ export type DashboardEventQueryVariables = Exact<{
 export type DashboardEventQuery = {
   __typename?: 'Query';
   dashboardEvent?: {
-    __typename?: 'EventWithRelations';
+    __typename?: 'EventWithRelationsWithEventUserRelations';
     id: number;
     name: string;
     description: string;
@@ -1350,15 +1388,7 @@ export type DashboardEventQuery = {
         name: string;
         image_url?: string | null;
       };
-      event_role: {
-        __typename?: 'EventRole';
-        id: number;
-        name: string;
-        event_role_permissions: Array<{
-          __typename?: 'EventRolePermission';
-          event_permission: { __typename?: 'EventPermission'; name: string };
-        }>;
-      };
+      event_role: { __typename?: 'EventRole'; id: number; name: string };
     }>;
   } | null;
 };
@@ -1667,7 +1697,7 @@ export type EventQueryVariables = Exact<{
 export type EventQuery = {
   __typename?: 'Query';
   event?: {
-    __typename?: 'EventWithRelations';
+    __typename?: 'EventWithRelationsWithEventUser';
     id: number;
     name: string;
     description: string;
@@ -1703,23 +1733,13 @@ export type EventQuery = {
       country: string;
     } | null;
     event_users: Array<{
-      __typename?: 'EventUserWithRelations';
-      subscribed: boolean;
+      __typename?: 'EventUserWithRsvpAndUser';
       rsvp: { __typename?: 'Rsvp'; name: string };
       user: {
         __typename?: 'User';
         id: number;
         name: string;
         image_url?: string | null;
-      };
-      event_role: {
-        __typename?: 'EventRole';
-        id: number;
-        name: string;
-        event_role_permissions: Array<{
-          __typename?: 'EventRolePermission';
-          event_permission: { __typename?: 'EventPermission'; name: string };
-        }>;
       };
     }>;
   } | null;
@@ -1876,7 +1896,7 @@ export type UserDownloadQuery = {
       updated_at: any;
       rsvp: { __typename?: 'Rsvp'; updated_at: any; name: string };
       event_role: {
-        __typename?: 'EventRole';
+        __typename?: 'EventRoleWithPermissions';
         name: string;
         event_role_permissions: Array<{
           __typename?: 'EventRolePermission';
@@ -2044,6 +2064,7 @@ export const MeDocument = gql`
             }
           }
         }
+        subscribed
       }
     }
   }
@@ -3693,11 +3714,6 @@ export const DashboardEventDocument = gql`
         event_role {
           id
           name
-          event_role_permissions {
-            event_permission {
-              name
-            }
-          }
         }
         subscribed
       }
@@ -4848,16 +4864,6 @@ export const EventDocument = gql`
           name
           image_url
         }
-        event_role {
-          id
-          name
-          event_role_permissions {
-            event_permission {
-              name
-            }
-          }
-        }
-        subscribed
       }
     }
   }

--- a/client/src/modules/auth/graphql/queries.ts
+++ b/client/src/modules/auth/graphql/queries.ts
@@ -40,6 +40,7 @@ export const meQuery = gql`
             }
           }
         }
+        subscribed
       }
     }
   }

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -73,11 +73,6 @@ export const DASHBOARD_EVENT = gql`
         event_role {
           id
           name
-          event_role_permissions {
-            event_permission {
-              name
-            }
-          }
         }
         subscribed
       }

--- a/client/src/modules/events/graphql/queries.ts
+++ b/client/src/modules/events/graphql/queries.ts
@@ -68,16 +68,6 @@ export const EVENT = gql`
           name
           image_url
         }
-        event_role {
-          id
-          name
-          event_role_permissions {
-            event_permission {
-              name
-            }
-          }
-        }
-        subscribed
       }
     }
   }

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -29,6 +29,7 @@ import SponsorsCard from '../../../components/SponsorsCard';
 import UserName from '../../../components/UserName';
 import { EVENT } from '../graphql/queries';
 import { DASHBOARD_EVENT } from '../../dashboard/Events/graphql/queries';
+import { meQuery } from '../../auth/graphql/queries';
 import {
   useCancelRsvpMutation,
   useEventQuery,
@@ -52,6 +53,7 @@ export const EventPage: NextPage = () => {
     refetchQueries: [
       { query: EVENT, variables: { eventId } },
       { query: DASHBOARD_EVENT, variables: { eventId } },
+      { query: meQuery },
     ],
   };
 
@@ -74,6 +76,9 @@ export const EventPage: NextPage = () => {
       ({ user: event_user }) => event_user.id === user?.id,
     );
   }, [data?.event, user]);
+  const userEvent = user?.user_events.find(
+    ({ event_id }) => event_id === eventId,
+  );
   const rsvpStatus = eventUser?.rsvp.name;
   const isLoading = loading || loadingUser;
   const canShowConfirmationModal =
@@ -304,9 +309,9 @@ export const EventPage: NextPage = () => {
             </Button>
           </HStack>
         )}
-        {eventUser && (
+        {userEvent && (
           <HStack>
-            {eventUser.subscribed ? (
+            {userEvent.subscribed ? (
               <>
                 <Text fontSize={'md'} fontWeight={'500'}>
                   You are subscribed

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -26,7 +26,8 @@ import { ResolverCtx } from '../../common-types/gql';
 import {
   Event,
   EventUserWithRelations,
-  EventWithRelations,
+  EventWithRelationsWithEventUserRelations,
+  EventWithRelationsWithEventUser,
   EventWithChapter,
   EventWithVenue,
   User,
@@ -63,11 +64,7 @@ import { EventInputs } from './inputs';
 const eventUserIncludes = {
   user: true,
   rsvp: true,
-  event_role: {
-    include: {
-      event_role_permissions: { include: { event_permission: true } },
-    },
-  },
+  event_role: true,
 };
 
 type EventWithUsers = Prisma.eventsGetPayload<{
@@ -333,27 +330,18 @@ export class EventResolver {
     });
   }
 
-  // TODO: Check we need all the returned data
   @Authorized(Permission.EventEdit)
-  @Query(() => EventWithRelations, { nullable: true })
+  @Query(() => EventWithRelationsWithEventUserRelations, { nullable: true })
   async dashboardEvent(
     @Arg('id', () => Int) id: number,
-  ): Promise<EventWithRelations | null> {
+  ): Promise<EventWithRelationsWithEventUserRelations | null> {
     return await prisma.events.findUnique({
       where: { id },
       include: {
         chapter: true,
         venue: true,
         event_users: {
-          include: {
-            user: true,
-            rsvp: true,
-            event_role: {
-              include: {
-                event_role_permissions: { include: { event_permission: true } },
-              },
-            },
-          },
+          include: eventUserIncludes,
           orderBy: { user: { name: 'asc' } },
         },
         sponsors: { include: { sponsor: true } },
@@ -379,11 +367,10 @@ export class EventResolver {
     });
   }
 
-  // TODO: Check we need all the returned data
-  @Query(() => EventWithRelations, { nullable: true })
+  @Query(() => EventWithRelationsWithEventUser, { nullable: true })
   async event(
     @Arg('id', () => Int) id: number,
-  ): Promise<EventWithRelations | null> {
+  ): Promise<EventWithRelationsWithEventUser | null> {
     return await prisma.events.findUnique({
       where: { id },
       include: {
@@ -393,11 +380,6 @@ export class EventResolver {
           include: {
             user: true,
             rsvp: true,
-            event_role: {
-              include: {
-                event_role_permissions: { include: { event_permission: true } },
-              },
-            },
           },
           orderBy: { user: { name: 'asc' } },
         },
@@ -416,9 +398,7 @@ export class EventResolver {
     const event = await prisma.events.findUniqueOrThrow({
       where: { id: eventId },
       include: {
-        event_users: {
-          include: eventUserIncludes,
-        },
+        event_users: { include: eventUserIncludes },
         venue: true,
         chapter: {
           select: {
@@ -531,9 +511,7 @@ export class EventResolver {
     const event = await prisma.events.findUniqueOrThrow({
       where: { id: eventId },
       include: {
-        event_users: {
-          include: eventUserIncludes,
-        },
+        event_users: { include: eventUserIncludes },
         venue: true,
         chapter: { select: { calendar_id: true } },
       },

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -289,38 +289,6 @@ const getNameForNewRsvp = (event: EventRsvpName) => {
 
 @Resolver()
 export class EventResolver {
-  @Query(() => [EventWithRelations])
-  async events(
-    @Arg('limit', () => Int, { nullable: true }) limit?: number,
-    @Arg('showAll', { nullable: true }) showAll?: boolean,
-  ): Promise<EventWithRelations[]> {
-    return await prisma.events.findMany({
-      where: {
-        ...(!showAll && { start_at: { gt: new Date() } }),
-      },
-      include: {
-        chapter: true,
-        venue: true,
-        event_users: {
-          include: {
-            user: true,
-            rsvp: true,
-            event_role: {
-              include: {
-                event_role_permissions: { include: { event_permission: true } },
-              },
-            },
-          },
-        },
-        sponsors: { include: { sponsor: true } }, // TODO: remove this, ideally "Omit" it, if TypeGraphQL supports that.
-      },
-      take: limit,
-      orderBy: {
-        start_at: 'asc',
-      },
-    });
-  }
-
   @Query(() => PaginatedEventsWithTotal)
   async paginatedEventsWithTotal(
     @Arg('limit', () => Int, { nullable: true }) limit?: number,

--- a/server/src/graphql-types/Event.ts
+++ b/server/src/graphql-types/Event.ts
@@ -1,7 +1,13 @@
 import { events_venue_type_enum } from '@prisma/client';
 import { ObjectType, Field, Int, registerEnumType } from 'type-graphql';
 import { BaseObject } from './BaseObject';
-import { Chapter, EventSponsor, EventUserWithRelations, Venue } from '.';
+import {
+  Chapter,
+  EventSponsor,
+  EventUserWithRelations,
+  EventUserWithRsvpAndUser,
+  Venue,
+} from '.';
 
 export { events_venue_type_enum };
 
@@ -56,6 +62,21 @@ export class EventWithChapter extends Event {
 }
 
 @ObjectType()
+export class EventWithVenue extends Event {
+  @Field(() => Venue, { nullable: true })
+  venue?: Venue | null;
+}
+
+@ObjectType()
+export class EventWithChapterAndVenue extends Event {
+  @Field(() => Chapter)
+  chapter: Chapter;
+
+  @Field(() => Venue, { nullable: true })
+  venue?: Venue | null;
+}
+
+@ObjectType()
 export class PaginatedEventsWithTotal {
   @Field(() => Int)
   total: number;
@@ -65,22 +86,19 @@ export class PaginatedEventsWithTotal {
 }
 
 @ObjectType()
-export class EventWithRelations extends Event {
-  @Field(() => Chapter)
-  chapter: Chapter;
-
+class EventRelationsWithoutEventUsers extends EventWithChapterAndVenue {
   @Field(() => [EventSponsor])
   sponsors: EventSponsor[];
-
-  @Field(() => Venue, { nullable: true })
-  venue?: Venue | null;
-
-  @Field(() => [EventUserWithRelations])
-  event_users: EventUserWithRelations[];
 }
 
 @ObjectType()
-export class EventWithVenue extends Event {
-  @Field(() => Venue, { nullable: true })
-  venue?: Venue | null;
+export class EventWithRelationsWithEventUser extends EventRelationsWithoutEventUsers {
+  @Field(() => [EventUserWithRsvpAndUser])
+  event_users: EventUserWithRsvpAndUser[];
+}
+
+@ObjectType()
+export class EventWithRelationsWithEventUserRelations extends EventRelationsWithoutEventUsers {
+  @Field(() => [EventUserWithRelations])
+  event_users: EventUserWithRelations[];
 }

--- a/server/src/graphql-types/EventReminder.ts
+++ b/server/src/graphql-types/EventReminder.ts
@@ -1,5 +1,5 @@
 import { Field, Int, ObjectType } from 'type-graphql';
-import { EventWithRelations, User } from '.';
+import { EventWithChapterAndVenue, User } from '.';
 
 @ObjectType()
 export class EventReminder {
@@ -15,8 +15,8 @@ export class EventReminder {
   @Field(() => User)
   user: User;
 
-  @Field(() => EventWithRelations)
-  event: Omit<EventWithRelations, 'sponsors' | 'event_users'>;
+  @Field(() => EventWithChapterAndVenue)
+  event: EventWithChapterAndVenue;
 
   @Field(() => Boolean)
   notifying: boolean;

--- a/server/src/graphql-types/EventUser.ts
+++ b/server/src/graphql-types/EventUser.ts
@@ -18,7 +18,10 @@ export class EventRolePermission {
 export class EventRole extends BaseObject {
   @Field(() => String)
   name: string;
+}
 
+@ObjectType()
+export class EventRoleWithPermissions extends EventRole {
   @Field(() => [EventRolePermission])
   event_role_permissions: EventRolePermission[];
 }
@@ -45,6 +48,12 @@ export class EventUserWithRole extends EventUser {
 }
 
 @ObjectType()
+export class EventUserWithRolePermissions extends EventUser {
+  @Field(() => EventRoleWithPermissions)
+  event_role: EventRoleWithPermissions;
+}
+
+@ObjectType()
 export class EventUserWithRelations extends EventUserWithRole {
   @Field(() => Rsvp)
   rsvp: Rsvp;
@@ -54,7 +63,16 @@ export class EventUserWithRelations extends EventUserWithRole {
 }
 
 @ObjectType()
-export class UserEvent extends EventUserWithRole {
+export class EventUserWithRsvpAndUser extends EventUser {
+  @Field(() => Rsvp)
+  rsvp: Rsvp;
+
+  @Field(() => User)
+  user: User;
+}
+
+@ObjectType()
+export class UserEvent extends EventUserWithRolePermissions {
   @Field(() => Rsvp)
   rsvp: Rsvp;
 

--- a/server/src/graphql-types/User.ts
+++ b/server/src/graphql-types/User.ts
@@ -3,7 +3,7 @@ import { BaseObject } from './BaseObject';
 import {
   ChapterUserWithRole,
   UserBan,
-  EventUserWithRole,
+  EventUserWithRolePermissions,
   InstanceRole,
   UserChapter,
   UserEvent,
@@ -36,8 +36,8 @@ export class UserWithPermissions extends UserWithInstanceRole {
   @Field(() => [ChapterUserWithRole])
   user_chapters: ChapterUserWithRole[];
 
-  @Field(() => [EventUserWithRole])
-  user_events: EventUserWithRole[];
+  @Field(() => [EventUserWithRolePermissions])
+  user_events: EventUserWithRolePermissions[];
 }
 
 @ObjectType()


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Removes unused query.
- Stops including event roles, and `subscribed` field of `event_user` in the event query. `subscribed` for the logged in user is taken now from `meQuery`.
- Stops the need to always include role permissions with the event user role.
  - For that was required to shuffle a bit `EventUser` object types. Naming is very rough, to not say horrible. I haven't thought of anything _better_ yet, that's not even longer.