### PR TITLE
fix: always display loading error

### DIFF
--- a/client/src/components/Loading.tsx
+++ b/client/src/components/Loading.tsx
@@ -3,15 +3,10 @@ import React from 'react';
 import { Spinner } from '@chakra-ui/react';
 
 type Props = {
-  loading: boolean;
   error?: Error;
 };
 
-export const Loading = ({ loading, error }: Props) => {
-  if (loading) {
-    return <Spinner />;
-  }
-
+export const Loading = ({ error }: Props) => {
   if (error) {
     return (
       <div>
@@ -19,7 +14,6 @@ export const Loading = ({ loading, error }: Props) => {
         <h2>{error?.message}</h2>
       </div>
     );
-  } else {
-    return null;
   }
+  return <Spinner />;
 };

--- a/client/src/modules/chapters/pages/chapterPage.tsx
+++ b/client/src/modules/chapters/pages/chapterPage.tsx
@@ -240,7 +240,7 @@ export const ChapterPage: NextPage = () => {
     }
   }, [canShowConfirmModal, isAlreadyMember, hasShownModal]);
 
-  if (isLoading || error) return <Loading loading={isLoading} error={error} />;
+  if (isLoading || error) return <Loading error={error} />;
   if (!data.chapter)
     return <NextError statusCode={404} title="Chapter not found" />;
 

--- a/client/src/modules/chapters/pages/chaptersPage.tsx
+++ b/client/src/modules/chapters/pages/chaptersPage.tsx
@@ -13,7 +13,7 @@ export const ChaptersPage: NextPage = () => {
   const { loading, error, data } = useChaptersQuery();
   const { user } = useUser();
   const isLoading = loading || !data;
-  if (isLoading || error) return <Loading loading={isLoading} error={error} />;
+  if (isLoading || error) return <Loading error={error} />;
 
   return (
     <Center>

--- a/client/src/modules/dashboard/shared/components/DashboardLayout.tsx
+++ b/client/src/modules/dashboard/shared/components/DashboardLayout.tsx
@@ -94,7 +94,7 @@ export const DashboardLayout = ({
     ref.current.scrollBy({ left: scrollBy, behavior: 'smooth' });
   };
 
-  if (loadingUser) return <Loading loading={loadingUser} />;
+  if (loadingUser) return <Loading />;
   if (!isLoggedIn)
     return <NextError statusCode={401} title={'Log in to see this page'} />;
 

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -199,7 +199,7 @@ export const EventPage: NextPage = () => {
     }
   }, [hasShownModal, canShowConfirmationModal, rsvpStatus]);
 
-  if (error || isLoading) return <Loading loading={isLoading} error={error} />;
+  if (error || isLoading) return <Loading error={error} />;
   if (!data?.event)
     return <NextError statusCode={404} title="Event not found" />;
 

--- a/client/src/modules/events/pages/eventsPage.tsx
+++ b/client/src/modules/events/pages/eventsPage.tsx
@@ -74,7 +74,7 @@ export const EventsPage: NextPage = () => {
   }, [currentPage]);
 
   const isLoading = loading || !data;
-  if (isLoading || error) return <Loading loading={isLoading} error={error} />;
+  if (isLoading || error) return <Loading error={error} />;
 
   return (
     <VStack>

--- a/client/src/modules/home/index.tsx
+++ b/client/src/modules/home/index.tsx
@@ -67,7 +67,7 @@ const Home = () => {
   };
 
   const isLoading = loading || !data;
-  if (isLoading || error) return <Loading loading={isLoading} error={error} />;
+  if (isLoading || error) return <Loading error={error} />;
 
   return (
     <>

--- a/client/src/modules/profiles/pages/userProfile.tsx
+++ b/client/src/modules/profiles/pages/userProfile.tsx
@@ -36,7 +36,7 @@ const createDataUrl = (userData: UserDownloadQuery['userDownload']) => {
 const RequireLogin = ({ children }: { children: React.ReactNode }) => {
   const { isLoggedIn, loadingUser } = useUser();
 
-  if (loadingUser) return <Loading loading={loadingUser} />;
+  if (loadingUser) return <Loading />;
   if (!isLoggedIn)
     return <NextError statusCode={401} title={'Log in to see this page'} />;
 
@@ -88,7 +88,7 @@ const UserProfile = () => {
   };
 
   const isLoading = loading || !data;
-  if (isLoading || error) return <Loading loading={isLoading} error={error} />;
+  if (isLoading || error) return <Loading error={error} />;
   const userInfo = data.userProfile;
 
   return (


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Fixes case when spinner would be displayed despite of error, passed in loading not necessarily is changed to `false` when error is present.