### PR TITLE
chore: instance authentication wording

### DIFF
--- a/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
+++ b/client/src/modules/dashboard/Chapters/components/ChapterForm.tsx
@@ -154,8 +154,8 @@ const ChapterForm: React.FC<ChapterFormProps> = (props) => {
           {isAuthenticated ? (
             <>
               <InfoIcon boxSize={5} marginRight={1} />
-              Chapter is authenticated with calendar api, it will attempt
-              creating calendar for chapter.
+              Instance is authenticated with calendar api, it will attempt
+              creating calendar for created chapter.
             </>
           ) : isBroken ? (
             <>
@@ -165,9 +165,9 @@ const ChapterForm: React.FC<ChapterFormProps> = (props) => {
             </>
           ) : (
             <>
-              <InfoIcon boxSize={5} marginRight={1} />
-              Chapter is not authenticated with calendar api, it will not create
-              calendar for chapter.
+              <WarningTwoIcon boxSize={5} marginRight={1} />
+              Instance is not authenticated with calendar api, it will not
+              create calendar for chapter.
             </>
           )}
         </Container>


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Slightly changes wording to use _Instance_ as what needs to be authenticated, instead of _Chapter_.
- Also changed the icon used for _not authenticated_ case.