### PR TITLE
fix: logo image being in the center of chaptersPage

### DIFF
--- a/client/src/modules/chapters/pages/chaptersPage.tsx
+++ b/client/src/modules/chapters/pages/chaptersPage.tsx
@@ -23,7 +23,6 @@ export const ChaptersPage: NextPage = () => {
         maxW="48em"
         mt={10}
         mb={5}
-        placeItems={'center'}
       >
         <Flex
           justifyContent={'space-between'}


### PR DESCRIPTION
Co-authored-by: gikf <60067306+gikf@users.noreply.github.com>

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Originally reported when added the logos, I thought that the cause was `Center` element, but after testing and more digging, that isn't true, and I should have investigated more instead of searching for second solution.

![image](https://user-images.githubusercontent.com/88248797/213530095-0e972ec0-c9c2-42de-9a9f-91cd2afa8260.png)


<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
