### PR TITLE
feat: change gitpod 3000 port to notify onOpen

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ image:
   file: .gitpod.dockerfile
 ports:
   - port: 3000
-    onOpen: open-preview
+    onOpen: notify
   - port: 5432
     onOpen: ignore
   - port: 5000


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

The port opening always got on my nerve, this change the behaviour to notify. if someone prefers the open-preview feel free to close it.
<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
