### PR TITLE
feat: enable auto_subscribe by default

### DIFF
--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -51,7 +51,11 @@ const SubscriptionWidget = ({
   return chapterUser?.subscribed ? (
     <HStack justifyContent={'space-between'} width={'100%'}>
       <Text fontWeight={500}>Unfollow upcoming chapter&apos;s events</Text>
-      <Button onClick={() => chapterSubscribe(false)} size="md">
+      <Button
+        data-cy="unsubscribe-chapter"
+        onClick={() => chapterSubscribe(false)}
+        size="md"
+      >
         Unsubscribe
       </Button>
     </HStack>
@@ -60,6 +64,7 @@ const SubscriptionWidget = ({
       <Text fontWeight={500}>Follow upcoming chapter&apos;s events</Text>
       <Button
         colorScheme="blue"
+        data-cy="subscribe-chapter"
         onClick={() => chapterSubscribe(true)}
         size="md"
       >

--- a/client/src/modules/profiles/component/ProfileForm.tsx
+++ b/client/src/modules/profiles/component/ProfileForm.tsx
@@ -114,8 +114,8 @@ export const ProfileForm: React.FC<ProfileFormProps> = (props) => {
         </Flex>
         <FormHelperText>
           {hasAutoSubscribe
-            ? '(After joining a new chapter, you will be notified when new events are created.)'
-            : '(After joining a new chapter, you will not be notified about new events unless you subscribe.)'}
+            ? '(After joining a chapter, you will be notified about new events unless you unsubscribe.)'
+            : '(After joining a chapter, you will not be notified about new events unless you subscribe.)'}
         </FormHelperText>
       </FormControl>
       <Button

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -23,6 +23,13 @@ const getEventUsers = (eventId: number) =>
 
 export type EventUsers = Awaited<ReturnType<typeof getEventUsers>>;
 
+const deleteEventUser = async (arg: { eventId: number; userId: number }) =>
+  await prisma.event_users.delete({
+    where: { user_id_event_id: { user_id: arg.userId, event_id: arg.eventId } },
+  });
+
+export type EventUser = Awaited<ReturnType<typeof deleteEventUser>>;
+
 const getUser = async (email: string) =>
   await prisma.users.findUnique({
     where: { email },
@@ -68,6 +75,7 @@ export default defineConfig({
       });
 
       on('task', {
+        deleteEventUser,
         getChapterMembers,
         getEventUsers,
         getUser,

--- a/cypress/e2e/chapters/[chapterId].cy.ts
+++ b/cypress/e2e/chapters/[chapterId].cy.ts
@@ -25,37 +25,31 @@ describe('chapter page', () => {
 
     cy.contains(/joined chapter/);
     cy.contains(/Join chapter/).should('not.exist');
-    cy.contains(/Subscribe/);
-
-    cy.findByRole('button', { name: 'Subscribe' }).click();
+    cy.get('[data-cy="unsubscribe-chapter"]').should('be.visible').click();
     cy.findByRole('button', { name: 'Confirm' }).click();
-
-    cy.contains(/subscribed/);
 
     cy.task<ChapterMembers>('getChapterMembers', chapterId).then(
       (chapter_users) => {
         expect(
-          chapter_users.findIndex(
+          chapter_users.find(
             ({ user: { email }, subscribed }) =>
-              email === users.testUser.email && subscribed,
+              email === users.testUser.email && !subscribed,
           ),
-        ).to.not.equal(-1);
+        ).to.exist;
       },
     );
 
-    cy.contains(/Unsubscribe/);
-    cy.findByRole('button', { name: 'Unsubscribe' }).click();
+    cy.get('[data-cy="subscribe-chapter"]').should('be.visible').click();
     cy.findByRole('button', { name: 'Confirm' }).click();
 
-    cy.contains(/unsubscribed/);
     cy.task<ChapterMembers>('getChapterMembers', chapterId).then(
       (chapter_users) => {
         expect(
-          chapter_users.findIndex(
+          chapter_users.find(
             ({ user: { email }, subscribed }) =>
               email === users.testUser.email && subscribed,
           ),
-        ).to.equal(-1);
+        ).to.exist;
       },
     );
     cy.leaveChapter(chapterId, { withAuth: true }).then(expectNoErrors);

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -33,15 +33,11 @@ describe('profile page', () => {
     beforeEach(() => {
       cy.login(users.testUser.email);
     });
-    it('when enabled, should automatically subscribe when joining chapter', () => {
+    it('by default users should automatically subscribe when joining chapters', () => {
       cy.visit(profilePage);
       cy.findByRole('checkbox', {
         name: 'Subscribe to chapters when joining them',
-      }).as('switch');
-
-      cy.get('@switch').check({ force: true });
-      cy.get('@switch').should('be.checked');
-      cy.findByRole('button', { name: 'Save Profile Changes' }).click();
+      }).should('be.checked');
 
       cy.joinChapter(chapterIdToJoin);
       cy.task<ChapterMembers>('getChapterMembers', chapterIdToJoin).then(
@@ -68,9 +64,10 @@ describe('profile page', () => {
       cy.visit(profilePage);
       cy.findByRole('checkbox', {
         name: 'Subscribe to chapters when joining them',
-      }).should('not.be.checked');
-
+      }).uncheck({ force: true });
+      cy.findByRole('button', { name: 'Save Profile Changes' }).click();
       cy.joinChapter(chapterIdToJoin);
+
       cy.task<ChapterMembers>('getChapterMembers', chapterIdToJoin).then(
         (chapterUsers) =>
           checkSubscription({
@@ -81,22 +78,37 @@ describe('profile page', () => {
       );
     });
 
-    it('should not affect default subscribing to event', () => {
-      cy.joinChapter(chapterIdToJoin);
-      cy.toggleChapterSubscription(chapterIdToJoin);
-      cy.task<ChapterMembers>('getChapterMembers', chapterIdToJoin).then(
-        (chapterUsers) =>
-          checkSubscription({
-            userName: users.testUser.name,
-            users: chapterUsers,
-            status: true,
-          }),
-      );
-
+    it('users should be subscribed to events they rsvp to, regardless of auto_subscribe', () => {
+      // first with auto_subscribe enabled
       cy.visit(profilePage);
       cy.findByRole('checkbox', {
         name: 'Subscribe to chapters when joining them',
-      }).should('not.be.checked');
+      }).check({ force: true });
+
+      cy.joinChapter(chapterIdToJoin);
+      cy.rsvpToEvent({ eventId: eventIdToJoin, chapterId: chapterIdToJoin });
+      cy.task<EventUsers>('getEventUsers', eventIdToJoin).then((eventUsers) => {
+        checkSubscription({
+          userName: users.testUser.name,
+          users: eventUsers,
+          status: true,
+        });
+        const eventUser = eventUsers.find(
+          ({ user: { name } }) => name === users.testUser.name,
+        );
+        cy.task('deleteEventUser', {
+          eventId: eventIdToJoin,
+          userId: eventUser.user.id,
+        });
+      });
+
+      // now with auto_subscribe disabled
+      cy.findByRole('checkbox', {
+        name: 'Subscribe to chapters when joining them',
+      }).uncheck({ force: true });
+      // leave and rejoin chapter to clear out old subscription
+      cy.leaveChapter(chapterIdToJoin);
+      cy.joinChapter(chapterIdToJoin);
 
       cy.rsvpToEvent({ eventId: eventIdToJoin, chapterId: chapterIdToJoin });
       cy.task<EventUsers>('getEventUsers', eventIdToJoin).then((eventUsers) =>

--- a/server/prisma/migrations/20221215172150_auto_subscribe_by_default/migration.sql
+++ b/server/prisma/migrations/20221215172150_auto_subscribe_by_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "auto_subscribe" SET DEFAULT true;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -268,7 +268,7 @@ model users {
   name             String
   image_url        String?
   email            String          @unique
-  auto_subscribe   Boolean         @default(false)
+  auto_subscribe   Boolean         @default(true)
   user_bans        user_bans[]
   user_chapters    chapter_users[]
   instance_role_id Int


### PR DESCRIPTION
Since users can be invited to a chapter by shared links, they may not
realise that they can subscribe to chapters.

Since auto_subscribe can be controlled via the profile, and users can
unsubscribe easily via the links in each email it seems reasonable to
have people subscribed to chapters they join by default.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

I know we (and I) went back and forth on this on the original issue, but I'd like to try this approach. I'll check in with the test users tomorrow, but I think they're unaware that subscribing is a thing they might want to do. I'll leave this blocked until then

@gikf @allella let me know if you've had any more thoughts on this.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
