### PR TITLE
feat: meet creation/removal based on venue_type

### DIFF
--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -58,6 +58,7 @@ import {
   getEventUnsubscribeOptions,
 } from '../../util/eventEmail';
 import { formatDate } from '../../util/date';
+import { isOnline, isPhysical } from '../../util/venue';
 import { EventInputs } from './inputs';
 
 const eventUserIncludes = {

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -1,12 +1,5 @@
 import { inspect } from 'util';
-import {
-  events,
-  events_venue_type_enum,
-  event_users,
-  Prisma,
-  rsvp,
-  venues,
-} from '@prisma/client';
+import { events, event_users, Prisma, rsvp, venues } from '@prisma/client';
 import { CalendarEvent, google, outlook } from 'calendar-link';
 import {
   Resolver,
@@ -77,11 +70,6 @@ type EventWithUsers = Prisma.eventsGetPayload<{
     };
   };
 }>;
-
-const isPhysical = (venue_type: events_venue_type_enum) =>
-  venue_type !== events_venue_type_enum.Online;
-const isOnline = (venue_type: events_venue_type_enum) =>
-  venue_type !== events_venue_type_enum.Physical;
 
 const sendRsvpInvitation = async (
   user: Required<ResolverCtx>['user'],
@@ -781,6 +769,10 @@ ${unsubscribeOptions}`,
 
     // TODO: warn the user if the any calendar ids are missing
     if (updatedEvent.chapter.calendar_id && updatedEvent.calendar_event_id) {
+      const createMeet =
+        isOnline(data.venue_type) && !isOnline(event.venue_type);
+      const removeMeet =
+        isOnline(event.venue_type) && !isOnline(data.venue_type);
       try {
         await updateCalendarEventDetails(
           {
@@ -791,6 +783,8 @@ ${unsubscribeOptions}`,
             summary: updatedEvent.name,
             start: updatedEvent.start_at,
             end: updatedEvent.ends_at,
+            createMeet,
+            removeMeet,
           },
         );
       } catch (e) {

--- a/server/src/services/Google.ts
+++ b/server/src/services/Google.ts
@@ -20,6 +20,7 @@ interface EventData {
   attendees?: calendar_v3.Schema$EventAttendee[];
   status?: 'cancelled';
   createMeet?: boolean;
+  removeMeet?: boolean;
 }
 
 interface CalendarId {
@@ -65,7 +66,7 @@ async function callWithHandler<T>(
 }
 
 function createEventRequestBody(
-  { attendees, start, end, summary, createMeet }: EventData,
+  { attendees, start, end, summary, createMeet, removeMeet }: EventData,
   oldEventData?: calendar_v3.Schema$Event,
 ): calendar_v3.Schema$Event {
   // Only send emails to attendees when creating or updating events in
@@ -91,6 +92,7 @@ function createEventRequestBody(
         },
       },
     }),
+    ...(removeMeet && { conferenceData: {} }),
     guestsCanSeeOtherGuests: false,
     guestsCanInviteOthers: false,
   };
@@ -115,6 +117,7 @@ async function getAndUpdateEvent(
       eventId,
       sendUpdates: 'all',
       requestBody: updater(oldEventData),
+      conferenceDataVersion: 1,
     }),
   );
 }
@@ -188,7 +191,7 @@ export async function createCalendarEvent(
     calendarApi.events.insert({
       calendarId,
       sendUpdates: 'all',
-      requestBody: createEventRequestBody({ ...eventData, createMeet: true }),
+      requestBody: createEventRequestBody(eventData),
       conferenceDataVersion: 1,
     }),
   );

--- a/server/src/util/calendar.ts
+++ b/server/src/util/calendar.ts
@@ -6,11 +6,12 @@ import { Event } from '../graphql-types';
 import { createCalendarEvent } from '../services/Google';
 import mailerService from '../services/MailerService';
 import { redactSecrets } from './redact-secrets';
+import { isOnline } from './venue';
 
 interface CreateCalendarEventData {
   attendeeEmails: string[];
   calendarId: string;
-  event: Pick<Event, 'id' | 'ends_at' | 'start_at' | 'name'>;
+  event: Pick<Event, 'id' | 'ends_at' | 'name' | 'start_at' | 'venue_type'>;
 }
 
 // TODO: consider pulling this back into the resolver (it's only used twice,
