### PR TITLE
feat: change chapter buttons layout to grid in the dashboard section

### DIFF
--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -149,7 +149,7 @@ export const ChapterPage: NextPageWithLayout = () => {
             </LinkButton>
           )}
           <Grid
-            gridTemplateColumns="repeat(auto-fit, minmax(6.5rem, 1fr))"
+            gridTemplateColumns="repeat(auto-fill, minmax(6.5rem, 1fr))"
             gap="1em"
           >
             {allowedActions.map(({ colorScheme, size, href, text, dataCy }) => (

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -1,8 +1,8 @@
 import {
-  Box,
   Button,
   Heading,
   HStack,
+  Grid,
   Spinner,
   Text,
   useToast,
@@ -140,13 +140,18 @@ export const ChapterPage: NextPageWithLayout = () => {
             </HStack>
           )}
           {checkPermission(user, Permission.UsersView, { chapterId }) && (
-            <Box>
-              <LinkButton href={`${chapterId}/users`} paddingBlock={'2'}>
-                Chapter Users
-              </LinkButton>
-            </Box>
+            <LinkButton
+              href={`${chapterId}/users`}
+              paddingBlock="2"
+              marginBlock="1.5em"
+            >
+              Chapter Users
+            </LinkButton>
           )}
-          <HStack mt={'2'}>
+          <Grid
+            gridTemplateColumns="repeat(auto-fit, minmax(6.5rem, 1fr))"
+            gap="1em"
+          >
             {allowedActions.map(({ colorScheme, size, href, text, dataCy }) => (
               <LinkButton
                 key={text}
@@ -158,6 +163,10 @@ export const ChapterPage: NextPageWithLayout = () => {
                 {text}
               </LinkButton>
             ))}
+            <SharePopOver
+              link={`${process.env.NEXT_PUBLIC_CLIENT_URL}/chapters/${chapterId}?ask_to_confirm=true`}
+              size="sm"
+            />
             {integrationStatus &&
               !data.dashboardChapter.calendar_id &&
               checkPermission(user, Permission.ChapterCreate, {
@@ -172,12 +181,8 @@ export const ChapterPage: NextPageWithLayout = () => {
                   Create calendar
                 </Button>
               )}
-            <SharePopOver
-              link={`${process.env.NEXT_PUBLIC_CLIENT_URL}/chapters/${chapterId}?ask_to_confirm=true`}
-              size="sm"
-            />
             <DeleteChapterButton size="sm" chapterId={chapterId} />
-          </HStack>
+          </Grid>
         </ProgressCardContent>
       </Card>
       <EventList


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

![image](https://user-images.githubusercontent.com/88248797/211198178-e65f977b-3d0e-4695-9e92-5dc0fa7a7147.png)

- changed the layout to grid, I have thought of duplicating Sanity PR, but went against it.
- moved the "create calendar" button forward to replace "delete" position, instead of "share" position. I think this may help people who used to certain layout not misclick stuff. But this maybe me overthinking.
- add some spacing to clean the cramped layout.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
