### PR TITLE
fix: ChapterCard displays past events after visiting chapter page

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -5276,7 +5276,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "ChapterCardRelations",
+                "name": "ChapterWithEvents",
                 "ofType": null
               }
             },

--- a/client/src/components/ChapterCard.tsx
+++ b/client/src/components/ChapterCard.tsx
@@ -124,37 +124,39 @@ export const ChapterCard: React.FC<ChapterCardProps> = ({ chapter }) => {
             Next Events
           </Text>
           <GridItem area="event" paddingInline={'1em'}>
-            {chapter.events.map(({ id, name, start_at, invite_only }) => (
-              <Flex
-                paddingBlock={'.5em'}
-                paddingInline={'.3em'}
-                justifyContent={'space-between'}
-                alignItems="center"
-                key={id}
-              >
-                <Link
-                  href={`/events/${id}`}
-                  mt="2"
-                  fontWeight={600}
-                  fontSize={['sm', 'md', 'lg']}
+            {chapter.events
+              .filter(({ ends_at }) => !isPast(new Date(ends_at)))
+              .map(({ id, name, start_at, invite_only }) => (
+                <Flex
+                  paddingBlock={'.5em'}
+                  paddingInline={'.3em'}
+                  justifyContent={'space-between'}
+                  alignItems="center"
+                  key={id}
                 >
-                  {name}
-                </Link>
-                {invite_only && (
-                  <Tooltip label="Invite only">
-                    <LockIcon
-                      mt="2"
-                      marginLeft="auto"
-                      marginRight="1"
-                      fontSize={['sm', 'md', 'lg']}
-                    />
-                  </Tooltip>
-                )}
-                <Text mt="2" fontWeight={600} fontSize={['sm', 'md', 'lg']}>
-                  {isPast(new Date(start_at)) ? 'Running' : 'Upcoming'}
-                </Text>
-              </Flex>
-            ))}
+                  <Link
+                    href={`/events/${id}`}
+                    mt="2"
+                    fontWeight={600}
+                    fontSize={['sm', 'md', 'lg']}
+                  >
+                    {name}
+                  </Link>
+                  {invite_only && (
+                    <Tooltip label="Invite only">
+                      <LockIcon
+                        mt="2"
+                        marginLeft="auto"
+                        marginRight="1"
+                        fontSize={['sm', 'md', 'lg']}
+                      />
+                    </Tooltip>
+                  )}
+                  <Text mt="2" fontWeight={600} fontSize={['sm', 'md', 'lg']}>
+                    {isPast(new Date(start_at)) ? 'Running' : 'Upcoming'}
+                  </Text>
+                </Flex>
+              ))}
           </GridItem>
         </Grid>
       </Box>

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -553,7 +553,7 @@ export type PaginatedEventsWithChapters = {
 export type Query = {
   __typename?: 'Query';
   calendarIntegrationStatus?: Maybe<Scalars['Boolean']>;
-  chapter: ChapterCardRelations;
+  chapter: ChapterWithEvents;
   chapterRoles: Array<ChapterRole>;
   chapterUser?: Maybe<ChapterUserWithRelations>;
   chapterVenues: Array<Venue>;
@@ -949,7 +949,7 @@ export type ChapterQueryVariables = Exact<{
 export type ChapterQuery = {
   __typename?: 'Query';
   chapter: {
-    __typename?: 'ChapterCardRelations';
+    __typename?: 'ChapterWithEvents';
     id: number;
     name: string;
     description: string;
@@ -961,7 +961,7 @@ export type ChapterQuery = {
     banner_url?: string | null;
     chat_url?: string | null;
     events: Array<{
-      __typename?: 'Event';
+      __typename?: 'EventWithVenue';
       id: number;
       name: string;
       description: string;
@@ -971,7 +971,6 @@ export type ChapterQuery = {
       invite_only: boolean;
       canceled: boolean;
     }>;
-    _count: { __typename?: 'ChapterUsersCount'; chapter_users: number };
   };
 };
 
@@ -2284,9 +2283,6 @@ export const ChapterDocument = gql`
         image_url
         invite_only
         canceled
-      }
-      _count {
-        chapter_users
       }
     }
   }

--- a/client/src/modules/chapters/graphql/queries.ts
+++ b/client/src/modules/chapters/graphql/queries.ts
@@ -23,9 +23,6 @@ export const CHAPTER = gql`
         invite_only
         canceled
       }
-      _count {
-        chapter_users
-      }
     }
   }
 `;

--- a/client/tests/__snapshots__/ChapterCard.test.tsx.snap
+++ b/client/tests/__snapshots__/ChapterCard.test.tsx.snap
@@ -98,21 +98,6 @@ exports[`ChapterCard should render 1`] = `
         >
           <a
             class="chakra-link css-1obgyuc"
-            href="/events/3"
-          >
-            Past event
-          </a>
-          <p
-            class="chakra-text css-1obgyuc"
-          >
-            Running
-          </p>
-        </div>
-        <div
-          class="css-1flr4u6"
-        >
-          <a
-            class="chakra-link css-1obgyuc"
             href="/events/5"
           >
             Visible event

--- a/server/src/controllers/Chapter/resolver.ts
+++ b/server/src/controllers/Chapter/resolver.ts
@@ -57,17 +57,11 @@ export class ChapterResolver {
     });
   }
 
-  @Query(() => ChapterCardRelations)
-  async chapter(
-    @Arg('id', () => Int) id: number,
-  ): Promise<ChapterCardRelations> {
+  @Query(() => ChapterWithEvents)
+  async chapter(@Arg('id', () => Int) id: number): Promise<ChapterWithEvents> {
     return await prisma.chapters.findUniqueOrThrow({
       where: { id },
-      include: {
-        events: true,
-        user_bans: { include: { user: true, chapter: true } },
-        _count: { select: { chapter_users: true } },
-      },
+      include: { events: true },
     });
   }
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #2440

---

- Filters out past events in the chapter card.
- Also modifies what graphql-type is returned by chapter query. It's right now not using `_count`, so no need for it.
