### PR TITLE
feat: update ci + prod compose files

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -20,3 +20,9 @@ services:
     environment:
       - DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@db:5432/${DB_NAME}
       - EMAIL_HOST=mailhog
+  mailhog:
+    restart: unless-stopped
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"

--- a/docker-compose.mailhog.yml
+++ b/docker-compose.mailhog.yml
@@ -1,9 +1,0 @@
-# .dev currently uses mailhog (but not postgres) hence the standalone service
-version: "3.7"
-services:
-  mailhog:
-    restart: unless-stopped
-    image: mailhog/mailhog
-    ports:
-      - "1025:1025"
-      - "8025:8025"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,8 @@
+# Use images from registry
+version: "3.7"
+services:
+  server:
+    image: camperbot/chapter-server
+
+  client:
+    image: camperbot/chapter-client

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "shx rm ./server/tsconfig.tsbuildinfo && npm run prisma -- generate",
     "gen": "npm -w=client run gen",
     "start": "docker compose -f docker-compose.yml up -d",
-    "start:ci": "docker compose -f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.mailhog.yml up -d",
+    "start:ci": "docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d",
     "stop": "docker compose down",
     "change-user": "node scripts/change-user.js",
     "change-user:banned": "npm run change-user banned@chapter.admin",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:coverage": "cross-env NODE_ENV=test npm run build",
     "clean": "shx rm ./server/tsconfig.tsbuildinfo && npm run prisma -- generate",
     "gen": "npm -w=client run gen",
-    "start": "docker compose -f docker-compose.yml up -d",
+    "start": "docker compose -f docker-compose.yml -f docker-compose.production.yml up -d",
     "start:ci": "docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d",
     "stop": "docker compose down",
     "change-user": "node scripts/change-user.js",


### PR DESCRIPTION
- refactor: combine mailhog and ci compose files
- feat: use Docker Hub images in production

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

We no longer need mailhog in staging, so we can merge that compose file into the .ci configuration.

Using a .production compose file was the simplest way I could think of to make production use the registry's images without us having to update all of the tags if we changed registry.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
