### PR TITLE
fix: only require chrome users to logout once

### DIFF
--- a/client/src/hooks/useSession.ts
+++ b/client/src/hooks/useSession.ts
@@ -60,5 +60,5 @@ export const useSession = () => {
     }
   }, [isAuthenticated, canAlterSession]);
 
-  return { createSession, login, logout, isAuthenticated };
+  return { login, logout, isAuthenticated };
 };

--- a/client/src/hooks/useSession.ts
+++ b/client/src/hooks/useSession.ts
@@ -37,28 +37,33 @@ export const useSession = () => {
   // Until the user initiates a login or logout, we don't want to create or
   // destroy a session
   const [canAlterSession, setCanAlterSession] = useState(false);
+  // isAuthenticated does not change immediately after login/logout, so we
+  // need to track the intent to prevent accidental session creation/deletion
+  const [toLogout, setToLogout] = useState(false);
 
   const login = async () => {
     await loginAuth();
     setCanAlterSession(true);
+    setToLogout(false);
   };
   const logout = async () => {
     await logoutAuth();
     setCanAlterSession(true);
+    setToLogout(true);
   };
 
   useEffect(() => {
     if (!canAlterSession) return;
     setCanAlterSession(false);
 
-    if (isAuthenticated) {
-      createSession().then(() => refetch());
-    } else {
+    if (toLogout) {
       destroySession()
         .then(() => refetch())
         .then(() => apollo.resetStore());
+    } else if (isAuthenticated) {
+      createSession().then(() => refetch());
     }
-  }, [isAuthenticated, canAlterSession]);
+  }, [isAuthenticated, canAlterSession, toLogout]);
 
   return { login, logout, isAuthenticated };
 };

--- a/client/src/modules/auth/user.tsx
+++ b/client/src/modules/auth/user.tsx
@@ -22,29 +22,16 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     loadingUser: true,
     isLoggedIn: false,
   });
-  const { loading: loadingMe, error, data: meData, refetch } = useMeQuery();
-  const { isAuthenticated, createSession } = useSession();
-
-  const tryToCreateSession = async () => {
-    if (isAuthenticated) {
-      const { status } = await createSession();
-      if (status === 200) refetch();
-    }
-  };
+  const { loading: loadingMe, error, data: meData } = useMeQuery();
+  const { isAuthenticated } = useSession();
 
   useEffect(() => {
-    if (!loadingMe && !error) {
-      if (meData)
-        setData({
-          user: meData.me,
-          loadingUser: false,
-          isLoggedIn: !!meData.me,
-        });
-      // If there is no user data, either the user doesn't have a session or
-      // they don't exist. Since we can't tell the difference, we have to try to
-      // create a session.
-      if (!meData?.me) tryToCreateSession();
-    }
+    if (!loadingMe && !error && meData)
+      setData({
+        user: meData.me,
+        loadingUser: false,
+        isLoggedIn: !!meData.me,
+      });
   }, [loadingMe, error, meData, isAuthenticated]);
 
   return (


### PR DESCRIPTION
- feat: stop trying to regenerate session

It's only useful in the weird edge case where a user has deleted their
session cookie, but not their auth0 cookies. In this case, they can just
login again.
- fix: only require single logout request on Chrome

Some browsers (such as Brave) delete third party cookies after when the
page unloads (i.e. refresh or tab closing). Chrome, however, does not
and this means that isAuthenticated is true when useSession checks to
see if it should create or destroy the session.

By specifying the intent, we can ensure the session is deleted on logout

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->



<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
