### PR TITLE
fix: add checks for success message

### DIFF
--- a/cypress/e2e/chapters/[chapterId].cy.ts
+++ b/cypress/e2e/chapters/[chapterId].cy.ts
@@ -28,6 +28,7 @@ describe('chapter page', () => {
     cy.get('[data-cy="unsubscribe-chapter"]').should('be.visible').click();
     cy.findByRole('button', { name: 'Confirm' }).click();
 
+    cy.contains('unsubscribed from new events');
     cy.task<ChapterMembers>('getChapterMembers', chapterId).then(
       (chapter_users) => {
         expect(
@@ -42,6 +43,7 @@ describe('chapter page', () => {
     cy.get('[data-cy="subscribe-chapter"]').should('be.visible').click();
     cy.findByRole('button', { name: 'Confirm' }).click();
 
+    cy.contains('successfully subscribed to new events');
     cy.task<ChapterMembers>('getChapterMembers', chapterId).then(
       (chapter_users) => {
         expect(


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Adds checks for the success message when subscribing/unsubscribing from chapter. This is to delay task of checking subscription status on the via chapter members, and make sure it's done after server completes mutation. In rare occasions this was causing single test attempt fail.