### PR TITLE
fix: overflow dashboard links

### DIFF
--- a/client/src/modules/dashboard/shared/components/Layout.tsx
+++ b/client/src/modules/dashboard/shared/components/Layout.tsx
@@ -54,16 +54,23 @@ export const Layout = ({
 
   return (
     <div data-cy={dataCy}>
-      <HStack {...rest} data-cy="dashboard-tabs" as="nav" my="2">
+      <HStack
+        {...rest}
+        as="nav"
+        data-cy="dashboard-tabs"
+        my="2"
+        overflowX="auto"
+      >
         {linksWithPermissions
           .filter((link) => !link.requiredPermission || link.hasPermission)
           .map((item) => (
             <LinkButton
-              key={item.link}
-              href={item.link}
               colorScheme={
                 router.pathname.startsWith(item.link) ? 'blue' : 'gray'
               }
+              href={item.link}
+              key={item.link}
+              minWidth="fit-content"
             >
               {item.text}{' '}
               <Text srOnly as="span">


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- In dashboard layout, links to specific pages, will now maintain minimum width and give ability to scroll when screen width is too small to fit all of them.
- I've tested this in mobile view.