### PR TITLE
Added Venue Data to confirmation emails

### DIFF
--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -515,6 +515,7 @@ export class EventResolver {
     return updatedEventUser;
   }
 
+  // Added venue data for updatedUser
   @Authorized(Permission.AttendeeConfirm)
   @Mutation(() => EventUserWithRelations)
   async confirmAttendee(
@@ -524,11 +525,20 @@ export class EventResolver {
     const updatedUser = await prisma.event_users.update({
       data: { attendance: { connect: { name: AttendanceNames.confirmed } } },
       where: { user_id_event_id: { user_id: userId, event_id: eventId } },
-      include: { event: { include: { chapter: true } }, ...eventUserIncludes },
+      include: {
+        event: { include: { chapter: true, venue: true } },
+        ...eventUserIncludes,
+      },
     });
 
+    // Added 5 more parameters related to venue data
     const { subject, attachUnsubscribe } = eventConfirmAttendeeEmail(
       updatedUser.event.name,
+      updatedUser.event.streaming_url,
+      updatedUser.event.venue?.name,
+      updatedUser.event.venue_type,
+      updatedUser.event.start_at,
+      updatedUser.event.ends_at,
     );
 
     await mailerService.sendEmail({

--- a/server/src/email-templates.ts
+++ b/server/src/email-templates.ts
@@ -132,13 +132,26 @@ Your role in chapter ${chapterName} has been changed from ${oldChapterRole} to $
 `,
 });
 
+// Manually adding venue data, possibly make an interface for it later
 export const eventConfirmAtendeeText = ({
   eventName,
+  physicalLocation,
+  streamingData,
+  start_at,
+  ends_at,
 }: {
   eventName: string;
+  physicalLocation: string;
+  streamingData: string;
+  start_at: Date;
+  ends_at: Date;
 }) => ({
   subject: 'Your attendance is confirmed',
-  emailText: `Your reservation is confirmed. You can attend the event ${eventName}`,
+  emailText: `Your reservation is confirmed. You can attend the event ${eventName}.<br />
+<br />
+When: ${start_at} to ${ends_at}
+<br />${physicalLocation}${streamingData}
+<br />`,
 });
 
 export const eventAttendeeToWaitlistText = ({
@@ -212,21 +225,36 @@ export const eventNewAttendeeNotificationText = ({
   emailText: `User ${userName} is attending.`,
 });
 
+// Added venue data, physical location, streaming data, start and end time
 interface AttendanceConfirmationData {
   eventName: string;
   googleURL: string;
   outlookURL: string;
   userName: string;
+  physicalLocation: string;
+  streamingData: string;
+  start_at: Date;
+  ends_at: Date;
 }
 
+// Added the 4 pieces of venue data for use in email text
 export const eventAttendanceConfirmationText = ({
   eventName,
   googleURL,
   outlookURL,
   userName,
+  physicalLocation,
+  streamingData,
+  start_at,
+  ends_at,
 }: AttendanceConfirmationData) => ({
   subject: `Confirmation of attendance: ${eventName}`,
   emailText: `Hi${userName},<br />
+Confirming your attendance of ${eventName}.<br />
+<br />
+When: ${start_at} to ${ends_at}
+<br />${physicalLocation}${streamingData}
+<br />
 You should receive a calendar invite shortly. If you do not, you can add the event to your calendars by clicking on the links below:<br />
 <br />
 <a href=${googleURL}>Google</a>

--- a/server/tests/event-email.test.ts
+++ b/server/tests/event-email.test.ts
@@ -141,10 +141,23 @@ You received this email because you Subscribed to Hammes - Sawayn Event.<br />`,
     });
   });
 
+  //Added some fake venue data to test
   describe('eventConfirmAttendeeEmail', () => {
     const data = 'Emard and Sons';
+    const streaming_url = 'http://streaming.url/abcd';
+    const venue_physical = 'Some Physical Location';
+    const venue_type = events_venue_type_enum.PhysicalAndOnline;
+    const start_at = new Date('2023-02-07 12:30');
+    const ends_at = new Date('2023-02-07 12:00');
     it('should return object with subject, emailText, attachUnsubscribe and attachUnsubscribeText properties', () => {
-      const result = eventConfirmAttendeeEmail(data);
+      const result = eventConfirmAttendeeEmail(
+        data,
+        streaming_url,
+        venue_physical,
+        venue_type,
+        start_at,
+        ends_at,
+      );
       expect(result).toHaveProperty('subject');
       expect(result).toHaveProperty('emailText');
       expect(result).toHaveProperty('attachUnsubscribe');
@@ -153,7 +166,16 @@ You received this email because you Subscribed to Hammes - Sawayn Event.<br />`,
 
     it('should return object with expected subject', () => {
       const expected = { subject: 'Your attendance is confirmed' };
-      expect(eventConfirmAttendeeEmail(data)).toMatchObject(expected);
+      expect(
+        eventConfirmAttendeeEmail(
+          data,
+          streaming_url,
+          venue_physical,
+          venue_type,
+          start_at,
+          ends_at,
+        ),
+      ).toMatchObject(expected);
     });
 
     it('should return object with expected emailText', () => {
@@ -161,7 +183,16 @@ You received this email because you Subscribed to Hammes - Sawayn Event.<br />`,
         emailText:
           'Your reservation is confirmed. You can attend the event Emard and Sons',
       };
-      expect(eventConfirmAttendeeEmail(data)).toMatchObject(expected);
+      expect(
+        eventConfirmAttendeeEmail(
+          data,
+          streaming_url,
+          venue_physical,
+          venue_type,
+          start_at,
+          ends_at,
+        ),
+      ).toMatchObject(expected);
     });
   });
 
@@ -209,6 +240,7 @@ You received this email because you Subscribed to Hammes - Sawayn Event.<br />`,
     });
   });
 
+  // Added streaming and venue type to match
   describe('eventAttendanceConfirmation', () => {
     const data = {
       event: {
@@ -216,7 +248,9 @@ You received this email because you Subscribed to Hammes - Sawayn Event.<br />`,
         start_at: new Date('2023-02-07 21:00'),
         ends_at: new Date('2023-02-08, 22:00'),
         description: '',
+        streaming_url: 'http://streaming.url/abcd',
         venue: { name: 'Nitzsche - Hills' },
+        venue_type: events_venue_type_enum.PhysicalAndOnline,
       },
       userName: 'Not the Owner',
     };


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #2229 

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
Venue data will now be visible in attendee's confirmation emails.
Added venue data(physicalLocation, streamingData, start_at, ends_at) to email-templates.ts.
Modified confirmation related functions in event-email.ts to use the mentioned variables.
Modified eventConfirmAttendeeEmail in resolver.ts to grab venue data.
Modfied eventConfirmAttendeeEmail function to properly take in newly created parameters(streaming_url, venue_physical, venue_type, start_at, ends_at). The test fails without these parameters.