### PR TITLE
chore: add joined_date field to event_users

### DIFF
--- a/server/prisma/migrations/20230301175317_add_joined_date_to_event_users/migration.sql
+++ b/server/prisma/migrations/20230301175317_add_joined_date_to_event_users/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "event_users" ADD COLUMN     "joined_date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -168,6 +168,7 @@ model event_permissions {
 model event_users {
   created_at     DateTime         @default(now())
   updated_at     DateTime         @updatedAt
+  joined_date    DateTime         @default(now())
   user_id        Int
   event_id       Int
   event_role_id  Int


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #1952

---

- Adds migration adding `joined_date` to `event_users`, with default value.