### PR TITLE
feat: indicate ability to scroll dashboard links

### DIFF
--- a/client/src/modules/dashboard/shared/components/Layout.tsx
+++ b/client/src/modules/dashboard/shared/components/Layout.tsx
@@ -31,7 +31,7 @@ const links = [
     requiredPermission: Permission.GoogleAuthenticate,
   },
 ];
-const scrollWidth = 50;
+const scrollWidth = 150;
 
 export const Layout = ({
   children,

--- a/client/src/modules/dashboard/shared/components/Layout.tsx
+++ b/client/src/modules/dashboard/shared/components/Layout.tsx
@@ -1,14 +1,16 @@
-import { HStack, Text } from '@chakra-ui/layout';
+import { IconButton, HStack, Text } from '@chakra-ui/react';
 import { LinkButton } from 'chakra-next-link';
 import { useRouter } from 'next/router';
 import NextError from 'next/error';
-import React from 'react';
+import React, { createRef, useEffect, useState } from 'react';
 
+import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import { Permission } from '../../../../../../common/permissions';
 import { checkPermission } from '../../../../util/check-permission';
 import { Loading } from '../../../../components/Loading';
 import { useAuth } from 'modules/auth/store';
 
+const iconSize = '1.5em';
 const links = [
   { text: 'Chapters', link: '/dashboard/chapters' },
   { text: 'Events', link: '/dashboard/events' },
@@ -29,6 +31,7 @@ const links = [
     requiredPermission: Permission.GoogleAuthenticate,
   },
 ];
+const scrollWidth = 50;
 
 export const Layout = ({
   children,
@@ -39,8 +42,51 @@ export const Layout = ({
   dataCy?: string;
   [prop: string]: unknown;
 }) => {
+  const ref = createRef<HTMLDivElement>();
+  const buttonRef = createRef<HTMLButtonElement>();
   const router = useRouter();
+  const [displayLeftScroll, setDisplayLeftScroll] = useState(false);
+  const [displayRightScroll, setDisplayRightScroll] = useState(false);
+  const [leftScroll, setLeftScroll] = useState(true);
+  const [rightScroll, setRightScroll] = useState(true);
   const { user, loadingUser, isLoggedIn } = useAuth();
+
+  const updateLayout = () => {
+    if (!ref.current) return;
+
+    const widthWithButtons =
+      ref.current.scrollWidth -
+      2 * (buttonRef.current ? buttonRef.current.clientWidth : 0);
+    if (widthWithButtons > ref.current.clientWidth) {
+      setDisplayLeftScroll(true);
+      setDisplayRightScroll(true);
+    }
+    if (widthWithButtons < ref.current.clientWidth) {
+      setDisplayLeftScroll(false);
+      setDisplayRightScroll(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', updateLayout);
+  });
+
+  const setScrolls = () => {
+    if (!ref.current) return;
+
+    const div = ref.current;
+    const left = div.scrollLeft;
+    if (leftScroll && left === 0) setLeftScroll(false);
+    if (!leftScroll && left > 0) setLeftScroll(true);
+
+    const maximumLeft = div.scrollWidth - div.clientWidth;
+    if (rightScroll && left === maximumLeft) setRightScroll(false);
+    if (!rightScroll && left < maximumLeft) setRightScroll(true);
+  };
+
+  useEffect(() => {
+    if (displayLeftScroll || displayRightScroll) setScrolls();
+  }, [displayLeftScroll, displayRightScroll]);
 
   const linksWithPermissions = links.map((link) => {
     if (!link.requiredPermission) return link;
@@ -48,36 +94,62 @@ export const Layout = ({
     return { ...link, hasPermission };
   });
 
+  const scroll = (scrollToLeft: boolean, element?: HTMLDivElement | null) => {
+    if (element)
+      element.scrollBy({
+        left: scrollToLeft ? scrollWidth : -scrollWidth,
+        behavior: 'smooth',
+      });
+  };
+
   if (loadingUser) return <Loading loading={loadingUser} />;
   if (!isLoggedIn)
     return <NextError statusCode={401} title={'Log in to see this page'} />;
 
   return (
     <div data-cy={dataCy}>
-      <HStack
-        {...rest}
-        as="nav"
-        data-cy="dashboard-tabs"
-        my="2"
-        overflowX="auto"
-      >
-        {linksWithPermissions
-          .filter((link) => !link.requiredPermission || link.hasPermission)
-          .map((item) => (
-            <LinkButton
-              colorScheme={
-                router.pathname.startsWith(item.link) ? 'blue' : 'gray'
-              }
-              href={item.link}
-              key={item.link}
-              minWidth="fit-content"
-            >
-              {item.text}{' '}
-              <Text srOnly as="span">
-                Dashboard
-              </Text>
-            </LinkButton>
-          ))}
+      <HStack my="2">
+        <IconButton
+          aria-label="Scroll left"
+          icon={<ChevronLeftIcon boxSize={iconSize} />}
+          isDisabled={!leftScroll}
+          onClick={() => scroll(false, ref.current)}
+          ref={buttonRef}
+          {...(!displayLeftScroll && { display: 'none' })}
+        />
+        <HStack
+          {...rest}
+          as="nav"
+          data-cy="dashboard-tabs"
+          onScroll={() => setScrolls()}
+          overflowX="auto"
+          ref={ref}
+        >
+          {linksWithPermissions
+            .filter((link) => !link.requiredPermission || link.hasPermission)
+            .map((item) => (
+              <LinkButton
+                colorScheme={
+                  router.pathname.startsWith(item.link) ? 'blue' : 'gray'
+                }
+                href={item.link}
+                key={item.link}
+                minWidth="fit-content"
+              >
+                {item.text}{' '}
+                <Text srOnly as="span">
+                  Dashboard
+                </Text>
+              </LinkButton>
+            ))}
+        </HStack>
+        <IconButton
+          aria-label="Scroll right"
+          icon={<ChevronRightIcon boxSize={iconSize} />}
+          isDisabled={!rightScroll}
+          onClick={() => scroll(true, ref.current)}
+          {...(!displayRightScroll && { display: 'none' })}
+        />
       </HStack>
       {children}
     </div>


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Ref https://github.com/freeCodeCamp/chapter/pull/2173#discussion_r1062217658

---

- Adds buttons to mobile view of dashboard links. They are not displayed when screen size is bigger than width of the links minus 2 * button width. If links are scrolled to either side, the appropriate button is being disabled then.
![image](https://user-images.githubusercontent.com/60067306/210871767-cf3b51a0-9d13-4f6d-bb8e-787e5e9dc560.png)
- Making this a draft as it's a bit messy. But feel free to review if anything catches the eye, especially as far as the functionality goes.