### PR TITLE
feat: add placeholder Undecided/TBD for venue and streaming url

### DIFF
--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -56,6 +56,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
       const date = new Date();
       return {
         venue_type: VenueType.PhysicalAndOnline,
+        venue_id: 0,
         chapter_id: initialChapterId,
         start_at: add(date, { days: 1 }),
         ends_at: add(date, { days: 1, minutes: 30 }),
@@ -64,13 +65,13 @@ const EventForm: React.FC<EventFormProps> = (props) => {
     return {
       name: data.name,
       description: data.description,
-      streaming_url: data.streaming_url,
+      streaming_url: data.streaming_url ?? '',
       capacity: data.capacity,
       start_at: new Date(data.start_at),
       ends_at: new Date(data.ends_at),
       sponsors: data.sponsors,
       venue_type: data.venue_type,
-      venue_id: data.venue_id,
+      venue_id: data.venue_id ?? 0,
       image_url: data.image_url,
       invite_only: data.invite_only,
       chapter_id: initialChapterId,

--- a/client/src/modules/dashboard/Events/components/EventVenueForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventVenueForm.tsx
@@ -68,6 +68,7 @@ const EventVenueForm: React.FC<EventVenueFormProps> = ({
               {...register('venue_id' as const, { valueAsNumber: true })}
               isDisabled={loadingForm}
             >
+              <option value={0}>Undecided/TBD</option>
               {data.chapterVenues.map((v) => (
                 <option key={v.id} value={v.id}>
                   {v.name}

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -160,27 +160,30 @@ export const EventPage: NextPageWithLayout = () => {
             {endAt}
           </Text>
         </Text>
-        {isPhysical(data.dashboardEvent.venue_type) &&
-          data.dashboardEvent.venue && (
-            <>
-              <Text opacity={'.9'}>
-                Venue:{' '}
-                <Text as={'span'} fontWeight={500}>
-                  {data.dashboardEvent.venue.name}
-                </Text>
+        {isPhysical(data.dashboardEvent.venue_type) && (
+          <>
+            <Text opacity={'.9'}>
+              Venue:{' '}
+              <Text as={'span'} fontWeight={500}>
+                {data?.dashboardEvent?.venue?.name || 'Undecided/TBD'}
               </Text>
+            </Text>
+            {data.dashboardEvent.venue && (
               <Text opacity={'.9'}>
                 Hosted at:{' '}
                 <Text as={'span'} fontWeight={500}>
                   {getLocationString(data.dashboardEvent.venue, true)}
                 </Text>
               </Text>
-            </>
-          )}
-        {isOnline(data.dashboardEvent.venue_type) &&
-          data.dashboardEvent.streaming_url && (
-            <Text opacity={'.9'}>
-              Streaming Url:{' '}
+            )}
+          </>
+        )}
+        {isOnline(data.dashboardEvent.venue_type) && (
+          <Text opacity={'.9'}>
+            Streaming Url:{' '}
+            {!data.dashboardEvent.streaming_url ? (
+              'Undecided/TBD'
+            ) : (
               <Link
                 fontWeight={500}
                 href={data.dashboardEvent.streaming_url}
@@ -188,8 +191,9 @@ export const EventPage: NextPageWithLayout = () => {
               >
                 {data.dashboardEvent.streaming_url}
               </Link>
-            </Text>
-          )}
+            )}
+          </Text>
+        )}
 
         {integrationStatus !== false &&
           data.dashboardEvent.chapter.calendar_id && (

--- a/client/src/modules/dashboard/Events/pages/EventsPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventsPage.tsx
@@ -135,12 +135,12 @@ export const EventsPage: NextPageWithLayout = () => {
             'invite only': (event) => (event.invite_only ? 'Yes' : 'No'),
             venue: (event) =>
               isPhysical(event.venue_type)
-                ? event.venue?.name || ''
+                ? event.venue?.name || 'TBD'
                 : 'Online only',
             capacity: true,
             streaming_url: (event) =>
               isOnline(event.venue_type)
-                ? event.streaming_url
+                ? event.streaming_url || 'TBD'
                 : 'In-person only',
             date: (event) => formatDate(event.start_at),
             action: (event) => (

--- a/client/src/modules/dashboard/Events/pages/EventsPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventsPage.tsx
@@ -133,15 +133,21 @@ export const EventsPage: NextPageWithLayout = () => {
               </VStack>
             ),
             'invite only': (event) => (event.invite_only ? 'Yes' : 'No'),
-            venue: (event) =>
-              isPhysical(event.venue_type)
-                ? event.venue?.name || 'TBD'
-                : 'Online only',
+            venue: (event) => (
+              <Text data-cy="venue">
+                {isPhysical(event.venue_type)
+                  ? event.venue?.name || 'TBD'
+                  : 'Online only'}
+              </Text>
+            ),
             capacity: true,
-            streaming_url: (event) =>
-              isOnline(event.venue_type)
-                ? event.streaming_url || 'TBD'
-                : 'In-person only',
+            streaming_url: (event) => (
+              <Text data-cy="streamingUrl">
+                {isOnline(event.venue_type)
+                  ? event.streaming_url || 'TBD'
+                  : 'In-person only'}
+              </Text>
+            ),
             date: (event) => formatDate(event.start_at),
             action: (event) => (
               <LinkButton
@@ -245,12 +251,14 @@ export const EventsPage: NextPageWithLayout = () => {
                     <Text>{invite_only ? 'Yes' : 'No'}</Text>
                     <Text>
                       {isPhysical(venue_type)
-                        ? venue?.name || ''
+                        ? venue?.name || 'TBD'
                         : 'Online only'}
                     </Text>
                     <Text>{capacity}</Text>
                     <Text>
-                      {isOnline(venue_type) ? streaming_url : 'In-person only'}
+                      {isOnline(venue_type)
+                        ? streaming_url || 'TBD'
+                        : 'In-person only'}
                     </Text>
                     <Text>{formatDate(start_at)}</Text>
                     <LinkButton

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -154,7 +154,9 @@ describe('spec needing owner', () => {
     cy.get('@streamingUrlField').type(streamingUrl);
     saveEventChanges();
 
-    cy.get('@editedEvent').find('[data-cy="venue"]').should('contain', 'TBD');
+    cy.get('@editedEvent')
+      .find('[data-cy="venue"]')
+      .should('contain', 'Online only');
     cy.get('@editedEvent')
       .find('[data-cy="streamingUrl"]')
       .should('contain', streamingUrl);

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -157,7 +157,7 @@ describe('spec needing owner', () => {
     cy.get('@editedEvent').find('[data-cy="venue"]').should('contain', 'TBD');
     cy.get('@editedEvent')
       .find('[data-cy="streamingUrl"]')
-      .should('contain', 'In-person only');
+      .should('contain', streamingUrl);
   });
 
   it('editing event updates cached events on home page', () => {

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -218,14 +218,18 @@ ${dateChange}
 };
 
 const getUpdateData = (data: EventInputs, event: EventWithUsers) => {
-  const getVenueData = (data: EventInputs, event: EventWithUsers) => ({
-    streaming_url: isOnline(event.venue_type) ? data.streaming_url : null,
+  const getVenueData = (
+    data: EventInputs,
+    venueType: events_venue_type_enum,
+  ) => ({
+    streaming_url: isOnline(venueType) ? data.streaming_url : null,
     venue:
-      isPhysical(event.venue_type) && data.venue_id !== TBD_VENUE_ID
+      isPhysical(venueType) && data.venue_id !== TBD_VENUE_ID
         ? { connect: { id: data.venue_id } }
         : { disconnect: true },
   });
 
+  const venueType = data.venue_type ?? event.venue_type;
   const update = {
     invite_only: data.invite_only ?? event.invite_only,
     name: data.name ?? event.name,
@@ -235,8 +239,8 @@ const getUpdateData = (data: EventInputs, event: EventWithUsers) => {
     ends_at: new Date(data.ends_at) ?? event.ends_at,
     capacity: data.capacity ?? event.capacity,
     image_url: data.image_url ?? event.image_url,
-    venue_type: data.venue_type ?? event.venue_type,
-    ...getVenueData(data, event),
+    venue_type: venueType,
+    ...getVenueData(data, venueType),
   };
   return update;
 };

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -65,6 +65,7 @@ const SPACER = `<br />
 <br />
 `;
 const TBD_VENUE_ID = 0;
+const TBD = 'Undecided/TBD';
 
 const eventUserIncludes = {
   user: true,
@@ -174,7 +175,7 @@ const buildEmailForUpdatedEvent = async (
 
   const createVenueLocationContent = async () => {
     if (!data.venue_id)
-      return `Location of event is currently Undecided/TBD.${SPACER}`;
+      return `Location of event is currently ${TBD}.${SPACER}`;
 
     const venue = await prisma.venues.findUniqueOrThrow({
       where: { id: data.venue_id },
@@ -195,7 +196,7 @@ ${venue.city} <br />
   - End: ${formatDate(data.ends_at)}${SPACER}`;
   };
   const createStreamUpdate = () => {
-    return `Streaming URL: ${data.streaming_url || 'Undecided/TBD'}${SPACER}`;
+    return `Streaming URL: ${data.streaming_url || TBD}${SPACER}`;
   };
 
   const streamingUrl =
@@ -934,8 +935,7 @@ ${unsubscribeOptions}`,
     const confirmRsvpQuery = '?confirm_rsvp=true';
     const description = event.description
       ? `About the event: <br />
-    ${event.description}<br />
-    ----------------------------<br /><br />`
+    ${event.description}${SPACER}`
       : '';
 
     const subsequentEventEmail = `Upcoming event for ${
@@ -944,12 +944,16 @@ ${unsubscribeOptions}`,
     <br />
     When: ${event.start_at} to ${event.ends_at}
     <br />
-   ${event.venue ? `Where: ${event.venue.name}.<br />` : ''}
-   ${event.streaming_url ? `Streaming URL: ${event.streaming_url}<br />` : ''}
+    ${
+      isPhysical(event.venue_type) &&
+      `Where: ${event.venue?.name || TBD}.<br />`
+    }
+    ${
+      isOnline(event.venue_type) &&
+      `Streaming URL: ${event.streaming_url || TBD}<br />`
+    }
     <br />
-    Go to <a href="${eventURL}${confirmRsvpQuery}">the event page</a> to confirm your attendance.<br />
-    ----------------------------<br />
-    <br />
+    Go to <a href="${eventURL}${confirmRsvpQuery}">the event page</a> to confirm your attendance.${SPACER}
     ${description}
     View all upcoming events for ${
       event.chapter.name


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

TODO
- [x] Update invitation email.
- [x] Mobile views.
- [x] Some tests.

---

- Displays _TBD_ in `/dashboard/events`.
- Displays _Undecided/TBD_ in `/dashboard/events/{id}`.
- Adds _Undecided/TBD_ option for physical venue. Selected by default for new events.
- Adds/Fixes default values for venue and streaming url. Form correctly detects when they are changed/reverted to original value.
- Fixes inability to remove streaming url (I have some very vague recollections this might have specific intent at some point).
- Fixes inability to change from event having physical venue to online-only event. 
- Slight tune to include in email information about (changed) venue and streaming url, only if event after changes is physical and online, respectively.