### PR TITLE
feat: distinct emails for possible attendances

### DIFF
--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -514,19 +514,10 @@ export class EventResolver {
       },
     });
 
-    const { subject, attachUnsubscribe } = eventAttendanceCancelation({
+    await sendUserEmail({
+      emailData: eventAttendanceCancelation,
       event,
-      userName: updatedEventUser.user.name,
-    });
-
-    await mailerService.sendEmail({
-      emailList: [updatedEventUser.user.email],
-      subject,
-      htmlEmail: attachUnsubscribe({
-        chapterId: event.chapter_id,
-        eventId: event.id,
-        userId: updatedEventUser.user.id,
-      }),
+      user: updatedEventUser.user,
     });
 
     const calendarId = event.chapter.calendar_id;

--- a/server/src/email-templates.ts
+++ b/server/src/email-templates.ts
@@ -261,6 +261,31 @@ You should receive a calendar invite shortly. If you do not, you can add the eve
 <a href=${outlookURL}>Outlook</a>`,
 });
 
+export const eventWaitlistConfirmationText = ({
+  eventName,
+  userName,
+}: {
+  eventName: string;
+  userName: string;
+}) => ({
+  subject: `Added to waitlist: ${eventName}`,
+  emailText: `Hi${userName},<br />
+You were added to waitlist for ${eventName}.<br />
+Once there will be available free spot, you will be moved to attendees. You will receive another email when that happens.`,
+});
+
+export const eventAttendanceRequestText = ({
+  eventName,
+  userName,
+}: {
+  eventName: string;
+  userName: string;
+}) => ({
+  subject: `Attendance request: ${eventName}`,
+  emailText: `Hi${userName},<br />
+This is confirmation of your request to attend ${eventName}. Once event administrator will accept your request, you will receive another email.`,
+});
+
 export const eventAttendanceCancelationText = ({
   eventName,
   userName,

--- a/server/src/util/event-email.ts
+++ b/server/src/util/event-email.ts
@@ -7,6 +7,7 @@ import {
   dateChangeText,
   eventAttendanceCancelationText,
   eventAttendanceConfirmationText,
+  eventAttendanceRequestText,
   eventAttendeeToWaitlistText,
   eventCancelationText,
   eventConfirmAtendeeText,
@@ -16,6 +17,7 @@ import {
   eventNewAttendeeNotificationText,
   eventUnsubscribeText,
   eventUpdateText,
+  eventWaitlistConfirmationText,
   physicalLocationChangeText,
   physicalLocationShortText,
   SPACER,
@@ -324,6 +326,38 @@ export const eventAttendanceConfirmation = ({
     }),
   );
 };
+
+interface WaitlistConfirmation {
+  event: { name: string };
+  userName: string;
+}
+
+export const eventWaitlistConfirmation = ({
+  event,
+  userName,
+}: WaitlistConfirmation) =>
+  withUnsubscribe(
+    eventWaitlistConfirmationText({
+      eventName: event.name,
+      userName: userName ? ` ${userName}` : '',
+    }),
+  );
+
+interface AttendanceRequest {
+  event: { name: string };
+  userName: string;
+}
+
+export const eventAttendanceRequest = ({
+  event,
+  userName,
+}: AttendanceRequest) =>
+  withUnsubscribe(
+    eventAttendanceRequestText({
+      eventName: event.name,
+      userName: userName ? ` ${userName}` : '',
+    }),
+  );
 
 interface AttendanceCancelation {
   event: { name: string };

--- a/server/tests/event-email.test.ts
+++ b/server/tests/event-email.test.ts
@@ -4,11 +4,13 @@ import {
   buildEmailForUpdatedEvent,
   eventAttendanceCancelation,
   eventAttendanceConfirmation,
+  eventAttendanceRequest,
   eventAttendeeToWaitlistEmail,
   eventCancelationEmail,
   eventConfirmAttendeeEmail,
   eventInviteEmail,
   eventNewAttendeeNotifyEmail,
+  eventWaitlistConfirmation,
 } from '../src/util/event-email';
 
 const streaming_url = 'http://streaming.url/abcd';
@@ -372,6 +374,55 @@ Streaming URL: http://streaming.url/abcd<br />
         emailText: `Hi The Owner,<br />\nYour attendance was canceled.`,
       };
       expect(eventAttendanceCancelation(data)).toMatchObject(expected);
+    });
+  });
+
+  describe('eventWaitlistConfirmation', () => {
+    const data = { event: { name: 'Huel - Lynch' }, userName: 'The Owner' };
+    it('should return object with subject, emailText, attachUnsubscribe and attachUnsubscribeText properties', () => {
+      const result = eventWaitlistConfirmation(data);
+      expect(result).toHaveProperty('subject');
+      expect(result).toHaveProperty('emailText');
+      expect(result).toHaveProperty('attachUnsubscribe');
+      expect(result).toHaveProperty('attachUnsubscribeText');
+    });
+
+    it('should return object with expected subject', () => {
+      const expected = { subject: 'Added to waitlist: Huel - Lynch' };
+      expect(eventWaitlistConfirmation(data)).toMatchObject(expected);
+    });
+
+    it('should return object with expected emailText for Physical & Online event', () => {
+      const expected = {
+        emailText: `Hi The Owner,<br />
+You were added to waitlist for Huel - Lynch.<br />
+Once there will be available free spot, you will be moved to attendees. You will receive another email when that happens.`,
+      };
+      expect(eventWaitlistConfirmation(data)).toMatchObject(expected);
+    });
+  });
+
+  describe('eventAttendanceRequest', () => {
+    const data = { event: { name: 'Huel - Lynch' }, userName: 'The Owner' };
+    it('should return object with subject, emailText, attachUnsubscribe and attachUnsubscribeText properties', () => {
+      const result = eventAttendanceRequest(data);
+      expect(result).toHaveProperty('subject');
+      expect(result).toHaveProperty('emailText');
+      expect(result).toHaveProperty('attachUnsubscribe');
+      expect(result).toHaveProperty('attachUnsubscribeText');
+    });
+
+    it('should return object with expected subject', () => {
+      const expected = { subject: 'Attendance request: Huel - Lynch' };
+      expect(eventAttendanceRequest(data)).toMatchObject(expected);
+    });
+
+    it('should return object with expected emailText for Physical & Online event', () => {
+      const expected = {
+        emailText: `Hi The Owner,<br />
+This is confirmation of your request to attend Huel - Lynch. Once event administrator will accept your request, you will receive another email.`,
+      };
+      expect(eventAttendanceRequest(data)).toMatchObject(expected);
     });
   });
 });


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Ref #2379

---
- Adds email for invite only event and when user _attends_ to full event.
- Fixes cause for https://github.com/freeCodeCamp/chapter/actions/runs/4637113197/jobs/8206065493 (Actually unsubscribed event was different than checked, difference was due to sending email only when user is added to attendees.)