### PR TITLE
chore: query chapter venues after chapterId is available

### DIFF
--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -90,9 +90,9 @@ const EventForm: React.FC<EventFormProps> = (props) => {
   const inviteOnly = watch('invite_only');
   const chapterId = watch('chapter_id');
 
-  const chapterVenuesQuery = useChapterVenuesQuery({
-    variables: { chapterId },
-  });
+  const chapterVenuesQuery = useChapterVenuesQuery(
+    !chapterId ? { skip: true } : { variables: { chapterId } },
+  );
 
   const { loading, disableWhileSubmitting } =
     useDisableWhileSubmitting<EventFormData>({


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Skips chapter venues query when `chapterId` is falsy.