### PR TITLE
feat: refactor userProfile form submit

### DIFF
--- a/client/src/modules/chapters/chapterContext.ts
+++ b/client/src/modules/chapters/chapterContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+import { useChapterQuery } from '../../generated/graphql';
+
+const { data } = useChapterQuery({});
+
+export const ChapterCardData = createContext(data);

--- a/client/src/modules/chapters/chapterContext.ts
+++ b/client/src/modules/chapters/chapterContext.ts
@@ -1,6 +1,0 @@
-import { createContext } from 'react';
-import { useChapterQuery } from '../../generated/graphql';
-
-const { data } = useChapterQuery({});
-
-export const ChapterCardData = createContext(data);

--- a/client/src/modules/profiles/component/ProfileForm.tsx
+++ b/client/src/modules/profiles/component/ProfileForm.tsx
@@ -6,7 +6,7 @@ import {
   FormLabel,
   Switch,
 } from '@chakra-ui/react';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useForm } from 'react-hook-form';
 import { Input } from '../../../components/Form/Input';
 import { TextArea } from '../../../components/Form/TextArea';
@@ -55,16 +55,11 @@ export const ProfileForm: React.FC<ProfileFormProps> = (props) => {
   const {
     handleSubmit,
     register,
-    reset,
     watch,
     formState: { isDirty },
   } = useForm<UpdateUserInputs>({
-    defaultValues,
+    values: defaultValues,
   });
-
-  useEffect(() => {
-    reset(defaultValues);
-  }, [data]);
 
   const hasAutoSubscribe = watch('auto_subscribe');
 

--- a/client/src/modules/profiles/component/ProfileForm.tsx
+++ b/client/src/modules/profiles/component/ProfileForm.tsx
@@ -49,8 +49,10 @@ const fields: Fields[] = [
 export const ProfileForm: React.FC<ProfileFormProps> = (props) => {
   const { onSubmit, data, submitText, loadingText } = props;
 
+  const { image_url, ...rest } = data;
   const defaultValues: UpdateUserInputs = {
-    ...data,
+    image_url: image_url ?? '',
+    ...rest,
   };
   const {
     handleSubmit,


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

in this PR https://github.com/freeCodeCamp/chapter/pull/2112, react form added `value` that reset the states when run `useForm` is activated.

I have delayed looking into refactoring the form, because of the holiday, but looking at it today there wasn't much to do. I may be missing component and I may be misunderstanding the `value` property 🤔.
 

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

Ref: #1970
