### PR TITLE
fix: simplify data fetching

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -5202,13 +5202,9 @@
               }
             ],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ChapterUserWithRelations",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "ChapterUserWithRelations",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -5202,9 +5202,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "ChapterUserWithRelations",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ChapterUserWithRelations",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5719,9 +5723,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "OBJECT",
-              "name": "UserForDownload",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserForDownload",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -538,7 +538,7 @@ export type Query = {
   calendarIntegrationStatus?: Maybe<Scalars['Boolean']>;
   chapter: ChapterWithRelations;
   chapterRoles: Array<ChapterRole>;
-  chapterUser: ChapterUserWithRelations;
+  chapterUser?: Maybe<ChapterUserWithRelations>;
   chapterVenues: Array<Venue>;
   chapters: Array<ChapterCardRelations>;
   dashboardChapter: ChapterWithRelations;
@@ -974,12 +974,12 @@ export type ChapterUserQueryVariables = Exact<{
 
 export type ChapterUserQuery = {
   __typename?: 'Query';
-  chapterUser: {
+  chapterUser?: {
     __typename?: 'ChapterUserWithRelations';
     subscribed: boolean;
     user: { __typename?: 'User'; name: string };
     chapter_role: { __typename?: 'ChapterRole'; name: string };
-  };
+  } | null;
 };
 
 export type ChaptersQueryVariables = Exact<{ [key: string]: never }>;

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -538,7 +538,7 @@ export type Query = {
   calendarIntegrationStatus?: Maybe<Scalars['Boolean']>;
   chapter: ChapterWithRelations;
   chapterRoles: Array<ChapterRole>;
-  chapterUser?: Maybe<ChapterUserWithRelations>;
+  chapterUser: ChapterUserWithRelations;
   chapterVenues: Array<Venue>;
   chapters: Array<ChapterCardRelations>;
   dashboardChapter: ChapterWithRelations;
@@ -556,7 +556,7 @@ export type Query = {
   sponsorWithEvents: SponsorWithEvents;
   sponsors: Array<Sponsor>;
   tokenStatuses: Array<TokenStatus>;
-  userDownload?: Maybe<UserForDownload>;
+  userDownload: UserForDownload;
   userProfile: UserProfile;
   users: Array<UserWithInstanceRole>;
   venue?: Maybe<VenueWithChapterEvents>;
@@ -974,12 +974,12 @@ export type ChapterUserQueryVariables = Exact<{
 
 export type ChapterUserQuery = {
   __typename?: 'Query';
-  chapterUser?: {
+  chapterUser: {
     __typename?: 'ChapterUserWithRelations';
     subscribed: boolean;
     user: { __typename?: 'User'; name: string };
     chapter_role: { __typename?: 'ChapterRole'; name: string };
-  } | null;
+  };
 };
 
 export type ChaptersQueryVariables = Exact<{ [key: string]: never }>;
@@ -1830,7 +1830,7 @@ export type UserDownloadQueryVariables = Exact<{ [key: string]: never }>;
 
 export type UserDownloadQuery = {
   __typename?: 'Query';
-  userDownload?: {
+  userDownload: {
     __typename?: 'UserForDownload';
     id: number;
     name: string;
@@ -1926,7 +1926,7 @@ export type UserDownloadQuery = {
         venue_type: VenueType;
       };
     }>;
-  } | null;
+  };
 };
 
 export type UnsubscribeMutationVariables = Exact<{

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -49,7 +49,7 @@ const SubscriptionWidget = ({
   chapterSubscribe: (toSubscribe: boolean) => Promise<void>;
   loading: boolean;
 }) => {
-  return chapterUser?.subscribed ? (
+  return chapterUser.subscribed ? (
     <>
       <Text fontWeight={500}>Unfollow upcoming chapter&apos;s events</Text>
       <Button
@@ -88,7 +88,7 @@ const ChapterUserRoleWidget = ({
   loadingJoin: boolean;
   loadingLeave: boolean;
 }) =>
-  chapterUser?.chapter_role ? (
+  chapterUser.chapter_role ? (
     <>
       <Text data-cy="join-success" fontWeight={500}>
         <CheckIcon marginRight={1} />
@@ -164,7 +164,7 @@ export const ChapterPage: NextPage = () => {
         <>
           Leaving will cancel your attendance at all of this chapter&apos;s
           events.
-          {dataChapterUser?.chapterUser?.chapter_role.name ===
+          {dataChapterUser?.chapterUser.chapter_role.name ===
             'administrator' && (
             <>
               <br />

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -49,7 +49,7 @@ const SubscriptionWidget = ({
   chapterSubscribe: (toSubscribe: boolean) => Promise<void>;
   loading: boolean;
 }) => {
-  return chapterUser.subscribed ? (
+  return chapterUser?.subscribed ? (
     <>
       <Text fontWeight={500}>Unfollow upcoming chapter&apos;s events</Text>
       <Button
@@ -88,7 +88,7 @@ const ChapterUserRoleWidget = ({
   loadingJoin: boolean;
   loadingLeave: boolean;
 }) =>
-  chapterUser.chapter_role ? (
+  chapterUser?.chapter_role ? (
     <>
       <Text data-cy="join-success" fontWeight={500}>
         <CheckIcon marginRight={1} />
@@ -124,6 +124,9 @@ export const ChapterPage: NextPage = () => {
     useChapterUserQuery({
       variables: { chapterId },
     });
+
+  console.log('dataChapterUser', dataChapterUser);
+  console.log('isLoggedIn', isLoggedIn);
 
   const refetch = {
     refetchQueries: [{ query: CHAPTER_USER, variables: { chapterId } }],
@@ -164,7 +167,7 @@ export const ChapterPage: NextPage = () => {
         <>
           Leaving will cancel your attendance at all of this chapter&apos;s
           events.
-          {dataChapterUser?.chapterUser.chapter_role.name ===
+          {dataChapterUser?.chapterUser?.chapter_role.name ===
             'administrator' && (
             <>
               <br />

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -125,9 +125,6 @@ export const ChapterPage: NextPage = () => {
       variables: { chapterId },
     });
 
-  console.log('dataChapterUser', dataChapterUser);
-  console.log('isLoggedIn', isLoggedIn);
-
   const refetch = {
     refetchQueries: [{ query: CHAPTER_USER, variables: { chapterId } }],
   };

--- a/client/src/modules/home/index.tsx
+++ b/client/src/modules/home/index.tsx
@@ -62,7 +62,6 @@ const Home = () => {
         toast({ title: err.message || err.name });
       } else {
         toast({ title: 'An unexpected error occurred' });
-        console.log(err);
       }
     }
   };

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -162,14 +162,14 @@ async function emailUserAboutRoleChange({
 
 @Resolver(() => ChapterUser)
 export class ChapterUserResolver {
-  @Query(() => ChapterUserWithRelations)
+  @Query(() => ChapterUserWithRelations, { nullable: true })
   async chapterUser(
     @Arg('chapterId', () => Int) chapterId: number,
     @Ctx() ctx: ResolverCtx,
-  ): Promise<ChapterUserWithRelations> {
+  ): Promise<ChapterUserWithRelations | null> {
     if (!ctx.user) throw Error('User not found');
 
-    return await prisma.chapter_users.findUniqueOrThrow({
+    return await prisma.chapter_users.findUnique({
       include: chapterUsersInclude,
       where: {
         user_id_chapter_id: { user_id: ctx.user.id, chapter_id: chapterId },

--- a/server/src/controllers/User/resolver.ts
+++ b/server/src/controllers/User/resolver.ts
@@ -37,7 +37,8 @@ export class UserWithPermissionsResolver {
   }
 
   @Query(() => UserProfile)
-  async userProfile(@Ctx() ctx: Required<ResolverCtx>): Promise<UserProfile> {
+  async userProfile(@Ctx() ctx: ResolverCtx): Promise<UserProfile> {
+    if (!ctx.user) throw Error('User not found');
     return await prisma.users.findUniqueOrThrow({
       where: {
         id: ctx.user.id,
@@ -54,10 +55,10 @@ export class UserWithPermissionsResolver {
     });
   }
 
-  @Query(() => UserForDownload, { nullable: true })
-  async userDownload(@Ctx() ctx: ResolverCtx): Promise<UserForDownload | null> {
-    if (!ctx.user) return null;
-    return await prisma.users.findUnique({
+  @Query(() => UserForDownload)
+  async userDownload(@Ctx() ctx: ResolverCtx): Promise<UserForDownload> {
+    if (!ctx.user) throw Error('User not found');
+    return await prisma.users.findUniqueOrThrow({
       where: {
         id: ctx.user.id,
       },
@@ -104,7 +105,8 @@ export class UserWithPermissionsResolver {
   }
 
   @Mutation(() => User)
-  async toggleAutoSubscribe(@Ctx() ctx: Required<ResolverCtx>): Promise<User> {
+  async toggleAutoSubscribe(@Ctx() ctx: ResolverCtx): Promise<User> {
+    if (!ctx.user) throw Error('User not found');
     return await prisma.users.update({
       data: { auto_subscribe: !ctx.user.auto_subscribe },
       where: { id: ctx.user.id },
@@ -113,9 +115,10 @@ export class UserWithPermissionsResolver {
 
   @Mutation(() => User)
   async updateMe(
-    @Ctx() ctx: Required<ResolverCtx>,
+    @Ctx() ctx: ResolverCtx,
     @Arg('data') data: UpdateUserInputs,
   ): Promise<User | undefined> {
+    if (!ctx.user) throw Error('User not found');
     const UserData: Prisma.usersUpdateInput = data;
     return await prisma.users.update({
       where: { id: ctx.user.id },
@@ -124,7 +127,8 @@ export class UserWithPermissionsResolver {
   }
 
   @Mutation(() => User)
-  async deleteMe(@Ctx() ctx: Required<ResolverCtx>): Promise<User | undefined> {
+  async deleteMe(@Ctx() ctx: ResolverCtx): Promise<User | undefined> {
+    if (!ctx.user) throw Error('User not found');
     return await prisma.users.delete({ where: { id: ctx.user.id } });
   }
 }


### PR DESCRIPTION
Rather than handling null results when the user is required and not
logged in, it's simpler (and more appropriate) to throw errors. Ideally
before querying the db, since we know that query will fail.

The rationale is that these are bad requests and should be treated as
errors. This benefit is that it simplifies the client logic by removing
some null checking.

~~I'll address me() in a separate commit.~~

The meQuery is a special case. Until the client makes a request to the
api it cannot know if it is logged in or not (since the session cookie
determines this and it is httponly). Treating unauthenticated requests
as errors seems wrong, in that case.

In all other cases the client can first check if the user is logged in
before initiating the request.

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->



<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
