### PR TITLE
fix: wait for two mails

### DIFF
--- a/cypress/e2e/events/[eventId].cy.ts
+++ b/cypress/e2e/events/[eventId].cy.ts
@@ -190,7 +190,8 @@ describe('event page', () => {
       cy.findByRole('button', { name: 'Attend' }).click();
       cy.findByRole('button', { name: 'Confirm' }).click();
 
-      cy.waitUntilMail();
+      // Two emails are send when user attends - one email to the admin, another to the Attendee.
+      cy.waitUntilMail({ expectedNumberOfEmails: 2 });
       cy.mhGetMailsByRecipient(users.chapter1Admin.email).should(
         'have.length',
         1,


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- When attending there are two emails send - one to the attendee and second one to the admin, in that order.
- Test is interested in the second of them, but was waiting only for single email. In most cases the email to admin must have been send in the meantime, so it was already there when was specifically looked for. In other rare cases test was failing.