### PR TITLE
feat: retry requests on network errors

### DIFF
--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import {
 } from '@apollo/client';
 import { NetworkError } from '@apollo/client/errors';
 import { onError } from '@apollo/client/link/error';
+import { RetryLink } from '@apollo/client/link/retry';
 import { offsetLimitPagination } from '@apollo/client/utilities';
 import { ChakraProvider } from '@chakra-ui/react';
 import { ConfirmContextProvider } from 'chakra-confirm';
@@ -49,8 +50,10 @@ const errorLink = onError(({ networkError }) => {
   }
 });
 
+const retryLink = new RetryLink();
+
 const client = new ApolloClient({
-  link: from([errorLink, httpLink]),
+  link: from([retryLink, errorLink, httpLink]),
   cache: new InMemoryCache({
     typePolicies: {
       Query: {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #415

---

- Adds RetryLink (https://www.apollographql.com/docs/react/api/link/apollo-link-retry/) to automatically retry requests on network errors. By default that's `5` tries.
- This will handle basic case from the related issue, when wild CORS error can appear during development, when client tries to open page while server restarts.