### PR TITLE
fix: refetch after event actions

### DIFF
--- a/client/src/modules/dashboard/Chapters/components/DeleteChapterButton.tsx
+++ b/client/src/modules/dashboard/Chapters/components/DeleteChapterButton.tsx
@@ -39,7 +39,11 @@ export const DeleteChapterButton = ({
       { query: DASHBOARD_VENUES },
       {
         query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-        variables: { offset: 0, limit: 5 },
+        variables: { offset: 0, limit: 2 },
+      },
+      {
+        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+        variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
       },
       { query: meQuery },
       { query: userProfileQuery },

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -3,12 +3,9 @@ import { useConfirm, useConfirmDelete } from 'chakra-confirm';
 import { LinkButton } from 'chakra-next-link';
 import React, { useMemo, useState } from 'react';
 
-import { CHAPTER } from '../../../chapters/graphql/queries';
-import { DASHBOARD_EVENT, DASHBOARD_EVENTS } from '../graphql/queries';
-import {
-  EVENT,
-  DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-} from '../../../events/graphql/queries';
+import { CHAPTER, CHAPTERS } from '../../../chapters/graphql/queries';
+import { DASHBOARD_EVENTS } from '../graphql/queries';
+import { DATA_PAGINATED_EVENTS_TOTAL_QUERY } from '../../../events/graphql/queries';
 import { useAlert } from '../../../../hooks/useAlert';
 import { SharePopOver } from '../../../../components/SharePopOver';
 import { checkChapterPermission } from '../../../../util/check-permission';
@@ -48,11 +45,14 @@ const Actions: React.FC<ActionsProps> = ({
       variables: { eventId: event.id },
       refetchQueries: [
         { query: CHAPTER, variables: { chapterId: chapter.id } },
-        { query: EVENT, variables: { eventId: event.id } },
-        { query: DASHBOARD_EVENT, variables: { eventId: event.id } },
+        { query: CHAPTERS },
         {
           query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
           variables: { offset: 0, limit: 2 },
+        },
+        {
+          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+          variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
         },
         { query: DASHBOARD_EVENTS },
       ],

--- a/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
+++ b/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
@@ -35,6 +35,10 @@ const EventCancelButton = (props: EventCancelButtonProps) => {
         query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
         variables: { offset: 0, limit: 2 },
       },
+      {
+        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+        variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
+      },
       { query: DASHBOARD_EVENTS },
     ],
   };

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -40,6 +40,10 @@ export const EditEventPage: NextPageWithLayout = () => {
         query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
         variables: { offset: 0, limit: 2 },
       },
+      {
+        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+        variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
+      },
     ],
   });
 

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -44,6 +44,10 @@ export const NewEventPage: NextPageWithLayout<{
           variables: { offset: 0, limit: 2 },
         },
         {
+          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+          variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
+        },
+        {
           query: DASHBOARD_EVENTS,
         },
       ],


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Fixes updating `/events` after edit, canceling or deletion (including chapter deletion).
- Fixes updating events displayed in chapter card after event deletion.
- Unfortunately queries having distinct arguments (like `showOnlyUpcoming`) need refetches with argument combinations.