### PR TITLE
chore: add grid to event actions on eventPage

### DIFF
--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -367,7 +367,7 @@ export const EventPage: NextPage = () => {
               paddingBlock="1"
               paddingInline="2"
             >
-              {data.event.invite_only ? 'Request' : 'Attend'}
+              {data.event.invite_only ? 'Request Invite' : 'Attend Event'}
             </Button>
           ) : (
             <>

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -9,6 +9,7 @@ import {
   List,
   ListIcon,
   ListItem,
+  SimpleGrid,
   Spinner,
   Text,
   Tooltip,
@@ -353,72 +354,77 @@ export const EventPage: NextPage = () => {
         <Text fontWeight={'500'} fontSize={['smaller', 'sm', 'md']}>
           Ending: {endsAt}
         </Text>
-        {!attendanceStatus || attendanceStatus === 'no' ? (
-          <Button
-            colorScheme="blue"
-            data-cy="attend-button"
-            isLoading={loadingAttend}
-            onClick={() => tryToAttend()}
-            paddingBlock="1"
-            paddingInline="2"
-          >
-            {data.event.invite_only ? 'Request' : 'Attend'}
-          </Button>
-        ) : (
-          <HStack>
-            {attendanceStatus === 'waitlist' ? (
-              <Text fontSize="md" fontWeight="500">
-                {data.event.invite_only
-                  ? 'Event owner will soon confirm your request'
-                  : "You're on waitlist for this event"}
-              </Text>
-            ) : (
-              <Text data-cy="attend-success">You are attending this event</Text>
-            )}
+        <SimpleGrid columns={2} gap={5} alignItems="center">
+          {!attendanceStatus || attendanceStatus === 'no' ? (
             <Button
-              isLoading={loadingCancel}
-              onClick={onCancelAttendance}
+              colorScheme="blue"
+              data-cy="attend-button"
+              gridColumnStart="span 2"
+              isLoading={loadingAttend}
+              onClick={() => tryToAttend()}
               paddingBlock="1"
               paddingInline="2"
             >
-              Cancel
+              {data.event.invite_only ? 'Request Invite' : 'Attend Event'}
             </Button>
-          </HStack>
-        )}
-        {userEvent && (
-          <HStack>
-            {userEvent.subscribed ? (
-              <>
-                <Text fontSize={'md'} fontWeight={'500'}>
-                  You are subscribed to event updates
+          ) : (
+            <>
+              {attendanceStatus === 'waitlist' ? (
+                <Text fontSize="md" fontWeight="500">
+                  {data.event.invite_only
+                    ? 'Event owner will soon confirm your request'
+                    : "You're on waitlist for this event"}
                 </Text>
-                <Button
-                  isLoading={loadingUnsubscribe}
-                  onClick={onUnsubscribeFromEvent}
-                  paddingBlock="1"
-                  paddingInline="2"
-                >
-                  Unsubscribe
-                </Button>
-              </>
-            ) : (
-              <>
-                <Text fontSize={'md'} fontWeight={'500'}>
-                  Not subscribed to event updates
+              ) : (
+                <Text data-cy="attend-success">
+                  You are attending this event
                 </Text>
-                <Button
-                  colorScheme="blue"
-                  isLoading={loadingSubscribe}
-                  onClick={onSubscribeToEvent}
-                  paddingBlock="1"
-                  paddingInline="2"
-                >
-                  Subscribe
-                </Button>
-              </>
-            )}
-          </HStack>
-        )}
+              )}
+              <Button
+                isLoading={loadingCancel}
+                onClick={onCancelAttendance}
+                paddingBlock="1"
+                paddingInline="2"
+              >
+                Cancel
+              </Button>
+            </>
+          )}
+          {userEvent && (
+            <>
+              {userEvent.subscribed ? (
+                <>
+                  <Text fontSize={'md'} fontWeight={'500'}>
+                    You are subscribed to event updates
+                  </Text>
+                  <Button
+                    isLoading={loadingUnsubscribe}
+                    onClick={onUnsubscribeFromEvent}
+                    paddingBlock="1"
+                    paddingInline="2"
+                  >
+                    Unsubscribe
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Text fontSize={'md'} fontWeight={'500'}>
+                    Not subscribed to event updates
+                  </Text>
+                  <Button
+                    colorScheme="blue"
+                    isLoading={loadingSubscribe}
+                    onClick={onSubscribeToEvent}
+                    paddingBlock="1"
+                    paddingInline="2"
+                  >
+                    Subscribe
+                  </Button>
+                </>
+              )}
+            </>
+          )}
+        </SimpleGrid>
 
         {data.event.sponsors.length ? (
           <SponsorsCard sponsors={data.event.sponsors} />

--- a/cypress/e2e/events/[eventId].cy.ts
+++ b/cypress/e2e/events/[eventId].cy.ts
@@ -139,7 +139,7 @@ describe('event page', () => {
           cy.findByText(users.testUser.name).should('not.exist');
         });
 
-      cy.findByRole('button', { name: 'Attend' }).click();
+      cy.findByRole('button', { name: 'Attend Event' }).click();
       cy.findByRole('button', { name: 'Confirm' }).click();
 
       cy.get('@attendees').within(() => {
@@ -159,7 +159,7 @@ describe('event page', () => {
       cy.login(users.testUser.email);
 
       // Attending is required for managing event subscription
-      cy.findByRole('button', { name: 'Attend' }).click();
+      cy.findByRole('button', { name: 'Attend Event' }).click();
       cy.findByRole('button', { name: 'Confirm' }).click();
 
       cy.contains(/You are subscribed/);
@@ -207,7 +207,7 @@ describe('event page', () => {
     it('should email the chapter administrator when a user attends', () => {
       cy.login(users.testUser.email);
 
-      cy.findByRole('button', { name: 'Attend' }).click();
+      cy.findByRole('button', { name: 'Attend Event' }).click();
       cy.findByRole('button', { name: 'Confirm' }).click();
 
       // Two emails are send when user attends - one email to the admin, another to the Attendee.
@@ -243,11 +243,11 @@ describe('event page', () => {
           cy.findByText(users.testUser.name).should('not.exist');
         });
 
-      cy.findByRole('button', { name: 'Request' }).click();
+      cy.findByRole('button', { name: 'Request Invite' }).click();
       cy.findByRole('button', { name: 'Confirm' }).click();
 
       cy.contains('Event owner will soon confirm your request');
-      cy.findByRole('button', { name: 'Request' }).should('not.exist');
+      cy.findByRole('button', { name: 'Request Invite' }).should('not.exist');
 
       cy.get('@attendees').within(() => {
         cy.findByText(users.testUser.name).should('not.exist');
@@ -266,7 +266,7 @@ describe('event page', () => {
       cy.findByRole('button', { name: 'Confirm' }).click();
 
       cy.contains('You canceled your attendance');
-      cy.findByRole('button', { name: 'Request' }).should('be.visible');
+      cy.findByRole('button', { name: 'Request Invite' }).should('be.visible');
 
       cy.task<EventUsers>('getEventUsers', inviteOnlyEventId).then(
         (eventUsers) => {


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---

- Adds grid to event actions on eventPage to slightly unify the look with chapterPage.