### PR TITLE
feat: unlink chapter calendar

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -4739,6 +4739,39 @@
             "deprecationReason": null
           },
           {
+            "name": "unlinkChapterCalendar",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Chapter",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "unsubscribe",
             "description": null,
             "args": [

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -5724,6 +5724,35 @@
             "deprecationReason": null
           },
           {
+            "name": "testChapterCalendarAccess",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "tokenStatuses",
             "description": null,
             "args": [],

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -560,6 +560,7 @@ export type Query = {
   paginatedEventsWithTotal: PaginatedEventsWithTotal;
   sponsorWithEvents: SponsorWithEvents;
   sponsors: Array<Sponsor>;
+  testChapterCalendarAccess?: Maybe<Scalars['Boolean']>;
   tokenStatuses: Array<TokenStatus>;
   userDownload: UserForDownload;
   userProfile: UserProfile;
@@ -611,6 +612,10 @@ export type QueryPaginatedEventsWithTotalArgs = {
 
 export type QuerySponsorWithEventsArgs = {
   sponsorId: Scalars['Int'];
+};
+
+export type QueryTestChapterCalendarAccessArgs = {
+  id: Scalars['Int'];
 };
 
 export type QueryVenueArgs = {
@@ -1229,6 +1234,15 @@ export type DashboardChapterUsersQuery = {
     }>;
     user_bans: Array<{ __typename?: 'UserBan'; user_id: number }>;
   };
+};
+
+export type TestChapterCalendarAccessQueryVariables = Exact<{
+  chapterId: Scalars['Int'];
+}>;
+
+export type TestChapterCalendarAccessQuery = {
+  __typename?: 'Query';
+  testChapterCalendarAccess?: boolean | null;
 };
 
 export type CreateEventMutationVariables = Exact<{
@@ -3344,6 +3358,62 @@ export type DashboardChapterUsersLazyQueryHookResult = ReturnType<
 export type DashboardChapterUsersQueryResult = Apollo.QueryResult<
   DashboardChapterUsersQuery,
   DashboardChapterUsersQueryVariables
+>;
+export const TestChapterCalendarAccessDocument = gql`
+  query testChapterCalendarAccess($chapterId: Int!) {
+    testChapterCalendarAccess(id: $chapterId)
+  }
+`;
+
+/**
+ * __useTestChapterCalendarAccessQuery__
+ *
+ * To run a query within a React component, call `useTestChapterCalendarAccessQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTestChapterCalendarAccessQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTestChapterCalendarAccessQuery({
+ *   variables: {
+ *      chapterId: // value for 'chapterId'
+ *   },
+ * });
+ */
+export function useTestChapterCalendarAccessQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    TestChapterCalendarAccessQuery,
+    TestChapterCalendarAccessQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    TestChapterCalendarAccessQuery,
+    TestChapterCalendarAccessQueryVariables
+  >(TestChapterCalendarAccessDocument, options);
+}
+export function useTestChapterCalendarAccessLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    TestChapterCalendarAccessQuery,
+    TestChapterCalendarAccessQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    TestChapterCalendarAccessQuery,
+    TestChapterCalendarAccessQueryVariables
+  >(TestChapterCalendarAccessDocument, options);
+}
+export type TestChapterCalendarAccessQueryHookResult = ReturnType<
+  typeof useTestChapterCalendarAccessQuery
+>;
+export type TestChapterCalendarAccessLazyQueryHookResult = ReturnType<
+  typeof useTestChapterCalendarAccessLazyQuery
+>;
+export type TestChapterCalendarAccessQueryResult = Apollo.QueryResult<
+  TestChapterCalendarAccessQuery,
+  TestChapterCalendarAccessQueryVariables
 >;
 export const CreateEventDocument = gql`
   mutation createEvent(

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -381,6 +381,7 @@ export type Mutation = {
   toggleAutoSubscribe: User;
   toggleChapterSubscription: ChapterUser;
   unbanUser: UserBan;
+  unlinkChapterCalendar: Chapter;
   unsubscribe: Scalars['Boolean'];
   unsubscribeFromEvent: EventUser;
   updateChapter: Chapter;
@@ -492,6 +493,10 @@ export type MutationToggleChapterSubscriptionArgs = {
 export type MutationUnbanUserArgs = {
   chapterId: Scalars['Int'];
   userId: Scalars['Int'];
+};
+
+export type MutationUnlinkChapterCalendarArgs = {
+  id: Scalars['Int'];
 };
 
 export type MutationUnsubscribeArgs = {
@@ -1059,6 +1064,19 @@ export type CreateChapterCalendarMutationVariables = Exact<{
 export type CreateChapterCalendarMutation = {
   __typename?: 'Mutation';
   createChapterCalendar: {
+    __typename?: 'Chapter';
+    id: number;
+    calendar_id?: string | null;
+  };
+};
+
+export type UnlinkChapterCalendarMutationVariables = Exact<{
+  chapterId: Scalars['Int'];
+}>;
+
+export type UnlinkChapterCalendarMutation = {
+  __typename?: 'Mutation';
+  unlinkChapterCalendar: {
     __typename?: 'Chapter';
     id: number;
     calendar_id?: string | null;
@@ -2728,6 +2746,57 @@ export type CreateChapterCalendarMutationResult =
 export type CreateChapterCalendarMutationOptions = Apollo.BaseMutationOptions<
   CreateChapterCalendarMutation,
   CreateChapterCalendarMutationVariables
+>;
+export const UnlinkChapterCalendarDocument = gql`
+  mutation unlinkChapterCalendar($chapterId: Int!) {
+    unlinkChapterCalendar(id: $chapterId) {
+      id
+      calendar_id
+    }
+  }
+`;
+export type UnlinkChapterCalendarMutationFn = Apollo.MutationFunction<
+  UnlinkChapterCalendarMutation,
+  UnlinkChapterCalendarMutationVariables
+>;
+
+/**
+ * __useUnlinkChapterCalendarMutation__
+ *
+ * To run a mutation, you first call `useUnlinkChapterCalendarMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUnlinkChapterCalendarMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [unlinkChapterCalendarMutation, { data, loading, error }] = useUnlinkChapterCalendarMutation({
+ *   variables: {
+ *      chapterId: // value for 'chapterId'
+ *   },
+ * });
+ */
+export function useUnlinkChapterCalendarMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UnlinkChapterCalendarMutation,
+    UnlinkChapterCalendarMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UnlinkChapterCalendarMutation,
+    UnlinkChapterCalendarMutationVariables
+  >(UnlinkChapterCalendarDocument, options);
+}
+export type UnlinkChapterCalendarMutationHookResult = ReturnType<
+  typeof useUnlinkChapterCalendarMutation
+>;
+export type UnlinkChapterCalendarMutationResult =
+  Apollo.MutationResult<UnlinkChapterCalendarMutation>;
+export type UnlinkChapterCalendarMutationOptions = Apollo.BaseMutationOptions<
+  UnlinkChapterCalendarMutation,
+  UnlinkChapterCalendarMutationVariables
 >;
 export const UpdateChapterDocument = gql`
   mutation updateChapter($chapterId: Int!, $data: UpdateChapterInputs!) {

--- a/client/src/modules/dashboard/Chapters/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Chapters/graphql/mutations.ts
@@ -23,6 +23,15 @@ export const createChapterCalendar = gql`
   }
 `;
 
+export const unlinkChapterCalendar = gql`
+  mutation unlinkChapterCalendar($chapterId: Int!) {
+    unlinkChapterCalendar(id: $chapterId) {
+      id
+      calendar_id
+    }
+  }
+`;
+
 export const updateChapter = gql`
   mutation updateChapter($chapterId: Int!, $data: UpdateChapterInputs!) {
     updateChapter(id: $chapterId, data: $data) {

--- a/client/src/modules/dashboard/Chapters/graphql/queries.ts
+++ b/client/src/modules/dashboard/Chapters/graphql/queries.ts
@@ -81,3 +81,9 @@ export const DASHBOARD_CHAPTER_USERS = gql`
     }
   }
 `;
+
+export const testChapterCalendarAccess = gql`
+  query testChapterCalendarAccess($chapterId: Int!) {
+    testChapterCalendarAccess(id: $chapterId)
+  }
+`;

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -203,6 +203,22 @@ export class ChapterResolver {
 
   @Authorized(Permission.ChapterEdit)
   @Mutation(() => Chapter)
+  async unlinkChapterCalendar(
+    @Arg('id', () => Int) id: number,
+  ): Promise<Chapter> {
+    await prisma.events.updateMany({
+      data: { calendar_event_id: null },
+      where: { chapter_id: id },
+    });
+
+    return await prisma.chapters.update({
+      data: { calendar_id: null },
+      where: { id },
+    });
+  }
+
+  @Authorized(Permission.ChapterEdit)
+  @Mutation(() => Chapter)
   async updateChapter(
     @Arg('id', () => Int) id: number,
     @Arg('data') data: UpdateChapterInputs,

--- a/server/src/services/Google.ts
+++ b/server/src/services/Google.ts
@@ -270,3 +270,17 @@ export async function testTokens() {
     }),
   );
 }
+
+export async function testCalendarAccess(calendarId: CalendarId) {
+  const calendarApi = await createCalendarApi();
+
+  try {
+    await callWithHandler(() => calendarApi.events.list(calendarId));
+    return true;
+  } catch (error) {
+    if (error instanceof Error && error.message === 'Not Found') {
+      return false;
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Ref #1896
Ref #2168

---

- Adds button for unlinking calendar from chapter dashboard.
  - Calendar id is removed from chapter.
  - Calendar event ids are removed from events in the chapter.
- Currently button is displayed always when calendar is linked. Related issue suggests displaying it under some conditions. I'm not sure if that's needed, if we know that access to calendar is lost, need to confirm it explicitly would be unnecessary.
- What bothers me a bit is refetching all `DASHBOARD_EVENTS`, because of unlinking events.
