### PR TITLE
fix: allow NODE_ENV to be set to production

### DIFF
--- a/client.Dockerfile
+++ b/client.Dockerfile
@@ -18,8 +18,9 @@ COPY client ./client
 COPY common ./common
 COPY package*.json ./
 
-# Install dependencies (by default all dependencies, as long as NODE_ENV is not production)
-RUN npm ci -w=client --ignore-scripts
+# Regardless of the NODE_ENV, we need to install dev dependencies to build the
+# app. They will not be included in the final image.
+RUN npm ci -w=client --ignore-scripts --include=dev
 RUN npm -w=client run build
 
 FROM node:18-alpine3.17 as production

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "db:reset": "npm run -w=server build && npm run prisma db push && npm run prisma db seed",
     "both": "concurrently \"npm run dev:server\" \"npm run dev:client\" \"./server/wait-for localhost:5000 -- npm -w=client run gen:dev\"",
     "both:coverage": "cross-env NODE_ENV=test concurrently \"npm run dev:server:coverage\" \"npm run dev:client\" \"./server/wait-for localhost:5000 -- npm -w=client run gen:dev\"",
-    "build": "docker compose -f docker-compose.yml build",
+    "build": "cross-env NODE_ENV=production docker compose -f docker-compose.yml build",
     "build:coverage": "cross-env NODE_ENV=test npm run build",
     "clean": "shx rm ./server/tsconfig.tsbuildinfo && npm run prisma -- generate",
     "gen": "npm -w=client run gen",


### PR DESCRIPTION
NextJS expects this to be the case when building the site, but we need to make sure that the dev dependencies are installed.  The site cannot be built without them. Hence the updates to the Dockerfile.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #XXXXX

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
