### PR TITLE
feat: fixed Individual chapter dashboards link to the dashboards for their events

### DIFF
--- a/client/src/components/ChapterCard.tsx
+++ b/client/src/components/ChapterCard.tsx
@@ -123,7 +123,7 @@ export const ChapterCard: React.FC<ChapterCardProps> = ({ chapter }) => {
                 key={id}
               >
                 <Link
-                  href={`/events/${id}`}
+                  href={`dashboard/events/${id}`}
                   mt="2"
                   fontWeight={600}
                   fontSize={['sm', 'md', 'lg']}

--- a/client/src/components/ChapterCard.tsx
+++ b/client/src/components/ChapterCard.tsx
@@ -123,7 +123,7 @@ export const ChapterCard: React.FC<ChapterCardProps> = ({ chapter }) => {
                 key={id}
               >
                 <Link
-                  href={`dashboard/events/${id}`}
+                  href={`/events/${id}`}
                   mt="2"
                   fontWeight={600}
                   fontSize={['sm', 'md', 'lg']}

--- a/client/src/modules/dashboard/shared/components/EventList.tsx
+++ b/client/src/modules/dashboard/shared/components/EventList.tsx
@@ -26,7 +26,7 @@ export const EventList = ({ events, emptyText, title }: Props) => {
         <Grid gap="2em">
           {events.map(({ canceled, id, invite_only, name }) => (
             <Flex justifyContent="space-between" key={id}>
-              <LinkButton href={`/events/${id}`}>{name}</LinkButton>
+              <LinkButton href={`/dashboard/events/${id}`}>{name}</LinkButton>
               <Flex marginTop="1" gap="1em">
                 {invite_only && (
                   <Tag


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #2297

1. In `EventList.tsx`, the `Link` component's (for events ) `href` was set to `href={`events/${id}`}`
2. I changed it to `href={`/dashboard/events/${id}`}`
