### PR TITLE
chore: replace rsvp with attendance in db

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -9,6 +9,65 @@
     "subscriptionType": null,
     "types": [
       {
+        "kind": "OBJECT",
+        "name": "Attendance",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "Boolean",
         "description": "The `Boolean` scalar type represents `true` or `false`.",
@@ -2294,6 +2353,22 @@
         "description": null,
         "fields": [
           {
+            "name": "attendance",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Attendance",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "event_id",
             "description": null,
             "args": [],
@@ -2319,22 +2394,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EventRole",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "rsvp",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Rsvp",
                 "ofType": null
               }
             },
@@ -2508,6 +2567,22 @@
         "description": null,
         "fields": [
           {
+            "name": "attendance",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Attendance",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "event_id",
             "description": null,
             "args": [],
@@ -2517,22 +2592,6 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "rsvp",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Rsvp",
                 "ofType": null
               }
             },
@@ -5885,65 +5944,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "Rsvp",
-        "description": null,
-        "fields": [
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updated_at",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "Sponsor",
         "description": null,
         "fields": [
@@ -6771,6 +6771,22 @@
         "description": null,
         "fields": [
           {
+            "name": "attendance",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Attendance",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "event",
             "description": null,
             "args": [],
@@ -6812,22 +6828,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EventRoleWithPermissions",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "rsvp",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Rsvp",
                 "ofType": null
               }
             },

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -22,6 +22,13 @@ export type Scalars = {
   DateTime: any;
 };
 
+export type Attendance = {
+  __typename?: 'Attendance';
+  id: Scalars['Int'];
+  name: Scalars['String'];
+  updated_at: Scalars['DateTime'];
+};
+
 export type Chapter = {
   __typename?: 'Chapter';
   banner_url?: Maybe<Scalars['String']>;
@@ -230,9 +237,9 @@ export type EventUser = {
 
 export type EventUserWithRelations = {
   __typename?: 'EventUserWithRelations';
+  attendance: Attendance;
   event_id: Scalars['Int'];
   event_role: EventRole;
-  rsvp: Rsvp;
   subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
   user: User;
@@ -250,8 +257,8 @@ export type EventUserWithRolePermissions = {
 
 export type EventUserWithRsvpAndUser = {
   __typename?: 'EventUserWithRsvpAndUser';
+  attendance: Attendance;
   event_id: Scalars['Int'];
-  rsvp: Rsvp;
   subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
   user: User;
@@ -622,13 +629,6 @@ export type QueryVenueArgs = {
   venueId: Scalars['Int'];
 };
 
-export type Rsvp = {
-  __typename?: 'Rsvp';
-  id: Scalars['Int'];
-  name: Scalars['String'];
-  updated_at: Scalars['DateTime'];
-};
-
 export type Sponsor = {
   __typename?: 'Sponsor';
   id: Scalars['Int'];
@@ -718,10 +718,10 @@ export type UserChapter = {
 
 export type UserEvent = {
   __typename?: 'UserEvent';
+  attendance: Attendance;
   event: Event;
   event_id: Scalars['Int'];
   event_role: EventRoleWithPermissions;
-  rsvp: Rsvp;
   subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
   user_id: Scalars['Int'];
@@ -1326,7 +1326,7 @@ export type ConfirmRsvpMutation = {
   __typename?: 'Mutation';
   confirmRsvp: {
     __typename?: 'EventUserWithRelations';
-    rsvp: { __typename?: 'Rsvp'; updated_at: any; name: string };
+    attendance: { __typename?: 'Attendance'; updated_at: any; name: string };
   };
 };
 
@@ -1423,7 +1423,7 @@ export type DashboardEventQuery = {
     event_users: Array<{
       __typename?: 'EventUserWithRelations';
       subscribed: boolean;
-      rsvp: { __typename?: 'Rsvp'; name: string };
+      attendance: { __typename?: 'Attendance'; name: string };
       user: {
         __typename?: 'User';
         id: number;
@@ -1776,7 +1776,7 @@ export type EventQuery = {
     } | null;
     event_users: Array<{
       __typename?: 'EventUserWithRsvpAndUser';
-      rsvp: { __typename?: 'Rsvp'; name: string };
+      attendance: { __typename?: 'Attendance'; name: string };
       user: {
         __typename?: 'User';
         id: number;
@@ -1937,7 +1937,7 @@ export type UserDownloadQuery = {
       __typename?: 'UserEvent';
       subscribed: boolean;
       updated_at: any;
-      rsvp: { __typename?: 'Rsvp'; updated_at: any; name: string };
+      attendance: { __typename?: 'Attendance'; updated_at: any; name: string };
       event_role: {
         __typename?: 'EventRoleWithPermissions';
         name: string;
@@ -3691,7 +3691,7 @@ export type DeleteEventMutationOptions = Apollo.BaseMutationOptions<
 export const ConfirmRsvpDocument = gql`
   mutation confirmRsvp($eventId: Int!, $userId: Int!) {
     confirmRsvp(eventId: $eventId, userId: $userId) {
-      rsvp {
+      attendance {
         updated_at
         name
       }
@@ -3951,7 +3951,7 @@ export const DashboardEventDocument = gql`
         country
       }
       event_users {
-        rsvp {
+        attendance {
           name
         }
         user {
@@ -5104,7 +5104,7 @@ export const EventDocument = gql`
         country
       }
       event_users {
-        rsvp {
+        attendance {
           name
         }
         user {
@@ -5407,11 +5407,8 @@ export const UserDownloadDocument = gql`
       user_events {
         subscribed
         updated_at
-        rsvp {
+        attendance {
           updated_at
-          name
-        }
-        rsvp {
           name
         }
         event_role {

--- a/client/src/modules/dashboard/Events/graphql/mutations.ts
+++ b/client/src/modules/dashboard/Events/graphql/mutations.ts
@@ -62,7 +62,7 @@ export const deleteEvent = gql`
 export const confirmRSVP = gql`
   mutation confirmRsvp($eventId: Int!, $userId: Int!) {
     confirmRsvp(eventId: $eventId, userId: $userId) {
-      rsvp {
+      attendance {
         updated_at
         name
       }

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -62,7 +62,7 @@ export const DASHBOARD_EVENT = gql`
         country
       }
       event_users {
-        rsvp {
+        attendance {
           name
         }
         user {

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -238,7 +238,7 @@ export const EventPage: NextPageWithLayout = () => {
         {userLists.map(({ title, statusFilter, action }) => {
           const users = data.dashboardEvent
             ? data.dashboardEvent.event_users.filter(
-                ({ rsvp }) => rsvp.name === statusFilter,
+                ({ attendance }) => attendance.name === statusFilter,
               )
             : [];
           return (
@@ -280,12 +280,12 @@ export const EventPage: NextPageWithLayout = () => {
                 />
               </Box>
               <Box display={{ base: 'block', lg: 'none' }} marginBlock={'2em'}>
-                {users.map(({ event_role, user, rsvp }, index) => (
+                {users.map(({ attendance, event_role, user }, index) => (
                   // For a single event, each user can only have one event_user
                   // entry, so we can use the user id as the key.
                   <HStack key={user.id}>
                     <DataTable
-                      title={'Attendee: ' + rsvp.name.toUpperCase()}
+                      title={'Attendee: ' + attendance.name.toUpperCase()}
                       data={[users[index]]}
                       keys={['type', 'action'] as const}
                       showHeader={false}

--- a/client/src/modules/events/graphql/queries.ts
+++ b/client/src/modules/events/graphql/queries.ts
@@ -60,7 +60,7 @@ export const EVENT = gql`
         country
       }
       event_users {
-        rsvp {
+        attendance {
           name
         }
         user {

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -85,7 +85,7 @@ export const EventPage: NextPage = () => {
   const userEvent = user?.user_events.find(
     ({ event_id }) => event_id === eventId,
   );
-  const attendanceStatus = eventUser?.rsvp.name;
+  const attendanceStatus = eventUser?.attendance.name;
   const isLoading = loading || loadingUser;
   const canShowConfirmationModal =
     router.query?.confirm_attendance && !isLoading;
@@ -200,7 +200,7 @@ export const EventPage: NextPage = () => {
       const eventUser = data?.event?.event_users.find(
         ({ user: event_user }) => event_user.id === user?.id,
       );
-      if (!isAlreadyAttending(eventUser?.rsvp.name)) onAttend();
+      if (!isAlreadyAttending(eventUser?.attendance.name)) onAttend();
     }
   }, [awaitingLogin, isLoggedIn]);
 
@@ -253,10 +253,10 @@ export const EventPage: NextPage = () => {
   }
 
   const attendees = data.event.event_users.filter(
-    ({ rsvp }) => rsvp.name === 'yes',
+    ({ attendance }) => attendance.name === 'yes',
   );
   const waitlist = data.event.event_users.filter(
-    ({ rsvp }) => rsvp.name === 'waitlist',
+    ({ attendance }) => attendance.name === 'waitlist',
   );
 
   const startAt = formatDate(data.event.start_at);

--- a/client/src/modules/profiles/graphql/queries.ts
+++ b/client/src/modules/profiles/graphql/queries.ts
@@ -81,11 +81,8 @@ export const userDownloadQuery = gql`
       user_events {
         subscribed
         updated_at
-        rsvp {
+        attendance {
           updated_at
-          name
-        }
-        rsvp {
           name
         }
         event_role {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -22,7 +22,7 @@ export type ChapterMembers = Awaited<ReturnType<typeof getChapterMembers>>;
 const getEventUsers = (eventId: number) =>
   prisma.event_users.findMany({
     where: { event_id: eventId },
-    include: { user: true, rsvp: true },
+    include: { user: true, attendance: true },
   });
 
 export type EventUsers = Awaited<ReturnType<typeof getEventUsers>>;

--- a/cypress/e2e/dashboard/events/[eventId].cy.ts
+++ b/cypress/e2e/dashboard/events/[eventId].cy.ts
@@ -111,10 +111,10 @@ describe('event dashboard', () => {
       // Starting as the instance owner to ensure we can find the attendees
       cy.task<EventUsers>('getEventUsers', eventId).then((eventUsers) => {
         const confirmedUser = eventUsers.find(
-          ({ rsvp: { name } }) => name === 'yes',
+          ({ attendance: { name } }) => name === 'yes',
         ).user;
         const waitlistUser = eventUsers.find(
-          ({ rsvp: { name } }) => name === 'waitlist',
+          ({ attendance: { name } }) => name === 'waitlist',
         ).user;
 
         // Switch to new member before trying to confirm and remove

--- a/cypress/e2e/dashboard/events/events-index.cy.ts
+++ b/cypress/e2e/dashboard/events/events-index.cy.ts
@@ -244,7 +244,7 @@ describe('spec needing owner', () => {
       .then((eventId) => cy.task<EventUsers>('getEventUsers', eventId))
       .then((eventUsers) => {
         const expectedEmails = eventUsers
-          .filter(({ rsvp }) => rsvp.name !== 'no')
+          .filter(({ attendance }) => attendance.name !== 'no')
           .map(({ user: { email } }) => email);
         cy.get('@emails')
           .mhGetRecipients()

--- a/cypress/e2e/events/[eventId].cy.ts
+++ b/cypress/e2e/events/[eventId].cy.ts
@@ -237,7 +237,7 @@ describe('event page', () => {
           const requestingUser = eventUsers.find(
             ({ user: { email } }) => email === users.testUser.email,
           );
-          expect(requestingUser.rsvp.name === 'waitlist');
+          expect(requestingUser.attendance.name === 'waitlist');
         },
       );
 
@@ -252,7 +252,7 @@ describe('event page', () => {
           const requestingUser = eventUsers.find(
             ({ user: { email } }) => email === users.testUser.email,
           );
-          expect(requestingUser.rsvp.name === 'no');
+          expect(requestingUser.attendance.name === 'no');
         },
       );
     });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -370,7 +370,7 @@ Cypress.Commands.add('confirmRsvp', (eventId, userId) => {
     },
     query: `mutation confirmRsvp($eventId: Int!, $userId: Int!) {
       confirmRsvp(eventId: $eventId, userId: $userId) {
-        rsvp {
+        attendance {
           updated_at
           name
         }

--- a/server/prisma/migrations/20230203174046_rename_rsvp_table/migration.sql
+++ b/server/prisma/migrations/20230203174046_rename_rsvp_table/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "event_users" RENAME CONSTRAINT "event_users_rsvp_id_fkey" TO "event_users_attendance_id_fkey";
+ALTER TABLE "event_users" RENAME COLUMN "rsvp_id" TO "attendance_id";
+ALTER TABLE "rsvp" RENAME CONSTRAINT "rsvp_pkey" TO "attendance_pkey";
+ALTER TABLE "rsvp" RENAME TO "attendance";
+ALTER TABLE "rsvp_id_seq" RENAME TO "attendance_id_seq";
+
+-- AlterIndex
+ALTER INDEX "rsvp_name_key" RENAME TO "attendance_name_key";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -171,13 +171,13 @@ model event_users {
   user_id        Int
   event_id       Int
   event_role_id  Int
-  rsvp_id        Int
+  attendance_id  Int
   subscribed     Boolean
   title          String[]
   user           users            @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   event          events           @relation(fields: [event_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   event_role     event_roles      @relation(fields: [event_role_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  rsvp           rsvp             @relation(fields: [rsvp_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  attendance    attendance        @relation(fields: [attendance_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   event_reminder event_reminders?
 
   @@id([user_id, event_id])
@@ -195,7 +195,7 @@ model event_reminders {
   @@id([user_id, event_id])
 }
 
-model rsvp {
+model attendance {
   created_at  DateTime      @default(now())
   updated_at  DateTime      @updatedAt
   id          Int           @id @default(autoincrement())

--- a/server/prisma/seed/factories/attendance.factory.ts
+++ b/server/prisma/seed/factories/attendance.factory.ts
@@ -3,7 +3,7 @@ import { sub } from 'date-fns';
 import { prisma } from '../../../src/prisma';
 import { random, randomItems } from '../lib/random';
 
-const createRsvps = async (eventIds: number[], userIds: number[]) => {
+const createAttendance = async (eventIds: number[], userIds: number[]) => {
   for (const eventId of eventIds) {
     const eventUserIds = randomItems(userIds, userIds.length / 2);
     const numberWaiting = 1 + random(eventUserIds.length - 2);
@@ -13,7 +13,7 @@ const createRsvps = async (eventIds: number[], userIds: number[]) => {
       const on_waitlist = i < numberWaiting;
       const canceled = !on_waitlist && i < numberWaiting + numberCanceled;
       const subscribed = true; // TODO: have some unsubscribed users
-      const rsvpName = on_waitlist ? 'waitlist' : canceled ? 'no' : 'yes';
+      const attendanceName = on_waitlist ? 'waitlist' : canceled ? 'no' : 'yes';
 
       await prisma.event_users.create({
         data: {
@@ -24,16 +24,16 @@ const createRsvps = async (eventIds: number[], userIds: number[]) => {
               name: 'member',
             },
           },
-          rsvp: {
+          attendance: {
             connect: {
-              name: rsvpName,
+              name: attendanceName,
             },
           },
           subscribed: subscribed,
         },
       });
 
-      if (subscribed && rsvpName === 'yes') {
+      if (subscribed && attendanceName === 'yes') {
         const event = await prisma.events.findUniqueOrThrow({
           where: { id: eventId },
         });
@@ -57,4 +57,4 @@ const createRsvps = async (eventIds: number[], userIds: number[]) => {
   }
 };
 
-export default createRsvps;
+export default createAttendance;

--- a/server/prisma/seed/seed.ts
+++ b/server/prisma/seed/seed.ts
@@ -1,7 +1,7 @@
 import { prisma } from '../../src/prisma';
+import createAttendance from './factories/attendance.factory';
 import createChapters from './factories/chapters.factory';
 import createEvents from './factories/events.factory';
-import createRsvps from './factories/rsvps.factory';
 import createSponsors from './factories/sponsors.factory';
 import createUsers from './factories/user.factory';
 import createVenues from './factories/venues.factory';
@@ -19,7 +19,7 @@ async function truncateTables() {
     'event_roles',
     'event_permissions',
     'event_role_permissions',
-    'rsvp',
+    'attendance',
   ];
   const tablenames = await prisma.$queryRaw<
     Array<{ tablename: string }>
@@ -53,7 +53,7 @@ async function seed() {
     15,
   );
 
-  await createRsvps(eventIds, userIds);
+  await createAttendance(eventIds, userIds);
   await setupRoles(
     { ownerId, chapter1AdminId, chapter2AdminId, bannedAdminId, userIds },
     chapterIds,

--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -55,9 +55,12 @@ async function removeUserFromEventsInChapter({
     },
     include: {
       event: {
-        include: { chapter: true, event_users: { include: { rsvp: true } } },
+        include: {
+          chapter: true,
+          event_users: { include: { attendance: true } },
+        },
       },
-      rsvp: true,
+      attendance: true,
     },
   });
   await prisma.event_users.deleteMany({
@@ -68,7 +71,7 @@ async function removeUserFromEventsInChapter({
   });
 
   const eventsAttended = eventUsers
-    .filter(({ rsvp: { name } }) => name === 'yes')
+    .filter(({ attendance: { name } }) => name === 'yes')
     .map(({ event }) => event);
 
   await Promise.all(

--- a/server/src/controllers/User/resolver.ts
+++ b/server/src/controllers/User/resolver.ts
@@ -90,7 +90,7 @@ export class UserWithPermissionsResolver {
         },
         user_events: {
           include: {
-            rsvp: true,
+            attendance: true,
             event_role: {
               include: {
                 event_role_permissions: {

--- a/server/src/graphql-types/EventUser.ts
+++ b/server/src/graphql-types/EventUser.ts
@@ -1,6 +1,6 @@
 import { Field, Int, ObjectType } from 'type-graphql';
 import { BaseObject } from './BaseObject';
-import { Rsvp, User, Event } from '.';
+import { Attendance, User, Event } from '.';
 
 @ObjectType()
 export class EventPermission extends BaseObject {
@@ -55,8 +55,8 @@ export class EventUserWithRolePermissions extends EventUser {
 
 @ObjectType()
 export class EventUserWithRelations extends EventUserWithRole {
-  @Field(() => Rsvp)
-  rsvp: Rsvp;
+  @Field(() => Attendance)
+  attendance: Attendance;
 
   @Field(() => User)
   user: User;
@@ -64,8 +64,8 @@ export class EventUserWithRelations extends EventUserWithRole {
 
 @ObjectType()
 export class EventUserWithRsvpAndUser extends EventUser {
-  @Field(() => Rsvp)
-  rsvp: Rsvp;
+  @Field(() => Attendance)
+  attendance: Attendance;
 
   @Field(() => User)
   user: User;
@@ -73,8 +73,8 @@ export class EventUserWithRsvpAndUser extends EventUser {
 
 @ObjectType()
 export class UserEvent extends EventUserWithRolePermissions {
-  @Field(() => Rsvp)
-  rsvp: Rsvp;
+  @Field(() => Attendance)
+  attendance: Attendance;
 
   @Field(() => Event)
   event: Event;

--- a/server/src/graphql-types/Rsvp.ts
+++ b/server/src/graphql-types/Rsvp.ts
@@ -2,7 +2,7 @@ import { Field, ObjectType } from 'type-graphql';
 import { BaseObject } from './BaseObject';
 
 @ObjectType()
-export class Rsvp extends BaseObject {
+export class Attendance extends BaseObject {
   @Field(() => Date)
   updated_at: Date;
 

--- a/server/src/util/waitlist.ts
+++ b/server/src/util/waitlist.ts
@@ -7,7 +7,7 @@ import { createReminder } from '../services/Reminders';
 
 type EventForWaitlistUpdate = Prisma.event_usersGetPayload<{
   include: {
-    event: { include: { event_users: { include: { rsvp: true } } } };
+    event: { include: { event_users: { include: { attendance: true } } } };
   };
 }>['event'];
 
@@ -23,18 +23,19 @@ export const updateWaitlistForUserRemoval = async ({
   // Since updateWaitlistForUserRemoval gets the original event_users before the
   // user was removed, we have to filter them out here.
   const waitlist = event_users.filter(
-    ({ user_id, rsvp: { name } }) => user_id !== userId && name === 'waitlist',
+    ({ attendance: { name }, user_id }) =>
+      user_id !== userId && name === 'waitlist',
   );
   if (!waitlist.length) return;
 
   const attendees = event_users.filter(
-    ({ user_id, rsvp: { name } }) => user_id !== userId && name === 'yes',
+    ({ user_id, attendance: { name } }) => user_id !== userId && name === 'yes',
   );
   if (capacity <= attendees.length) return;
 
   const [newAttendee] = waitlist;
   await prisma.event_users.update({
-    data: { rsvp: { connect: { name: 'yes' } } },
+    data: { attendance: { connect: { name: 'yes' } } },
     where: {
       user_id_event_id: {
         user_id: newAttendee.user_id,


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Ref #2272

---

- Renamed rsvp to attendance in db, plus places in client/server/tests using the table name.
- Migration written by hand to rename tables/column/index, as prisma wasn't able to generate one with it's drop-create approach.