### PR TITLE
feat: send email after cancelation of attendance

### DIFF
--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -65,6 +65,7 @@ import {
   hasPhysicalLocationChanged,
   hasStreamingUrlChanged,
   hasVenueTypeChanged,
+  eventAttendanceCancelation,
 } from '../../util/event-email';
 import { isOnline, isPhysical } from '../../util/venue';
 import { EventInputs } from './inputs';
@@ -477,6 +478,21 @@ export class EventResolver {
           event_id: eventId,
         },
       },
+    });
+
+    const { subject, attachUnsubscribe } = eventAttendanceCancelation({
+      event,
+      userName: updatedEventUser.user.name,
+    });
+
+    await mailerService.sendEmail({
+      emailList: [updatedEventUser.user.email],
+      subject,
+      htmlEmail: attachUnsubscribe({
+        chapterId: event.chapter_id,
+        eventId: event.id,
+        userId: updatedEventUser.user.id,
+      }),
     });
 
     const calendarId = event.chapter.calendar_id;

--- a/server/src/email-templates.ts
+++ b/server/src/email-templates.ts
@@ -222,6 +222,18 @@ You should receive a calendar invite shortly. If you do not, you can add the eve
 <a href=${outlookURL}>Outlook</a>`,
 });
 
+export const eventAttendanceCancelationText = ({
+  eventName,
+  userName,
+}: {
+  eventName: string;
+  userName: string;
+}) => ({
+  subject: `Cancelation of attendance: ${eventName}`,
+  emailText: `Hi${userName},<br />
+Your attendance was canceled.`,
+});
+
 interface EventUpdateData {
   dateChange: string;
   eventName: string;

--- a/server/src/util/event-email.ts
+++ b/server/src/util/event-email.ts
@@ -5,6 +5,7 @@ import {
   chapterAdminUnsubscribeText,
   chapterUnsubscribeText,
   dateChangeText,
+  eventAttendanceCancelationText,
   eventAttendanceConfirmationText,
   eventCancelationText,
   eventConfirmAtendeeText,
@@ -254,6 +255,24 @@ export const eventAttendanceConfirmation = ({
       eventName,
       googleURL,
       outlookURL,
+      userName: userName ? ` ${userName}` : '',
+    }),
+  );
+};
+
+interface AttendanceCancelation {
+  event: { name: string };
+  userName: string;
+}
+
+export const eventAttendanceCancelation = ({
+  event,
+  userName,
+}: AttendanceCancelation) => {
+  const eventName = event.name;
+  return withUnsubscribe(
+    eventAttendanceCancelationText({
+      eventName,
       userName: userName ? ` ${userName}` : '',
     }),
   );

--- a/server/tests/event-email.test.ts
+++ b/server/tests/event-email.test.ts
@@ -2,6 +2,7 @@ import { events_venue_type_enum } from '@prisma/client';
 
 import {
   buildEmailForUpdatedEvent,
+  eventAttendanceCancelation,
   eventAttendanceConfirmation,
   eventCancelationEmail,
   eventConfirmAttendeeEmail,
@@ -303,6 +304,29 @@ Streaming URL: http://streaming.url/abcd<br />
           oldData,
         }),
       ).toMatchObject(expected);
+    });
+  });
+
+  describe('eventAttendanceCancelation', () => {
+    const data = { event: { name: 'Huel - Lynch' }, userName: 'The Owner' };
+    it('should return object with subject, emailText, attachUnsubscribe and attachUnsubscribeText properties', () => {
+      const result = eventAttendanceCancelation(data);
+      expect(result).toHaveProperty('subject');
+      expect(result).toHaveProperty('emailText');
+      expect(result).toHaveProperty('attachUnsubscribe');
+      expect(result).toHaveProperty('attachUnsubscribeText');
+    });
+
+    it('should return object with expected subject', () => {
+      const expected = { subject: 'Cancelation of attendance: Huel - Lynch' };
+      expect(eventAttendanceCancelation(data)).toMatchObject(expected);
+    });
+
+    it('should return object with expected emailText for Physical & Online event', () => {
+      const expected = {
+        emailText: `Hi The Owner,<br />\nYour attendance was canceled.`,
+      };
+      expect(eventAttendanceCancelation(data)).toMatchObject(expected);
     });
   });
 });


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #1854

---

- Sends email when user cancels the attendance.
- Text is really basic so far. It's more of a placeholder.