### PR TITLE
fix: seed events with minimum capacity

### DIFF
--- a/server/prisma/seed/factories/events.factory.ts
+++ b/server/prisma/seed/factories/events.factory.ts
@@ -62,7 +62,7 @@ const createEvents = async (
       description: lorem.words(),
       url: internet.url(),
       venue_type: venueType,
-      capacity: random(1000),
+      capacity: 10 + random(1000),
       canceled: canceled[i],
       // Setting the first event to be open, so that we can test the user attend flow
       invite_only: i == 0 ? false : inviteOnly[i],


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Seeds events capacity with at least `10`. This is to ensure events used in tests will not be full (and place test user on the waitlist when attending).