### PR TITLE
fix: limit unhelpful errors

### DIFF
--- a/server/src/util/eventEmail.ts
+++ b/server/src/util/eventEmail.ts
@@ -10,12 +10,11 @@ export const chapterUnsubscribeOptions = ({
   chapterId: number;
   userId: number;
 }) => {
+  const url = unsubscribeUrlFromToken(
+    generateToken(UnsubscribeType.Chapter, chapterId, userId),
+  );
   return `<br />
-  - To stop receiving notifications about new events in this chapter, <a href="${generateToken(
-    UnsubscribeType.Chapter,
-    chapterId,
-    userId,
-  )}">unsubscribe here</a>.`;
+  - To stop receiving notifications about new events in this chapter, <a href="${url}">unsubscribe here</a>.`;
 };
 
 export const eventUnsubscribeOptions = ({

--- a/server/src/util/eventEmail.ts
+++ b/server/src/util/eventEmail.ts
@@ -1,6 +1,24 @@
 import { generateToken, UnsubscribeType } from '../services/UnsubscribeToken';
 
-export const getEventUnsubscribeOptions = ({
+const unsubscribeUrlFromToken = (token: string) =>
+  `${process.env.CLIENT_LOCATION}/unsubscribe?token=${token}`;
+
+export const chapterUnsubscribeOptions = ({
+  chapterId,
+  userId,
+}: {
+  chapterId: number;
+  userId: number;
+}) => {
+  return `<br />
+  - To stop receiving notifications about new events in this chapter, <a href="${generateToken(
+    UnsubscribeType.Chapter,
+    chapterId,
+    userId,
+  )}">unsubscribe here</a>.`;
+};
+
+export const eventUnsubscribeOptions = ({
   chapterId,
   eventId,
   userId,
@@ -9,29 +27,30 @@ export const getEventUnsubscribeOptions = ({
   eventId: number;
   userId: number;
 }) => {
-  const chapterUnsubscribeToken = generateToken(
-    UnsubscribeType.Chapter,
-    chapterId,
-    userId,
-  );
   const eventUnsubscribeToken = generateToken(
     UnsubscribeType.Event,
     eventId,
     userId,
   );
-  const linkToEvent = `${process.env.CLIENT_LOCATION}/unsubscribe?token=${eventUnsubscribeToken}`;
-  const linkToChapter = `${process.env.CLIENT_LOCATION}/unsubscribe?token=${chapterUnsubscribeToken}`;
+  const linkForEvent = unsubscribeUrlFromToken(eventUnsubscribeToken);
+  const chapterUnsubscribe = chapterUnsubscribeOptions({ chapterId, userId });
   return `<br />
-  - To stop receiving notifications about this event, <a href="${linkToEvent}">unsubscribe here</a>.<br />
-  - To stop receiving notifications about new events in this chapter, <a href="${linkToChapter}">unsubscribe here</a>.<br />`;
+  - To stop receiving notifications about this event, <a href="${linkForEvent}">unsubscribe here</a>.${chapterUnsubscribe}`;
 };
 
-export const getChapterUnsubscribeOptions = ({
+export const chapterAdminUnsubscribeOptions = ({
   chapterId,
   userId,
 }: {
   chapterId: number;
   userId: number;
 }) => {
-  generateToken(UnsubscribeType.Chapter, chapterId, userId);
+  const chapterUnsubscribeToken = generateToken(
+    UnsubscribeType.Chapter,
+    chapterId,
+    userId,
+  );
+  return `<br /><a href="${unsubscribeUrlFromToken(
+    chapterUnsubscribeToken,
+  )}">Unsubscribe from chapter emails</a>`;
 };


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #2215

---
- Catches `RECORD_MISSING`. Whatever the reason there's no such subscription, technically that's being unsubscribed. It happens only if:
  - `event_users` entry doesn't exist - user never rsvped to the event.
  - `chapter_users` entry doesn't exist - user is not a part of chapter (anymore or yet).
- Event invite has only chapter unsubscribe option.
- Some shuffling, renaming and moving around the unsubscribe options functions.