### PR TITLE
fix: consider streaming_url changed when venue_type changes

### DIFF
--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -158,7 +158,8 @@ const hasDateChanged = (data: EventInputs, event: EventWithUsers) =>
   !isEqual(data.ends_at, event.ends_at) ||
   !isEqual(data.start_at, event.start_at);
 const hasStreamingUrlChanged = (data: EventInputs, event: EventWithUsers) =>
-  isOnline(event.venue_type) && data.streaming_url !== event.streaming_url;
+  data.venue_type !== event.venue_type ||
+  (isOnline(event.venue_type) && data.streaming_url !== event.streaming_url);
 
 const buildEmailForUpdatedEvent = async (
   data: EventInputs,


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Considers `streaming_url` as changed when `venue_type` is changed. Otherwise the existing streaming url wouldn't be included in the email informing about new venue details. Ie. when event was online-only and now is changed to physical & online, email about changes would include venue location, but streaming url would get lost, making it appear as physical only event going forward.