### PR TITLE
fix: Add space between event image and header using PageLayout

### DIFF
--- a/client/src/components/PageLayout/index.tsx
+++ b/client/src/components/PageLayout/index.tsx
@@ -58,6 +58,7 @@ const PageLayout = ({ children }: { children: React.ReactNode }) => {
         minHeight={{ base: '70vh', md: '82vh' }}
         px={[4, 4, 8, 16]}
         id="main-content"
+        marginTop="4"
       >
         {children}
       </Box>

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -338,7 +338,7 @@ export const EventPage: NextPage = () => {
       </Modal>
       <VStack align="flex-start">
         {data.event.image_url && (
-          <Box height={'300px'}>
+          <Box height={'300px'} marginTop="4">
             <Image
               data-cy="event-image"
               boxSize="100%"

--- a/client/src/modules/events/pages/eventPage.tsx
+++ b/client/src/modules/events/pages/eventPage.tsx
@@ -338,7 +338,7 @@ export const EventPage: NextPage = () => {
       </Modal>
       <VStack align="flex-start">
         {data.event.image_url && (
-          <Box height={'300px'} marginTop="4">
+          <Box height={'300px'}>
             <Image
               data-cy="event-image"
               boxSize="100%"


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #2497 

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
[Gitpod workspace snapshot](https://gitpod.io#snapshot/90b362e7-3cbd-40df-bf1d-6f52b55c8dd6)

as suggested in the bug description:

>  Also maybe separating margin might be set on the PageLayout, instead of individual pages.

Added to `<Box>` component, in PageLayout file, a margin top of 1rem spacing which in [chakra is "4"](https://chakra-ui.com/docs/styled-system/theme#spacing):

client/src/components/PageLayout/index.tsx

![image](https://user-images.githubusercontent.com/90356410/226819268-c1d14558-e0c6-455b-b3df-74038b9ea8b8.png)