### PR TITLE
feat: use Grid to display the events link buttons

### DIFF
--- a/client/src/modules/dashboard/shared/components/EventList.tsx
+++ b/client/src/modules/dashboard/shared/components/EventList.tsx
@@ -2,7 +2,7 @@ import { Flex, Grid, Heading, Tag, Text } from '@chakra-ui/react';
 import React from 'react';
 
 import { LinkButton } from 'chakra-next-link';
-import { LockIcon } from '@chakra-ui/icons';
+import { CalendarIcon, LockIcon, SettingsIcon } from '@chakra-ui/icons';
 
 interface Event {
   canceled: boolean;
@@ -22,7 +22,7 @@ export const EventList = ({ events, emptyText, title }: Props) => {
         {title}
       </Heading>
       {events.length > 0 ? (
-        <Grid gap="2em">
+        <Grid gap="4em">
           {events.map(({ canceled, id, invite_only, name }) => (
             <Grid gap="1rem" key={id} gridTemplateColumns="repeat(4, 1fr)">
               <Flex marginTop="1" gap="3em" gridColumn="1 / -1">
@@ -60,14 +60,16 @@ export const EventList = ({ events, emptyText, title }: Props) => {
                 gridColumn={{ base: '1/ -1', md: '1/3', xl: '1/2' }}
                 href={`/dashboard/events/${id}`}
               >
-                {name} dashboard
+                <Text srOnly>{name}</Text> Dashboard{' '}
+                <SettingsIcon marginInlineStart=".5em" />
               </LinkButton>
               <LinkButton
                 gridRow={{ base: '3', md: '2' }}
                 gridColumn={{ base: '1/ -1', md: '-3/ -1', xl: '2/3' }}
                 href={`/events/${id}`}
               >
-                {name} homepage
+                <Text srOnly>{name}</Text> Event Page{' '}
+                <CalendarIcon marginInlineStart=".5em" />
               </LinkButton>
             </Grid>
           ))}

--- a/client/src/modules/dashboard/shared/components/EventList.tsx
+++ b/client/src/modules/dashboard/shared/components/EventList.tsx
@@ -1,17 +1,7 @@
-import {
-  Flex,
-  Grid,
-  Heading,
-  Tag,
-  Text,
-  Button,
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem,
-} from '@chakra-ui/react';
+import { Flex, Grid, Heading, Tag, Text } from '@chakra-ui/react';
 import React from 'react';
 
+import { LinkButton } from 'chakra-next-link';
 import { LockIcon } from '@chakra-ui/icons';
 
 interface Event {
@@ -20,13 +10,11 @@ interface Event {
   invite_only: boolean;
   name: string;
 }
-
 interface Props {
   events: Event[];
   emptyText?: string;
   title: string;
 }
-
 export const EventList = ({ events, emptyText, title }: Props) => {
   return (
     <>
@@ -36,20 +24,9 @@ export const EventList = ({ events, emptyText, title }: Props) => {
       {events.length > 0 ? (
         <Grid gap="2em">
           {events.map(({ canceled, id, invite_only, name }) => (
-            <Flex justifyContent="space-between" key={id}>
-              <Menu>
-                <MenuButton as={Button}>{name}</MenuButton>
-                <MenuList minWidth="200">
-                  <MenuItem as="a" href={`/dashboard/events/${id}`}>
-                    Event dashboard
-                  </MenuItem>
-                  <MenuItem as="a" href={`/events/${id}`}>
-                    Event page
-                  </MenuItem>
-                </MenuList>
-              </Menu>
-
-              <Flex marginTop="1" gap="1em">
+            <Grid gap="1rem" key={id} gridTemplateColumns="repeat(4, 1fr)">
+              <Flex marginTop="1" gap="3em" gridColumn="1 / -1">
+                <Text>{name}</Text>
                 {invite_only && (
                   <Tag
                     borderRadius="lg"
@@ -78,7 +55,21 @@ export const EventList = ({ events, emptyText, title }: Props) => {
                   </Tag>
                 )}
               </Flex>
-            </Flex>
+              <LinkButton
+                gridRow="2"
+                gridColumn={{ base: '1/ -1', md: '1/3', xl: '1/2' }}
+                href={`/dashboard/events/${id}`}
+              >
+                {name} dashboard
+              </LinkButton>
+              <LinkButton
+                gridRow={{ base: '3', md: '2' }}
+                gridColumn={{ base: '1/ -1', md: '-3/ -1', xl: '2/3' }}
+                href={`/events/${id}`}
+              >
+                {name} homepage
+              </LinkButton>
+            </Grid>
           ))}
         </Grid>
       ) : (


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

MenuButton wraps its child in span, so changing its layout as I was planning is impossible without using position, this reverts to using grid

You can test the changes in 


> /dashboard/chapters/3

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
