### PR TITLE
feat: count chapter users in db

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -959,7 +959,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Float",
+                "name": "Int",
                 "ofType": null
               }
             },

--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -274,6 +274,22 @@
         "description": null,
         "fields": [
           {
+            "name": "_count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ChapterUsersCount",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "banner_url",
             "description": null,
             "args": [],
@@ -296,30 +312,6 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "chapter_users",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ChapterUser",
-                    "ofType": null
-                  }
-                }
               }
             },
             "isDeprecated": false,
@@ -941,6 +933,33 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ChapterUsersCount",
+        "description": null,
+        "fields": [
+          {
+            "name": "chapter_users",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -5257,7 +5276,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "ChapterWithRelations",
+                "name": "ChapterCardRelations",
                 "ofType": null
               }
             },

--- a/client/src/components/ChapterCard.tsx
+++ b/client/src/components/ChapterCard.tsx
@@ -94,7 +94,7 @@ export const ChapterCard: React.FC<ChapterCardProps> = ({ chapter }) => {
             paddingInline="1.5em"
           >
             <Text fontWeight="bold">
-              Members: {chapter.chapter_users.length}
+              Members: {chapter._count.chapter_users}
             </Text>
           </GridItem>
           <Text

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -47,9 +47,9 @@ export type Chapter = {
 
 export type ChapterCardRelations = {
   __typename?: 'ChapterCardRelations';
+  _count: ChapterUsersCount;
   banner_url?: Maybe<Scalars['String']>;
   category: Scalars['String'];
-  chapter_users: Array<ChapterUser>;
   chat_url?: Maybe<Scalars['String']>;
   city: Scalars['String'];
   country: Scalars['String'];
@@ -109,6 +109,11 @@ export type ChapterUserWithRole = {
   joined_date: Scalars['DateTime'];
   subscribed: Scalars['Boolean'];
   user_id: Scalars['Int'];
+};
+
+export type ChapterUsersCount = {
+  __typename?: 'ChapterUsersCount';
+  chapter_users: Scalars['Float'];
 };
 
 export type ChapterWithEvents = {
@@ -548,7 +553,7 @@ export type PaginatedEventsWithTotal = {
 export type Query = {
   __typename?: 'Query';
   calendarIntegrationStatus?: Maybe<Scalars['Boolean']>;
-  chapter: ChapterWithRelations;
+  chapter: ChapterCardRelations;
   chapterRoles: Array<ChapterRole>;
   chapterUser?: Maybe<ChapterUserWithRelations>;
   chapterVenues: Array<Venue>;
@@ -949,7 +954,7 @@ export type ChapterQueryVariables = Exact<{
 export type ChapterQuery = {
   __typename?: 'Query';
   chapter: {
-    __typename?: 'ChapterWithRelations';
+    __typename?: 'ChapterCardRelations';
     id: number;
     name: string;
     description: string;
@@ -1008,7 +1013,7 @@ export type ChaptersQuery = {
       name: string;
       invite_only: boolean;
     }>;
-    chapter_users: Array<{ __typename?: 'ChapterUser'; subscribed: boolean }>;
+    _count: { __typename?: 'ChapterUsersCount'; chapter_users: number };
   }>;
 };
 
@@ -1835,7 +1840,7 @@ export type HomeQuery = {
       name: string;
       invite_only: boolean;
     }>;
-    chapter_users: Array<{ __typename?: 'ChapterUser'; subscribed: boolean }>;
+    _count: { __typename?: 'ChapterUsersCount'; chapter_users: number };
   }>;
 };
 
@@ -2452,8 +2457,8 @@ export const ChaptersDocument = gql`
         name
         invite_only
       }
-      chapter_users {
-        subscribed
+      _count {
+        chapter_users
       }
     }
   }
@@ -5249,8 +5254,8 @@ export const HomeDocument = gql`
         name
         invite_only
       }
-      chapter_users {
-        subscribed
+      _count {
+        chapter_users
       }
     }
   }

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -113,7 +113,7 @@ export type ChapterUserWithRole = {
 
 export type ChapterUsersCount = {
   __typename?: 'ChapterUsersCount';
-  chapter_users: Scalars['Float'];
+  chapter_users: Scalars['Int'];
 };
 
 export type ChapterWithEvents = {

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -976,6 +976,7 @@ export type ChapterQuery = {
       invite_only: boolean;
       canceled: boolean;
     }>;
+    _count: { __typename?: 'ChapterUsersCount'; chapter_users: number };
   };
 };
 
@@ -2331,6 +2332,9 @@ export const ChapterDocument = gql`
         image_url
         invite_only
         canceled
+      }
+      _count {
+        chapter_users
       }
     }
   }

--- a/client/src/modules/chapters/graphql/queries.ts
+++ b/client/src/modules/chapters/graphql/queries.ts
@@ -23,6 +23,9 @@ export const CHAPTER = gql`
         invite_only
         canceled
       }
+      _count {
+        chapter_users
+      }
     }
   }
 `;

--- a/client/src/modules/chapters/graphql/queries.ts
+++ b/client/src/modules/chapters/graphql/queries.ts
@@ -57,8 +57,8 @@ export const CHAPTERS = gql`
         name
         invite_only
       }
