### PR TITLE
fix: ensure more consistent events ordering

### DIFF
--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -49,7 +49,7 @@ export class ChapterResolver {
             AND: [{ canceled: false }, { ends_at: { gt: new Date() } }],
           },
           take: 3,
-          orderBy: { start_at: 'desc' },
+          orderBy: [{ start_at: 'desc' }, { name: 'asc' }],
         },
         chapter_users: {
           include: {

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -240,9 +240,7 @@ export class EventResolver {
       include: {
         chapter: true,
       },
-      orderBy: {
-        start_at: 'asc',
-      },
+      orderBy: [{ start_at: 'asc' }, { name: 'asc' }],
       take: limit ?? 10,
       skip: offset,
     });
@@ -266,9 +264,7 @@ export class EventResolver {
       include: {
         chapter: true,
       },
-      orderBy: {
-        start_at: 'asc',
-      },
+      orderBy: [{ start_at: 'asc' }, { name: 'asc' }],
       take: limit ?? 10,
       skip: offset,
     });
@@ -305,7 +301,7 @@ export class EventResolver {
         }),
       },
       include: { venue: true },
-      orderBy: { start_at: 'desc' },
+      orderBy: [{ start_at: 'desc' }, { name: 'asc' }],
     });
   }
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Ensures more consistent ordering of events.
- For some reason events with the same start date not always were ordered the same way.
- This was creating issues for one of the tests, which uses the first event in the dashboard. If after editing that event, while keeping date without changes, order would be flipped with another event having the same date, the test would fail.
- If needed I can also augment mentioned test, but as far as test goes, chances to have seeded event with the same date and name is way much closer to none.