### PR TITLE
refactor: track dev authentication via local store

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -7,8 +7,13 @@ export const useLogin = () => {
   const { createSession } = useSession();
   const { refetch } = useMeQuery();
 
+  const loginHelper =
+    process.env.NEXT_PUBLIC_USE_AUTH0 !== 'false'
+      ? loginWithPopup
+      : () => localStorage.setItem('dev-login-authenticated', 'true');
+
   const login = async () => {
-    if (process.env.NEXT_PUBLIC_USE_AUTH0 !== 'false') await loginWithPopup();
+    await loginHelper();
     await createSession();
     return await refetch();
   };
@@ -21,8 +26,13 @@ export const useLogout = () => {
   const { destroySession } = useSession();
   const { refetch } = useMeQuery();
 
+  const logoutHelper =
+    process.env.NEXT_PUBLIC_USE_AUTH0 !== 'false'
+      ? logoutAuth0
+      : () => localStorage.removeItem('dev-login-authenticated');
+
   const logout = async () => {
-    if (process.env.NEXT_PUBLIC_USE_AUTH0 !== 'false') logoutAuth0();
+    logoutHelper();
     await destroySession();
     return await refetch();
   };

--- a/client/src/hooks/useSession.ts
+++ b/client/src/hooks/useSession.ts
@@ -45,14 +45,13 @@ export const useDevSession = (): {
   createSession: () => Promise<Response>;
   destroySession: () => Promise<Response>;
 } => {
+  const isAuthenticated =
+    typeof window !== 'undefined' &&
+    !!window.localStorage.getItem('dev-login-authenticated');
   const createSession = async () => await requestSession('fake-token');
 
-  // Unlike the Auth0 login, the dev login creates the session immediately when
-  // you click the login button. Since `isAuthenticated` communicates that a
-  // session can be created, we return false to stop the client from trying to
-  // create a session on every page load.
   return {
-    isAuthenticated: false,
+    isAuthenticated,
     createSession,
     destroySession,
   };


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

The difference between useAuth0Session and useDevSession had been bugging me for a while now and https://github.com/freeCodeCamp/chapter/issues/1997 highlighted that the existing approach is cumbersome.

To fix this I've put useAuth0Session and useDevSession on a similar footing: both rely on a third 'service' to tell them if a user is authenticated.


<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
