### PR TITLE
feat: change eventForm CTA buttons to grid

### DIFF
--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -459,7 +459,6 @@ export type MutationDeleteRsvpArgs = {
 };
 
 export type MutationDeleteVenueArgs = {
-  _onlyUsedForAuth: Scalars['Int'];
   id: Scalars['Int'];
 };
 

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -459,6 +459,7 @@ export type MutationDeleteRsvpArgs = {
 };
 
 export type MutationDeleteVenueArgs = {
+  _onlyUsedForAuth: Scalars['Int'];
   id: Scalars['Int'];
 };
 

--- a/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
+++ b/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
@@ -7,7 +7,6 @@ import { EVENT } from '../../../events/graphql/queries';
 import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 
 interface EventCancelButtonProps {
-  isFullWidth?: boolean;
   size?: ButtonProps['size'];
   buttonText: string;
   event: Pick<Event, 'id' | 'canceled'>;
@@ -15,7 +14,7 @@ interface EventCancelButtonProps {
 }
 
 const EventCancelButton = (props: EventCancelButtonProps) => {
-  const { isDisabled = false, isFullWidth, buttonText, event, ...rest } = props;
+  const { isDisabled = false, buttonText, event, ...rest } = props;
 
   const [cancel] = useCancelEventMutation();
 
@@ -43,12 +42,7 @@ const EventCancelButton = (props: EventCancelButtonProps) => {
     }
   };
   return (
-    <Button
-      {...rest}
-      width={isFullWidth ? 'full' : 'auto'}
-      onClick={clickCancel}
-      isDisabled={isDisabled}
-    >
+    <Button {...rest} onClick={clickCancel} isDisabled={isDisabled}>
       {buttonText}
     </Button>
   );

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -183,7 +183,6 @@ const EventForm: React.FC<EventFormProps> = (props) => {
           </Button>
           {data && !data.canceled && (
             <EventCancelButton
-              isFullWidth={true}
               event={data}
               isDisabled={loading}
               buttonText="Cancel this Event"

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Heading, HStack, Text } from '@chakra-ui/react';
+import { Button, Checkbox, Heading, Grid, Text } from '@chakra-ui/react';
 import React, { useMemo } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { add } from 'date-fns';
@@ -167,9 +167,12 @@ const EventForm: React.FC<EventFormProps> = (props) => {
           </Checkbox>
         )}
 
-        <HStack width="100%" mb="10 !important">
+        <Grid
+          gridTemplateColumns="repeat(auto-fit, minmax(13rem, 1fr))"
+          width="100%"
+          gap="1em"
+        >
           <Button
-            width="full"
             colorScheme="blue"
             type="submit"
             isDisabled={!isDirty || loading}
@@ -186,7 +189,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
               buttonText="Cancel this Event"
             />
           )}
-        </HStack>
+        </Grid>
       </Form>
     </FormProvider>
   );


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

I was going to add `flexDirection` to make the buttons more responsive in mobile layout, but decided nah the grid is simpler, live is short

New 
![image](https://user-images.githubusercontent.com/88248797/211609231-6f08d762-0892-4676-8811-a76cd37f49e4.png)


Old
![image](https://user-images.githubusercontent.com/88248797/211609006-549cb045-997f-46e0-9dbd-9b35333cf7da.png)


<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
