### PR TITLE
feat: only warn about missing keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "db:migrate:dev": "npm run prisma migrate dev",
     "db:migrate:reset": "npm run prisma migrate reset -- --force",
     "db:reset": "npm run -w=server build && npm run prisma db push && npm run prisma db seed",
-    "both": "concurrently \"npm run dev:server\" \"npm run dev:client\" \"./server/wait-for localhost:5000 -- npm -w=client run gen:dev\"",
+    "both": "concurrently -c 'auto' \"npm run dev:server\" \"npm run dev:client\" \"./server/wait-for localhost:5000 -- npm -w=client run gen:dev\"",
     "both:coverage": "cross-env NODE_ENV=test concurrently \"npm run dev:server:coverage\" \"npm run dev:client\" \"./server/wait-for localhost:5000 -- npm -w=client run gen:dev\"",
     "build": "cross-env NODE_ENV=production docker compose -f docker-compose.yml build",
     "build:coverage": "cross-env NODE_ENV=test npm run build",

--- a/server/src/services/InitGoogle.ts
+++ b/server/src/services/InitGoogle.ts
@@ -5,7 +5,6 @@ import { Credentials, OAuth2Client } from 'google-auth-library';
 import { calendar } from '@googleapis/calendar';
 
 import { prisma } from '../prisma';
-import { isProd } from '../config';
 import { redactSecrets } from '../util/redact-secrets';
 
 // We need a single set of tokens for the server and Prisma needs a unique id
@@ -30,8 +29,9 @@ function init() {
 
     return { keys };
   } catch {
-    if (isProd())
-      throw new Error('OAuth2 keys file missing, cannot start server');
+    console.warn(
+      'WARN: oauth2.keys.json file missing, the Google Calendar integration will not work.',
+    );
   }
 
   return {};


### PR DESCRIPTION
- chore: use colours to better differentiate logs
- chore: downgrade oauth2.keys.json error to warning

<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

The main thing is we can't rely on `oauth2.keys.json` existing. Notably it won't exist in [railway](https://railway.app/), so we need an alternative approach.

For now, I just want to downgrade the error to a warning.  Longer term we could make use of environment variables, but I'm focusing on getting the MVP deployable for now.

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
