### PR TITLE
fix: loadingUser stuck on error

### DIFF
--- a/client/src/components/PageLayout/Header.tsx
+++ b/client/src/components/PageLayout/Header.tsx
@@ -8,6 +8,7 @@ import {
   MenuItem,
   MenuList,
   Spinner,
+  useToast,
 } from '@chakra-ui/react';
 import { Link } from 'chakra-next-link';
 import { SkipNavLink } from '@chakra-ui/skip-nav';
@@ -38,8 +39,10 @@ const menuButtonStyles = {
 export const Header: React.FC = () => {
   const router = useRouter();
   const { user, loadingUser } = useUser();
-  const { login, logout, isAuthenticated } = useSession();
+  const { login, logout, isAuthenticated, error } = useSession();
   const [loading, setLoading] = useState(false);
+
+  const toast = useToast();
 
   const goHome = () => router.push('/');
 
@@ -48,6 +51,14 @@ export const Header: React.FC = () => {
       setLoading(false);
     }
   }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (error) {
+      toast({ title: 'Something went wrong', status: 'error' });
+      setLoading(false);
+      console.log(error);
+    }
+  }, [error]);
 
   return (
     <>

--- a/client/src/components/PageLayout/Header.tsx
+++ b/client/src/components/PageLayout/Header.tsx
@@ -13,7 +13,7 @@ import { Link } from 'chakra-next-link';
 import { SkipNavLink } from '@chakra-ui/skip-nav';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import Avatar from '../Avatar';
@@ -38,9 +38,16 @@ const menuButtonStyles = {
 export const Header: React.FC = () => {
   const router = useRouter();
   const { user, loadingUser } = useUser();
-  const { login, logout } = useSession();
+  const { login, logout, isAuthenticated } = useSession();
+  const [loading, setLoading] = useState(false);
 
   const goHome = () => router.push('/');
+
+  useEffect(() => {
+    if (loading || isAuthenticated) {
+      setLoading(false);
+    }
+  }, [isAuthenticated]);
 
   return (
     <>
@@ -74,7 +81,11 @@ export const Header: React.FC = () => {
                 <Button
                   data-cy="login-button"
                   background="gray.10"
-                  onClick={login}
+                  onClick={() => {
+                    setLoading(true);
+                    login();
+                  }}
+                  isLoading={loading}
                   fontWeight="600"
                   width="4.5em"
                 >

--- a/client/src/hooks/useSession.ts
+++ b/client/src/hooks/useSession.ts
@@ -61,11 +61,17 @@ export const useSession = () => {
 
     if (toLogout) {
       destroySession()
+        .then((res) => {
+          if (!res.ok) throw Error(`Server returned ${res.status} error.`);
+        })
         .then(() => refetch())
         .then(() => apollo.resetStore())
         .catch((e) => setError(e));
     } else if (isAuthenticated) {
       createSession()
+        .then((res) => {
+          if (!res.ok) throw Error(`Server returned ${res.status} error.`);
+        })
         .then(() => refetch())
         .catch((e) => setError(e));
     }

--- a/client/src/hooks/useSession.ts
+++ b/client/src/hooks/useSession.ts
@@ -40,13 +40,16 @@ export const useSession = () => {
   // isAuthenticated does not change immediately after login/logout, so we
   // need to track the intent to prevent accidental session creation/deletion
   const [toLogout, setToLogout] = useState(false);
+  const [error, setError] = useState<Error | undefined>(undefined);
 
   const login = async () => {
+    setError(undefined);
     await loginAuth();
     setCanAlterSession(true);
     setToLogout(false);
   };
   const logout = async () => {
+    setError(undefined);
     await logoutAuth();
     setCanAlterSession(true);
     setToLogout(true);
@@ -59,11 +62,14 @@ export const useSession = () => {
     if (toLogout) {
       destroySession()
         .then(() => refetch())
-        .then(() => apollo.resetStore());
+        .then(() => apollo.resetStore())
+        .catch((e) => setError(e));
     } else if (isAuthenticated) {
-      createSession().then(() => refetch());
+      createSession()
+        .then(() => refetch())
+        .catch((e) => setError(e));
     }
   }, [isAuthenticated, canAlterSession, toLogout]);
 
-  return { login, logout, isAuthenticated };
+  return { login, logout, isAuthenticated, error };
 };

--- a/client/src/hooks/useSession.ts
+++ b/client/src/hooks/useSession.ts
@@ -40,16 +40,16 @@ export const useSession = () => {
   // isAuthenticated does not change immediately after login/logout, so we
   // need to track the intent to prevent accidental session creation/deletion
   const [toLogout, setToLogout] = useState(false);
-  const [error, setError] = useState<Error | undefined>(undefined);
+  const [error, setError] = useState<Error | null>(null);
 
   const login = async () => {
-    setError(undefined);
+    setError(null);
     await loginAuth();
     setCanAlterSession(true);
     setToLogout(false);
   };
   const logout = async () => {
-    setError(undefined);
+    setError(null);
     await logoutAuth();
     setCanAlterSession(true);
     setToLogout(true);

--- a/client/src/modules/auth/user.tsx
+++ b/client/src/modules/auth/user.tsx
@@ -32,6 +32,12 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
         loadingUser: false,
         isLoggedIn: !!meData.me,
       });
+    if (error) {
+      setData({
+        loadingUser: false,
+        isLoggedIn: false,
+      });
+    }
   }, [loadingMe, error, meData, isAuthenticated]);
 
   return (

--- a/client/src/modules/auth/user.tsx
+++ b/client/src/modules/auth/user.tsx
@@ -23,20 +23,18 @@ export const UserProvider = ({ children }: { children: React.ReactNode }) => {
     isLoggedIn: false,
   });
   const { loading: loadingMe, error, data: meData } = useMeQuery();
-  const { isAuthenticated } = useSession();
+  const { logout, isAuthenticated } = useSession();
 
   useEffect(() => {
-    if (!loadingMe && !error && meData)
+    if (!loadingMe && !error && meData) {
       setData({
         user: meData.me,
         loadingUser: false,
         isLoggedIn: !!meData.me,
       });
-    if (error) {
-      setData({
-        loadingUser: false,
-        isLoggedIn: false,
-      });
+    } else if (error) {
+      setData({ loadingUser: false, isLoggedIn: false });
+      logout();
     }
   }, [loadingMe, error, meData, isAuthenticated]);
 

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -47,7 +47,7 @@ export const EventPage: NextPage = () => {
   const { param: eventId } = useParam('eventId');
   const router = useRouter();
   const { user, loadingUser, isLoggedIn } = useUser();
-  const { login } = useSession();
+  const { login, error: loginError } = useSession();
   const modalProps = useDisclosure();
 
   const refetch = {
@@ -265,7 +265,11 @@ export const EventPage: NextPage = () => {
   return (
     <>
       <Modal modalProps={modalProps} title="Waiting for login">
-        <Spinner />
+        {loginError ? (
+          <>Something went wrong, {loginError.message}</>
+        ) : (
+          <Spinner />
+        )}
       </Modal>
       <VStack align="flex-start">
         {data.event.image_url && (


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #2259

---

- Changes `loadingUser` to `false` when there's `useMeQuery` error.
- Catches errors when creating or destroying session.
- `logout()` along setting `loadingUser` on error is a hacky try to start next time from as clean state as possible. For development that's flipping the `isAuthenticated`. 