-      chapter_users {
-        subscribed
+      _count {
+        chapter_users
       }
     }
   }

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -43,6 +43,7 @@ import {
 import { formatDate } from '../../../util/date';
 import { useParam } from '../../../hooks/useParam';
 import { useSession } from '../../../hooks/useSession';
+import { CHAPTER, CHAPTER_USER } from 'modules/chapters/graphql/queries';
 
 export const EventPage: NextPage = () => {
   const { param: eventId } = useParam('eventId');
@@ -63,7 +64,7 @@ export const EventPage: NextPage = () => {
     useAttendEventMutation(refetch);
   const [cancelAttendance, { loading: loadingCancel }] =
     useCancelAttendanceMutation(refetch);
-  const [joinChapter] = useJoinChapterMutation(refetch);
+  const [joinChapter] = useJoinChapterMutation();
   const [subscribeToEvent, { loading: loadingSubscribe }] =
     useSubscribeToEventMutation(refetch);
   const [unsubscribeFromEvent, { loading: loadingUnsubscribe }] =
@@ -113,7 +114,14 @@ export const EventPage: NextPage = () => {
       return;
     }
     try {
-      await joinChapter({ variables: { chapterId } });
+      await joinChapter({
+        variables: { chapterId },
+        refetchQueries: [
+          ...refetch.refetchQueries,
+          { query: CHAPTER, variables: { chapterId } },
+          { query: CHAPTER_USER, variables: { chapterId } },
+        ],
+      });
       const { data: dataAttend } = await attendEvent({
         variables: { eventId, chapterId },
       });

--- a/client/src/modules/home/graphql/queries.ts
+++ b/client/src/modules/home/graphql/queries.ts
@@ -31,8 +31,8 @@ export const HOME_PAGE_QUERY = gql`
         name
         invite_only
       }
-      chapter_users {
-        subscribed
+      _count {
+        chapter_users
       }
     }
   }

--- a/client/tests/ChapterCard.test.tsx
+++ b/client/tests/ChapterCard.test.tsx
@@ -51,11 +51,7 @@ describe('ChapterCard', () => {
               invite_only: false,
             },
           ],
-          chapter_users: [
-            { subscribed: false },
-            { subscribed: true },
-            { subscribed: true },
-          ],
+          _count: { chapter_users: 3 },
         }}
       />,
     );

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -51,18 +51,7 @@ export class ChapterResolver {
           take: 3,
           orderBy: [{ start_at: 'desc' }, { name: 'asc' }],
         },
-        chapter_users: {
-          include: {
-            chapter_role: {
-              include: {
-                chapter_role_permissions: {
-                  include: { chapter_permission: true },
-                },
-              },
-            },
-            user: true,
-          },
-        },
+        _count: { select: { chapter_users: true } },
       },
       orderBy: { name: 'asc' },
     });

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -57,6 +57,20 @@ export class ChapterResolver {
     });
   }
 
+  @Query(() => ChapterCardRelations)
+  async chapter(
+    @Arg('id', () => Int) id: number,
+  ): Promise<ChapterCardRelations> {
+    return await prisma.chapters.findUniqueOrThrow({
+      where: { id },
+      include: {
+        events: true,
+        user_bans: { include: { user: true, chapter: true } },
+        _count: { select: { chapter_users: true } },
+      },
+    });
+  }
+
   @Authorized(Permission.ChapterEdit)
   @Query(() => ChapterWithRelations)
   async dashboardChapter(
@@ -115,32 +129,6 @@ export class ChapterResolver {
       }),
       include: { events: true },
       orderBy: { name: 'asc' },
-    });
-  }
-
-  @Query(() => ChapterWithRelations)
-  async chapter(
-    @Arg('id', () => Int) id: number,
-  ): Promise<ChapterWithRelations> {
-    return await prisma.chapters.findUniqueOrThrow({
-      where: { id },
-      include: {
-        events: true,
-        chapter_users: {
-          include: {
-            chapter_role: {
-              include: {
-                chapter_role_permissions: {
-                  include: { chapter_permission: true },
-                },
-              },
-            },
-            user: true,
-          },
-          orderBy: { user: { name: 'asc' } },
-        },
-        user_bans: { include: { user: true, chapter: true } },
-      },
     });
   }
 

--- a/server/src/graphql-types/Chapter.ts
+++ b/server/src/graphql-types/Chapter.ts
@@ -1,12 +1,6 @@
 import { ObjectType, Field, Int } from 'type-graphql';
 import { BaseObject } from './BaseObject';
-import {
-  ChapterUserWithRelations,
-  Event,
-  EventWithVenue,
-  UserBan,
-  ChapterUser,
-} from '.';
+import { ChapterUserWithRelations, Event, EventWithVenue, UserBan } from '.';
 
 @ObjectType()
 export class Chapter extends BaseObject {
@@ -62,10 +56,16 @@ export class ChapterWithEvents extends Chapter {
 }
 
 @ObjectType()
+export class ChapterUsersCount {
+  @Field(() => Number)
+  chapter_users: number;
+}
+
+@ObjectType()
 export class ChapterCardRelations extends Chapter {
   @Field(() => [Event])
   events: Event[];
 
-  @Field(() => [ChapterUser])
-  chapter_users: ChapterUser[];
+  @Field(() => ChapterUsersCount)
+  _count: ChapterUsersCount;
 }

--- a/server/src/graphql-types/Chapter.ts
+++ b/server/src/graphql-types/Chapter.ts
@@ -57,7 +57,7 @@ export class ChapterWithEvents extends Chapter {
 
 @ObjectType()
 export class ChapterUsersCount {
-  @Field(() => Number)
+  @Field(() => Int)
   chapter_users: number;
 }
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Uses `_count` from prisma to obtain number of chapter users.
- Changes returned object for `chapter` query.
- Fixes couple refetch issues in the chapter <-> event relation, mainly concentrating on counted users, but not only.