### PR TITLE
fix: ensure switch state before unchecking

### DIFF
--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -62,9 +62,12 @@ describe('profile page', () => {
 
     it('when disabled, should not automatically subscribe to chapter when joining chapter', () => {
       cy.visit(profilePage);
+      cy.contains('will be notified');
       cy.findByRole('checkbox', {
         name: 'Subscribe to chapters when joining them',
-      }).uncheck({ force: true });
+      })
+        .should('be.checked')
+        .uncheck({ force: true });
       cy.findByRole('button', { name: 'Save Profile Changes' }).click();
       cy.joinChapter(chapterIdToJoin);
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Attempt to deflake test failing due to not being able to click the _Save Profile Changes_.
- My assumption is cypress was _unchecking_ the switch too fast, before it could have been unchecked. Changes try to ensure switch state is appropriate before commencing uncheck.