### PR TITLE
fix: admined_chapters order

### DIFF
--- a/server/src/controllers/User/resolver.ts
+++ b/server/src/controllers/User/resolver.ts
@@ -33,6 +33,7 @@ export class UserWithPermissionsResolver {
       ...(!isAdminFromInstanceRole(user) && {
         where: isChapterAdminWhere(user.id),
       }),
+      orderBy: { name: 'asc' },
     });
   }
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Sorts `admined_chapters` by name.
- Sorry, one has fallen through the cracks.