### PR TITLE
fix: prevent the same start_at and ends_at

### DIFF
--- a/server/prisma/seed/factories/events.factory.ts
+++ b/server/prisma/seed/factories/events.factory.ts
@@ -67,7 +67,7 @@ const createEvents = async (
       // Setting the first event to be open, so that we can test the user attend flow
       invite_only: i == 0 ? false : inviteOnly[i],
       start_at,
-      ends_at: addHours(start_at, random(5)),
+      ends_at: addHours(start_at, 1 + random(5)),
       image_url: image.imageUrl(640, 480, 'nature', true),
       ...venueData,
     };


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Event form doesn't allow `ends_at` to be the same as `start_at`.
- Therefore when test is trying to edit event having them the same, without changing dates - it will fail.