### PR TITLE
feat: increase the min height for content in laptops layout

### DIFF
--- a/client/src/components/PageLayout/index.tsx
+++ b/client/src/components/PageLayout/index.tsx
@@ -53,7 +53,7 @@ const PageLayout = ({ children }: { children: React.ReactNode }) => {
       <SkipNavContent />
       <Box
         as="main"
-        minHeight={{ base: '70vh', xl: '82vh' }}
+        minHeight={{ base: '70vh', md: '82vh' }}
         px={[4, 4, 8, 16]}
         id="main-content"
       >

--- a/client/src/components/PageLayout/index.tsx
+++ b/client/src/components/PageLayout/index.tsx
@@ -53,7 +53,7 @@ const PageLayout = ({ children }: { children: React.ReactNode }) => {
       <SkipNavContent />
       <Box
         as="main"
-        minHeight={{ base: '70vh', '2xl': '82vh' }}
+        minHeight={{ base: '70vh', xl: '82vh' }}
         px={[4, 4, 8, 16]}
         id="main-content"
       >


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Screens with width between 1000px and 1440px have the footer away from the bottom of the layout.

![image](https://user-images.githubusercontent.com/88248797/222913388-7df00155-a4e2-4ee4-b83e-a1fa816ca797.png)


<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
