### PR TITLE
feat: don't update calendar attendees for events in the past

### DIFF
--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -45,7 +45,7 @@ import {
   cancelEventAttendance,
   deleteCalendarEvent,
   removeEventAttendee,
-  updateCalendarEvent,
+  updateCalendarEventDetails,
 } from '../../services/Google';
 import {
   isAdminFromInstanceRole,
@@ -780,7 +780,7 @@ ${unsubscribeOptions}`,
     // TODO: warn the user if the any calendar ids are missing
     if (updatedEvent.chapter.calendar_id && updatedEvent.calendar_event_id) {
       try {
-        await updateCalendarEvent(
+        await updateCalendarEventDetails(
           {
             calendarId: updatedEvent.chapter.calendar_id,
             calendarEventId: updatedEvent.calendar_event_id,

--- a/server/src/services/Google.ts
+++ b/server/src/services/Google.ts
@@ -105,13 +105,12 @@ async function updateAttendees(
   { calendarId, calendarEventId }: EventIds,
   updateAttendees: (
     attendees?: calendar_v3.Schema$EventAttendee[],
-  ) => calendar_v3.Schema$EventAttendee[] | undefined,
+  ) => calendar_v3.Schema$EventAttendee[],
 ) {
   function updater(oldEventData: calendar_v3.Schema$Event) {
     const canUpdateAttendees =
       oldEventData.start?.dateTime &&
-      isFuture(new Date(oldEventData.start.dateTime)) &&
-      updateAttendees;
+      isFuture(new Date(oldEventData.start.dateTime));
     const attendees = canUpdateAttendees
       ? updateAttendees(oldEventData.attendees)
       : oldEventData.attendees;

--- a/server/tests/google.test.ts
+++ b/server/tests/google.test.ts
@@ -124,7 +124,7 @@ describe('Google Service', () => {
       );
     });
 
-    it('should ignore request for event in past', async () => {
+    it('should not update attendees for past events', async () => {
       mockGet.mockImplementationOnce(mockGetPastEvent);
       const updatedEvent = await removeEventAttendee(
         { calendarId: 'id', calendarEventId: 'id' },
@@ -169,7 +169,7 @@ describe('Google Service', () => {
       );
     });
 
-    it('should ignore request for event in the past', async () => {
+    it('should not update attendees for past events', async () => {
       mockGet.mockImplementationOnce(mockGetPastEvent);
       const updatedEvent = await addEventAttendee(
         { calendarId: 'id', calendarEventId: 'id' },
@@ -209,7 +209,7 @@ describe('Google Service', () => {
       );
     });
 
-    it('should ignore request for event in the past', async () => {
+    it('should not update attendees for past events', async () => {
       mockGet.mockImplementationOnce(mockGetPastEvent);
       const updatedEvent = await cancelEventAttendance(
         { calendarId: 'id', calendarEventId: 'id' },

--- a/server/tests/google.test.ts
+++ b/server/tests/google.test.ts
@@ -1,4 +1,5 @@
 import type { calendar_v3 } from '@googleapis/calendar';
+import { add, sub } from 'date-fns';
 
 import {
   addEventAttendee,
@@ -18,13 +19,23 @@ const attendees: calendar_v3.Schema$EventAttendee[] = [
   { email: 'c@person', responseStatus: 'accepted' },
 ];
 
-const mockGet = () => {
+const mockGet = jest.fn(() => {
   return {
     data: {
-      attendees: attendees,
+      start: { dateTime: add(new Date(), { days: 1 }).toISOString() },
+      attendees,
     },
   };
-};
+});
+
+const mockGetPastEvent = jest.fn(() => {
+  return {
+    data: {
+      start: { dateTime: sub(new Date(), { days: 1 }).toISOString() },
+      attendees,
+    },
+  };
+});
 
 // This just returns whatever was passed in. In reality, each attendee would
 // get a responseStatus, but we're only checking that the update is called
@@ -101,7 +112,7 @@ describe('Google Service', () => {
       { email: 'c@person', responseStatus: 'accepted' },
     ];
 
-    it('should remove the attendee from the event', async () => {
+    it('should remove the attendee from the event for future event', async () => {
       const updatedEvent = await removeEventAttendee(
         { calendarId: 'id', calendarEventId: 'id' },
         { attendeeEmail: 'b@person' },
@@ -111,6 +122,17 @@ describe('Google Service', () => {
       expect(updatedEvent.data.attendees).toEqual(
         arrayContaining(remainingAttendees),
       );
+    });
+
+    it('should ignore request for event in past', async () => {
+      mockGet.mockImplementationOnce(mockGetPastEvent);
+      const updatedEvent = await removeEventAttendee(
+        { calendarId: 'id', calendarEventId: 'id' },
+        { attendeeEmail: 'b@person' },
+      );
+
+      expect(updatedEvent.data.attendees?.length).toBe(3);
+      expect(updatedEvent.data.attendees).toEqual(arrayContaining(attendees));
     });
 
     it("should do nothing if the email is not one of the attendee's", async () => {
@@ -135,7 +157,7 @@ describe('Google Service', () => {
       expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
 
-    it('should add the attendee to the event', async () => {
+    it('should add the attendee to the event for future event', async () => {
       const updatedEvent = await addEventAttendee(
         { calendarId: 'id', calendarEventId: 'id' },
         { attendeeEmail: 'd@person' },
@@ -145,6 +167,17 @@ describe('Google Service', () => {
       expect(updatedEvent.data.attendees).toEqual(
         arrayContaining([...attendees, { email: 'd@person' }]),
       );
+    });
+
+    it('should ignore request for event in the past', async () => {
+      mockGet.mockImplementationOnce(mockGetPastEvent);
+      const updatedEvent = await addEventAttendee(
+        { calendarId: 'id', calendarEventId: 'id' },
+        { attendeeEmail: 'd@person' },
+      );
+
+      expect(updatedEvent.data.attendees?.length).toBe(3);
+      expect(updatedEvent.data.attendees).toEqual(arrayContaining(attendees));
     });
   });
 
@@ -159,7 +192,7 @@ describe('Google Service', () => {
       expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
 
-    it('should cancel (but not remove) attendance', async () => {
+    it('should cancel (but not remove) attendance for future event', async () => {
       const updatedEvent = await cancelEventAttendance(
         { calendarId: 'id', calendarEventId: 'id' },
         { attendeeEmail: 'b@person' },
@@ -173,6 +206,24 @@ describe('Google Service', () => {
       expect(updatedEvent.data.attendees?.length).toBe(3);
       expect(updatedEvent.data.attendees).toEqual(
         arrayContaining(expectedAttendees),
+      );
+    });
+
+    it('should ignore request for event in the past', async () => {
+      mockGet.mockImplementationOnce(mockGetPastEvent);
+      const updatedEvent = await cancelEventAttendance(
+        { calendarId: 'id', calendarEventId: 'id' },
+        { attendeeEmail: 'b@person' },
+      );
+
+      const expectedAttendees = [
+        ...attendees.filter((attendee) => attendee.email !== 'b@person'),
+        { email: 'b@person', responseStatus: 'declined' },
+      ];
+
+      expect(updatedEvent.data.attendees?.length).toBe(3);
+      expect(updatedEvent.data.attendees).toEqual(
+        expect.not.arrayContaining(expectedAttendees),
       );
     });
   });
@@ -192,12 +243,33 @@ describe('Google Service', () => {
         start: new Date(start),
         end: new Date(end),
         summary: 'test',
-        attendees: [{ email: 'a@person' }, { email: 'b@person' }],
       };
       const expectedRequestBody = {
         start: { dateTime: start },
         end: { dateTime: end },
         summary: 'test',
+      };
+      await createCalendarEvent({ calendarId: 'foo' }, eventData);
+
+      expect(mockInsertEvent).toHaveBeenCalledWith(
+        objectContaining({
+          requestBody: objectContaining(expectedRequestBody),
+        }),
+      );
+      expect(mockInsertEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('should include attendees details for future event', async () => {
+      const date = new Date();
+      const start = add(date, { days: 1 });
+      const end = add(date, { days: 1, minutes: 30 });
+      const eventData = {
+        start,
+        end,
+        summary: 'test',
+        attendees: [{ email: 'a@person' }, { email: 'b@person' }],
+      };
+      const expectedRequestBody = {
         attendees: [{ email: 'a@person' }, { email: 'b@person' }],
       };
       await createCalendarEvent({ calendarId: 'foo' }, eventData);
@@ -205,6 +277,25 @@ describe('Google Service', () => {
       expect(mockInsertEvent).toHaveBeenCalledWith(
         objectContaining({
           requestBody: objectContaining(expectedRequestBody),
+        }),
+      );
+      expect(mockInsertEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('should ignore attendees details for event in the past', async () => {
+      const start = '2022-12-05T14:07:12.687Z';
+      const eventData = {
+        start: new Date(start),
+        summary: 'test',
+        attendees: [{ email: 'a@person' }, { email: 'b@person' }],
+      };
+      await createCalendarEvent({ calendarId: 'foo' }, eventData);
+
+      expect(mockInsertEvent).toHaveBeenCalledWith(
+        objectContaining({
+          requestBody: expect.not.objectContaining({
+            attendees: [{ email: 'a@person' }, { email: 'b@person' }],
+          }),
         }),
       );
       expect(mockInsertEvent).toHaveBeenCalledTimes(1);

--- a/server/tests/google.test.ts
+++ b/server/tests/google.test.ts
@@ -8,7 +8,7 @@ import {
   createCalendarEvent,
   deleteCalendarEvent,
   removeEventAttendee,
-  updateCalendarEvent,
+  updateCalendarEventDetails,
 } from '../src/services/Google';
 
 const { objectContaining, arrayContaining } = expect;
@@ -302,9 +302,9 @@ describe('Google Service', () => {
     });
   });
 
-  describe('updateCalendarEvent', () => {
+  describe('updateCalendarEventDetails', () => {
     it('should update everyone and configure guest permissions', async () => {
-      await updateCalendarEvent(
+      await updateCalendarEventDetails(
         { calendarId: 'foo', calendarEventId: 'bar' },
         {},
       );
@@ -329,7 +329,7 @@ describe('Google Service', () => {
         attendees,
       };
 
-      await updateCalendarEvent(
+      await updateCalendarEventDetails(
         { calendarId: 'foo', calendarEventId: 'bar' },
         eventData,
       );

--- a/server/tests/google.test.ts
+++ b/server/tests/google.test.ts
@@ -216,15 +216,11 @@ describe('Google Service', () => {
         { attendeeEmail: 'b@person' },
       );
 
-      const expectedAttendees = [
-        ...attendees.filter((attendee) => attendee.email !== 'b@person'),
-        { email: 'b@person', responseStatus: 'declined' },
-      ];
-
       expect(updatedEvent.data.attendees?.length).toBe(3);
-      expect(updatedEvent.data.attendees).toEqual(
-        expect.not.arrayContaining(expectedAttendees),
-      );
+      expect(updatedEvent.data.attendees).not.toContainEqual({
+        email: 'b@person',
+        responseStatus: 'declined',
+      });
     });
   });
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #1661

---

- Doesn't include attendees when creating calendar event. (This must be included, as creating calendar event can happen also after creation of the event).
- Ignores all attendee changes for event in the past. Maybe it should be ignored only for adding new attendee?