@@ -18,7 +19,7 @@ interface CreateCalendarEventData {
 export const createCalendarEventHelper = async ({
   attendeeEmails,
   calendarId,
-  event: { ends_at, id, name, start_at },
+  event: { ends_at, id, name, start_at, venue_type },
 }: CreateCalendarEventData) => {
   try {
     const { calendarEventId } = await createCalendarEvent(
@@ -30,6 +31,7 @@ export const createCalendarEventHelper = async ({
         end: ends_at,
         summary: name,
         attendees: attendeeEmails.map((email) => ({ email })),
+        createMeet: isOnline(venue_type),
       },
     );
 

--- a/server/src/util/venue.ts
+++ b/server/src/util/venue.ts
@@ -1,0 +1,7 @@
+import { events_venue_type_enum } from '@prisma/client';
+
+export const isPhysical = (venue_type: events_venue_type_enum) =>
+  venue_type !== events_venue_type_enum.Online;
+
+export const isOnline = (venue_type: events_venue_type_enum) =>
+  venue_type !== events_venue_type_enum.Physical;

--- a/server/tests/google.test.ts
+++ b/server/tests/google.test.ts
@@ -97,14 +97,6 @@ const eventCreateParams = objectContaining({
   requestBody: {
     guestsCanInviteOthers: false,
     guestsCanSeeOtherGuests: false,
-    conferenceData: {
-      createRequest: {
-        requestId: stringContaining(''),
-        conferenceSolutionKey: {
-          type: 'hangoutsMeet',
-        },
-      },
-    },
   },
   conferenceDataVersion: 1,
 });
@@ -242,7 +234,7 @@ describe('Google Service', () => {
   });
 
   describe('createCalendarEvent', () => {
-    it('should update everyone, configure guest permissions and add a meet', async () => {
+    it('should update everyone, configure guest permissions and not add a meet', async () => {
       await createCalendarEvent({ calendarId: 'foo' }, {});
 
       expect(mockInsertEvent).toHaveBeenCalledWith(eventCreateParams);
@@ -267,6 +259,50 @@ describe('Google Service', () => {
       expect(mockInsertEvent).toHaveBeenCalledWith(
         objectContaining({
           requestBody: objectContaining(expectedRequestBody),
+        }),
+      );
+      expect(mockInsertEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('when createMeet is true should include meet creation in the request to Google', async () => {
+      const eventData = { createMeet: true };
+      const expectedRequestBody = {
+        conferenceData: {
+          createRequest: {
+            requestId: stringContaining(''),
+            conferenceSolutionKey: {
+              type: 'hangoutsMeet',
+            },
+          },
+        },
+      };
+      await createCalendarEvent({ calendarId: 'foo' }, eventData);
+
+      expect(mockInsertEvent).toHaveBeenCalledWith(
+        objectContaining({
+          requestBody: objectContaining(expectedRequestBody),
+        }),
+      );
+      expect(mockInsertEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('when createMeet is false should not include meet creation in the request to Google', async () => {
+      const eventData = { createMeet: false };
+      const expectedRequestBody = {
+        conferenceData: {
+          createRequest: {
+            requestId: stringContaining(''),
+            conferenceSolutionKey: {
+              type: 'hangoutsMeet',
+            },
+          },
+        },
+      };
+      await createCalendarEvent({ calendarId: 'foo' }, eventData);
+
+      expect(mockInsertEvent).toHaveBeenCalledWith(
+        objectContaining({
+          requestBody: expect.not.objectContaining(expectedRequestBody),
         }),
       );
       expect(mockInsertEvent).toHaveBeenCalledTimes(1);
@@ -350,6 +386,96 @@ describe('Google Service', () => {
       expect(mockUpdate).toHaveBeenCalledWith(
         objectContaining({
           requestBody: objectContaining(expectedRequestBody),
+        }),
+      );
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('when createMeet is true should request meet creation in the request to Google', async () => {
+      const eventData = { createMeet: true };
+      const expectedRequestBody = {
+        conferenceData: {
+          createRequest: {
+            requestId: stringContaining(''),
+            conferenceSolutionKey: {
+              type: 'hangoutsMeet',
+            },
+          },
+        },
+      };
+
+      await updateCalendarEventDetails(
+        { calendarId: 'foo', calendarEventId: 'bar' },
+        eventData,
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        objectContaining({
+          requestBody: objectContaining(expectedRequestBody),
+        }),
+      );
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('when createMeet is false should not request meet creation in the request to Google', async () => {
+      const eventData = { createMeet: false };
+      const expectedRequestBody = {
+        conferenceData: {
+          createRequest: {
+            requestId: stringContaining(''),
+            conferenceSolutionKey: {
+              type: 'hangoutsMeet',
+            },
+          },
+        },
+      };
+
+      await updateCalendarEventDetails(
+        { calendarId: 'foo', calendarEventId: 'bar' },
+        eventData,
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        objectContaining({
+          requestBody: expect.not.objectContaining(expectedRequestBody),
+        }),
+      );
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('when removeMeet is true should request meet removal in the request to Google', async () => {
+      const eventData = { removeMeet: true };
+      const expectedRequestBody = {
+        conferenceData: {},
+      };
+
+      await updateCalendarEventDetails(
+        { calendarId: 'foo', calendarEventId: 'bar' },
+        eventData,
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        objectContaining({
+          requestBody: objectContaining(expectedRequestBody),
+        }),
+      );
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('when removeMeet is false should not request meet removal in the request to Google', async () => {
+      const eventData = { removeMeet: false };
+      const expectedRequestBody = {
+        conferenceData: {},
+      };
+
+      await updateCalendarEventDetails(
+        { calendarId: 'foo', calendarEventId: 'bar' },
+        eventData,
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        objectContaining({
+          requestBody: expect.not.objectContaining(expectedRequestBody),
         }),
       );
       expect(mockUpdate).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Ref #2200

---
- When creating event, creates meet if `venue_type` has _online venue_.
- When editing event
  - Creates meet if `venue_type` was changed _physical-only -> online venue_
  - Removes meet if `venue_type` was changed _online venue -> physical-only_