### PR TITLE
feat: set profile links to fit-content in its parents

### DIFF
--- a/client/src/modules/profiles/pages/userProfile.tsx
+++ b/client/src/modules/profiles/pages/userProfile.tsx
@@ -90,7 +90,7 @@ export const UserProfilePage = () => {
               <Heading as="h2" marginBlock={'.5em'} size="md">
                 You are an administrator for these Chapters:
               </Heading>
-              <Flex marginTop={'1em'} flexDirection={'column'} gap={4}>
+              <Flex marginTop={'1em'} maxWidth={ 'fit-content'} flexDirection={'column'} gap={4}>
                 {userInfo.admined_chapters.map(({ name, id }) => (
                   <Link key={id} href={`/chapters/${id}`}>
                     {name}


### PR DESCRIPTION
maxWidth property is set to fit-content

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #2055

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
In userProfile.tsx the profile link was wrapped with a Flex component. This component had a page size width. I set it to maxWidth to fit-content