### PR TITLE
fix: prevent double next calls in user middleware

### DIFF
--- a/server/src/controllers/Auth/middleware.ts
+++ b/server/src/controllers/Auth/middleware.ts
@@ -56,52 +56,46 @@ export type Venues = Merge<
   Prisma.venuesGetPayload<{ select: { id: true; chapter_id: true } }>[]
 >;
 
+const findAndAddUser = async (req: Request, next: NextFunction, id: number) => {
+  // While we can't make a findUnique call here (sessions.id is not in users),
+  // there is a 1-1 relationship between user and session. So, if a session
+  // exists, there can only be one user with that session.
+  const user = await prisma.users.findFirst({
+    where: { session: { id } },
+    ...userInclude,
+  });
+
+  if (!user) {
+    req.session = null;
+    return next();
+  }
+
+  const [venues, events] = await Promise.all([
+    prisma.venues.findMany({
+      select: { id: true, chapter_id: true },
+      where: {
+        chapter: { chapter_users: { some: { user_id: id } } },
+      },
+    }),
+    prisma.events.findMany({
+      select: { id: true, chapter_id: true },
+      where: { chapter: { chapter_users: { some: { user_id: id } } } },
+    }),
+  ]);
+
+  req.user = user;
+  req.venues = venues;
+  req.events = events;
+  next();
+};
+
 export const user = (req: Request, _res: Response, next: NextFunction) => {
   const id = req.session?.id;
 
   // user is not logged in, so we will not be adding user to the request and can
   // move on
   if (!id) return next();
-
-  // While we can't make a findUnique call here (sessions.id is not in users),
-  // there is a 1-1 relationship between user and session. So, if a session
-  // exists, there can only be one user with that session.
-  prisma.users
-    .findFirst({
-      where: { session: { id } },
-      ...userInclude,
-    })
-    .then((user) => {
-      if (user) {
-        req.user = user;
-        return user.id;
-      }
-      // if the session user does not exist in the db, the session is invalid
-      req.session = null;
-      next();
-    })
-    .then((id) =>
-      Promise.all([
-        prisma.venues.findMany({
-          select: { id: true, chapter_id: true },
-          where: {
-            chapter: { chapter_users: { some: { user_id: id } } },
-          },
-        }),
-        prisma.events.findMany({
-          select: { id: true, chapter_id: true },
-          where: { chapter: { chapter_users: { some: { user_id: id } } } },
-        }),
-      ]),
-    )
-    .then(([venues, events]) => {
-      req.venues = venues;
-      req.events = events;
-      next();
-    })
-    .catch((err) => {
-      next(err);
-    });
+  findAndAddUser(req, next, id);
 };
 
 export function handleError(


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

https://github.com/freeCodeCamp/chapter/pull/2181 added a bug in the client which exposed a bug in the server.

The client bug is that the client asks the server to destroy the session on page load.  I'll address this in a followup PR.

The server bug is that it's possible for the session to exist when the middleware is called, but be destroyed during the call. In this case, the middleware would see that no user existed, call next, but continue processing and call next again.

The combination of the two means that it's quite likely that the server simply crashes on page load.

