### PR TITLE
feat: display only events from venue

### DIFF
--- a/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
+++ b/client/src/modules/dashboard/Venues/pages/VenuePage.tsx
@@ -38,7 +38,7 @@ export const VenuePage: NextPageWithLayout = () => {
         </ProgressCardContent>
       </Card>
       <EventList
-        title="Organized By The Venue's Chapter"
+        title="Organized At The Venue"
         events={data.venue.chapter.events}
       />
     </>

--- a/server/src/controllers/Venue/resolver.ts
+++ b/server/src/controllers/Venue/resolver.ts
@@ -56,7 +56,13 @@ export class VenueResolver {
   ): Promise<VenueWithChapterEvents | null> {
     return prisma.venues.findUnique({
       where: { id },
-      include: { chapter: { include: { events: true } } },
+      include: {
+        chapter: {
+          include: {
+            events: { where: { venue_id: id }, orderBy: { start_at: 'desc' } },
+          },
+        },
+      },
     });
   }
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Narrows events displayed in the _Venue dashboard_ to events organized at the venue. Instead of displaying all events from the chapter.
- Additionally sorts these events in the descending order by date.