### PR TITLE
fix: make users-view just an instance permission again

### DIFF
--- a/client/src/components/PageLayout/Header.tsx
+++ b/client/src/components/PageLayout/Header.tsx
@@ -21,7 +21,7 @@ import { useUser } from '../../modules/auth/user';
 import { useSession } from '../../hooks/useSession';
 import { Permission } from '../../../../common/permissions';
 import { HeaderContainer } from './component/HeaderContainer';
-import { checkPermission } from 'util/check-permission';
+import { checkInstancePermission } from 'util/check-permission';
 
 const menuButtonStyles = {
   logout: { backgroundColor: 'gray.10' },
@@ -135,7 +135,10 @@ export const Header: React.FC = () => {
                             Profile
                           </MenuItem>
                         </NextLink>
-                        {checkPermission(user, Permission.ChaptersView) && (
+                        {checkInstancePermission(
+                          user,
+                          Permission.ChaptersView,
+                        ) && (
                           <NextLink passHref href="/dashboard/chapters">
                             <MenuItem data-cy="menu-dashboard-link" as="a">
                               Dashboard

--- a/client/src/components/PageLayout/index.tsx
+++ b/client/src/components/PageLayout/index.tsx
@@ -11,14 +11,14 @@ import { SkipNavContent } from '@chakra-ui/skip-nav';
 import Link from 'next/link';
 import { useCalendarIntegrationStatusQuery } from '../../generated/graphql';
 import { useUser } from '../../modules/auth/user';
-import { checkPermission } from '../../util/check-permission';
+import { checkInstancePermission } from '../../util/check-permission';
 import { Permission } from '../../../../common/permissions';
 import { Header } from './Header';
 import { Footer } from './component/Footer';
 
 const PageLayout = ({ children }: { children: React.ReactNode }) => {
   const { user } = useUser();
-  const canAuthenticateWithGoogle = checkPermission(
+  const canAuthenticateWithGoogle = checkInstancePermission(
     user,
     Permission.GoogleAuthenticate,
   );

--- a/client/src/modules/chapters/pages/chaptersPage.tsx
+++ b/client/src/modules/chapters/pages/chaptersPage.tsx
@@ -6,7 +6,7 @@ import { ChapterCard } from '../../../components/ChapterCard';
 import { useChaptersQuery } from '../../../generated/graphql';
 import { Loading } from '../../../components/Loading';
 import { useUser } from '../../auth/user';
-import { checkPermission } from '../../../util/check-permission';
+import { checkInstancePermission } from '../../../util/check-permission';
 import { Permission } from '../../../../../common/permissions';
 
 export const ChaptersPage: NextPage = () => {
@@ -30,7 +30,7 @@ export const ChaptersPage: NextPage = () => {
           width={'100%'}
         >
           <Heading marginBlock={'1em'}>Chapters: </Heading>
-          {checkPermission(user, Permission.ChaptersView) && (
+          {checkInstancePermission(user, Permission.ChaptersView) && (
             <LinkButton href="/dashboard/chapters" colorScheme={'blue'}>
               Chapter Dashboard
             </LinkButton>

--- a/client/src/modules/dashboard/Calendar/pages/Calendar.tsx
+++ b/client/src/modules/dashboard/Calendar/pages/Calendar.tsx
@@ -8,7 +8,7 @@ import {
   useCalendarIntegrationTestMutation,
   useTokenStatusesQuery,
 } from '../../../../generated/graphql';
-import { checkPermission } from '../../../../util/check-permission';
+import { checkInstancePermission } from '../../../../util/check-permission';
 import { Permission } from '../../../../../../common/permissions';
 import { useUser } from '../../../auth/user';
 import { DashboardLayout } from '../../shared/components/DashboardLayout';
@@ -20,7 +20,7 @@ const serverUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:5000';
 
 export const Calendar: NextPageWithLayout = () => {
   const { user } = useUser();
-  const canAuthenticateWithGoogle = checkPermission(
+  const canAuthenticateWithGoogle = checkInstancePermission(
     user,
     Permission.GoogleAuthenticate,
   );

--- a/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/Users/pages/ChapterUsersPage.tsx
@@ -33,7 +33,7 @@ import {
 import { useParam } from '../../../../../hooks/useParam';
 import { DASHBOARD_CHAPTER_USERS } from '../../graphql/queries';
 import { NextPageWithLayout } from '../../../../../pages/_app';
-import { checkPermission } from '../../../../../util/check-permission';
+import { checkInstancePermission } from '../../../../../util/check-permission';
 import { Permission } from '../../../../../../../common/permissions';
 import { useUser } from '../../../../auth/user';
 
@@ -176,9 +176,10 @@ export const ChapterUsersPage: NextPageWithLayout = () => {
               ),
               actions: ({ is_bannable, user: otherUser, chapter_role }) => (
                 <HStack>
-                  {checkPermission(user, Permission.ChapterUserRoleChange, {
-                    chapterId,
-                  }) && (
+                  {checkInstancePermission(
+                    user,
+                    Permission.ChapterUserRoleChange,
+                  ) && (
                     <Button
                       data-cy="changeRole"
                       colorScheme="blue"

--- a/client/src/modules/dashboard/Chapters/components/DeleteChapterButton.tsx
+++ b/client/src/modules/dashboard/Chapters/components/DeleteChapterButton.tsx
@@ -15,7 +15,7 @@ import {
   userProfileQuery,
 } from '../../../profiles/graphql/queries';
 import { useUser } from '../../../auth/user';
-import { checkPermission } from '../../../../util/check-permission';
+import { checkInstancePermission } from '../../../../util/check-permission';
 import { Permission } from '../../../../../../common/permissions';
 import { useDeleteChapterMutation } from '../../../../generated/graphql';
 
@@ -62,7 +62,7 @@ export const DeleteChapterButton = ({
 
   return (
     <>
-      {checkPermission(user, Permission.ChapterDelete, { chapterId }) && (
+      {checkInstancePermission(user, Permission.ChapterDelete) && (
         <Button
           colorScheme="red"
           size={size}

--- a/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChapterPage.tsx
@@ -29,7 +29,10 @@ import { EventList } from '../../shared/components/EventList';
 import { DashboardLayout } from '../../shared/components/DashboardLayout';
 import { NextPageWithLayout } from '../../../../pages/_app';
 import { useUser } from '../../../auth/user';
-import { checkPermission } from '../../../../util/check-permission';
+import {
+  checkChapterPermission,
+  checkInstancePermission,
+} from '../../../../util/check-permission';
 import { Permission } from '../../../../../../common/permissions';
 import { DeleteChapterButton } from '../components/DeleteChapterButton';
 import { DASHBOARD_CHAPTER } from '../graphql/queries';
@@ -103,7 +106,7 @@ export const ChapterPage: NextPageWithLayout = () => {
       actionLinks.filter(
         ({ requiredPermission }) =>
           !requiredPermission ||
-          checkPermission(user, requiredPermission, { chapterId }),
+          checkChapterPermission(user, requiredPermission, { chapterId }),
       ),
     [actionLinks, chapterId, user],
   );
@@ -139,7 +142,9 @@ export const ChapterPage: NextPageWithLayout = () => {
               )}
             </HStack>
           )}
-          {checkPermission(user, Permission.UsersView, { chapterId }) && (
+          {checkChapterPermission(user, Permission.ChapterEdit, {
+            chapterId,
+          }) && (
             <LinkButton
               href={`${chapterId}/users`}
               paddingBlock="2"
@@ -169,9 +174,7 @@ export const ChapterPage: NextPageWithLayout = () => {
             />
             {integrationStatus &&
               !data.dashboardChapter.calendar_id &&
-              checkPermission(user, Permission.ChapterCreate, {
-                chapterId,
-              }) && (
+              checkInstancePermission(user, Permission.ChapterCreate) && (
                 <Button
                   colorScheme="blue"
                   isLoading={loadingCalendar}

--- a/client/src/modules/dashboard/Chapters/pages/ChaptersPage.tsx
+++ b/client/src/modules/dashboard/Chapters/pages/ChaptersPage.tsx
@@ -3,7 +3,10 @@ import { DataTable } from 'chakra-data-table';
 import { LinkButton } from 'chakra-next-link';
 import React, { ReactElement } from 'react';
 
-import { checkPermission } from '../../../../util/check-permission';
+import {
+  checkInstancePermission,
+  checkChapterPermission,
+} from '../../../../util/check-permission';
 import { useDashboardChaptersQuery } from '../../../../generated/graphql';
 import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import { DashboardLayout } from '../../shared/components/DashboardLayout';
@@ -39,7 +42,7 @@ export const ChaptersPage: NextPageWithLayout = () => {
   const { loading, error, data } = useDashboardChaptersQuery();
   const { user, loadingUser } = useUser();
 
-  const hasPermissionToCreateChapter = checkPermission(
+  const hasPermissionToCreateChapter = checkInstancePermission(
     user,
     Permission.ChapterCreate,
   );
@@ -86,7 +89,7 @@ export const ChaptersPage: NextPageWithLayout = () => {
                   .filter(
                     ({ requiredPermission }) =>
                       !requiredPermission ||
-                      checkPermission(user, requiredPermission, {
+                      checkChapterPermission(user, requiredPermission, {
                         chapterId: chapter.id,
                       }),
                   )
@@ -152,7 +155,7 @@ export const ChaptersPage: NextPageWithLayout = () => {
                         .filter(
                           ({ requiredPermission }) =>
                             !requiredPermission ||
-                            checkPermission(user, requiredPermission, {
+                            checkChapterPermission(user, requiredPermission, {
                               chapterId: chapter.id,
                             }),
                         )

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -8,7 +8,7 @@ import { DASHBOARD_EVENT, DASHBOARD_EVENTS } from '../graphql/queries';
 import { EVENT } from '../../../events/graphql/queries';
 import { HOME_PAGE_QUERY } from '../../../home/graphql/queries';
 import { SharePopOver } from '../../../../components/SharePopOver';
-import { checkPermission } from '../../../../util/check-permission';
+import { checkChapterPermission } from '../../../../util/check-permission';
 import { Permission } from '../../../../../../common/permissions';
 import {
   Chapter,
@@ -97,7 +97,7 @@ const Actions: React.FC<ActionsProps> = ({
       {integrationStatus &&
         !event.calendar_event_id &&
         chapter.calendar_id &&
-        checkPermission(user, Permission.EventCreate, {
+        checkChapterPermission(user, Permission.EventCreate, {
           chapterId: chapter.id,
           eventId: event.id,
         }) && (

--- a/client/src/modules/dashboard/Sponsors/pages/NewSponsorPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/NewSponsorPage.tsx
@@ -8,7 +8,7 @@ import { DashboardLayout } from '../../shared/components/DashboardLayout';
 import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import SponsorForm, { SponsorFormData } from '../components/SponsorForm';
 import { useCreateSponsorMutation } from '../../../../generated/graphql';
-import { checkPermission } from '../../../../util/check-permission';
+import { checkInstancePermission } from '../../../../util/check-permission';
 import { NextPageWithLayout } from '../../../../pages/_app';
 import { Permission } from '../../../../../../common/permissions';
 import { useUser } from '../../../auth/user';
@@ -20,7 +20,7 @@ const NewSponsorPage: NextPageWithLayout = () => {
   });
   const { user, loadingUser } = useUser();
 
-  const hasPermissionToCreateSponsor = checkPermission(
+  const hasPermissionToCreateSponsor = checkInstancePermission(
     user,
     Permission.SponsorManage,
   );

--- a/client/src/modules/dashboard/Sponsors/pages/SponsorsPage.tsx
+++ b/client/src/modules/dashboard/Sponsors/pages/SponsorsPage.tsx
@@ -4,7 +4,7 @@ import { LinkButton } from 'chakra-next-link';
 import Head from 'next/head';
 import React, { ReactElement } from 'react';
 
-import { checkPermission } from '../../../../util/check-permission';
+import { checkInstancePermission } from '../../../../util/check-permission';
 import { DashboardLayout } from '../../shared/components/DashboardLayout';
 import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import { Permission } from '../../../../../../common/permissions';
@@ -16,7 +16,7 @@ export const SponsorsPage: NextPageWithLayout = () => {
   const { loading, error, data } = useSponsorsQuery();
   const { user, loadingUser } = useUser();
 
-  const hasPermissionToManageSponsor = checkPermission(
+  const hasPermissionToManageSponsor = checkInstancePermission(
     user,
     Permission.SponsorManage,
   );

--- a/client/src/modules/dashboard/shared/components/DashboardLayout.tsx
+++ b/client/src/modules/dashboard/shared/components/DashboardLayout.tsx
@@ -6,7 +6,7 @@ import React, { createRef, useLayoutEffect, useState } from 'react';
 
 import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import { Permission } from '../../../../../../common/permissions';
-import { checkPermission } from '../../../../util/check-permission';
+import { checkInstancePermission } from '../../../../util/check-permission';
 import { Loading } from '../../../../components/Loading';
 import { useUser } from '../../../auth/user';
 
@@ -85,7 +85,10 @@ export const DashboardLayout = ({
 
   const linksWithPermissions = links.map((link) => {
     if (!link.requiredPermission) return link;
-    const hasPermission = checkPermission(user, link.requiredPermission);
+    const hasPermission = checkInstancePermission(
+      user,
+      link.requiredPermission,
+    );
     return { ...link, hasPermission };
   });
 

--- a/client/src/modules/events/pages/eventsPage.tsx
+++ b/client/src/modules/events/pages/eventsPage.tsx
@@ -7,7 +7,7 @@ import { Loading } from '../../../components/Loading';
 import { EventCard } from '../../../components/EventCard';
 import { usePaginatedEventsWithTotalQuery } from '../../../generated/graphql';
 import { useUser } from '../../auth/user';
-import { checkPermission } from '../../../util/check-permission';
+import { checkInstancePermission } from '../../../util/check-permission';
 import { Permission } from '../../../../../common/permissions';
 
 function Pagination({
@@ -81,7 +81,7 @@ export const EventsPage: NextPage = () => {
       <Stack w={['90%', '90%', '60%']} maxW="37.5em" spacing={6} mt={10} mb={5}>
         <Flex justifyContent={'space-between'} alignItems={'center'}>
           <Heading as="h1">Events: </Heading>
-          {checkPermission(user, Permission.EventsView) && (
+          {checkInstancePermission(user, Permission.EventsView) && (
             <LinkButton href="/dashboard/events" colorScheme={'blue'}>
               Events Dashboard
             </LinkButton>

--- a/client/src/util/check-permission.ts
+++ b/client/src/util/check-permission.ts
@@ -5,12 +5,21 @@ import {
 } from '../../../common/permissions';
 import { UserContextType } from '../modules/auth/user';
 
-export const checkPermission = (
+export const checkInstancePermission = (
   user: UserContextType['user'],
-  requiredPermission: InstancePermission | ChapterPermission,
-  variableValues?: Record<string, number>,
+  requiredPermission: InstancePermission,
 ) => {
   if (!user) return false;
   const context = { user, events: [], venues: [] };
-  return checker(context, requiredPermission, variableValues || {});
+  return checker(context, requiredPermission, {});
+};
+
+export const checkChapterPermission = (
+  user: UserContextType['user'],
+  requiredPermission: ChapterPermission,
+  variableValues: { chapterId?: number; eventId?: number; venueId?: number },
+) => {
+  if (!user) return false;
+  const context = { user, events: [], venues: [] };
+  return checker(context, requiredPermission, variableValues);
 };

--- a/common/permissions.ts
+++ b/common/permissions.ts
@@ -9,7 +9,6 @@ export enum ChapterPermission {
   Rsvp = 'rsvp',
   RsvpDelete = 'rsvp-delete',
   RsvpConfirm = 'rsvp-confirm',
-  UsersView = 'users-view',
   VenueCreate = 'venue-create',
   VenueEdit = 'venue-edit',
   VenueDelete = 'venue-delete',
@@ -28,6 +27,7 @@ export enum InstancePermission {
   SponsorView = 'sponsor-view',
   UserInstanceRoleChange = 'user-instance-role-change',
   GoogleAuthenticate = 'google-authenticate',
+  UsersView = 'users-view',
 }
 
 // Ideally this would be a new enum, but TS does not (to my knowledge) support

--- a/server/prisma/migrations/20230124093945_remove_users_view_from_chapter_permissions/migration.sql
+++ b/server/prisma/migrations/20230124093945_remove_users_view_from_chapter_permissions/migration.sql
@@ -1,0 +1,18 @@
+-- Reverts
+-- server/prisma/migrations/20221123213911_add_UsersView_to_chapter_permissions/migration.sql
+-- Rationale: only instance owners should be able to view instance users.
+-- Chapter administrators can already view chapter users via the chapter-edit
+-- permission.
+DELETE FROM
+    chapter_role_permissions
+WHERE
+    chapter_permissions_id = (
+        SELECT
+            id
+        FROM
+            chapter_permissions
+        WHERE
+            name = 'users-view'
+    );
+    
+DELETE FROM chapter_permissions WHERE name = 'users-view';


### PR DESCRIPTION
- feat: make users-view an instance permission again
- refactor: split checkPermission into two functions

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Chapter administrators cannot currently view instance users - they have the chapter permission, but the query resolver ignores `chapterId`, so chapter permissions cannot be used. Nonetheless, it _looks_ like they can and that's confusing. This is addressed by removing it from the chapter permissions (it's already an instance permission).

The bulk of the code is the refactor that uncovered this issue: by creating `checkInstancePermission` and `checkChapterPermission` it makes it obvious how these should be used.
<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
