### PR TITLE
fix: remove no longer used argument

### DIFF
--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -251,14 +251,14 @@ describe('events dashboard', () => {
 
   it('chapter admin should be allowed to send email to attendees', () => {
     const eventId = 1;
-    cy.sendEventInvite(eventId, ['confirmed']).then(expectNoErrors);
+    cy.sendEventInvite(eventId).then(expectNoErrors);
 
     cy.login(users.testUser.email);
-    cy.sendEventInvite(eventId, ['confirmed']).then(expectToBeRejected);
+    cy.sendEventInvite(eventId).then(expectToBeRejected);
 
     // banned admin should be rejected
     cy.login(users.bannedAdmin.email);
-    cy.sendEventInvite(eventId, ['confirmed']).then(expectToBeRejected);
+    cy.sendEventInvite(eventId).then(expectToBeRejected);
   });
 
   it('chapter admin should see only events from admined chapters', () => {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- `cy.sendEventInvite` was updated to use only single argument.