### PR TITLE
feat: display user joined date in event dashboard

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -2317,6 +2317,22 @@
             "deprecationReason": null
           },
           {
+            "name": "joined_date",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "subscribed",
             "description": null,
             "args": [],
@@ -2401,6 +2417,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "joined_date",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
                 "ofType": null
               }
             },
@@ -2531,6 +2563,22 @@
             "deprecationReason": null
           },
           {
+            "name": "joined_date",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "subscribed",
             "description": null,
             "args": [],
@@ -2631,6 +2679,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EventRoleWithPermissions",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "joined_date",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
                 "ofType": null
               }
             },
@@ -6849,6 +6913,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EventRoleWithPermissions",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "joined_date",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
                 "ofType": null
               }
             },

--- a/client/src/generated/graphql.tsx
+++ b/client/src/generated/graphql.tsx
@@ -235,6 +235,7 @@ export type EventSponsor = {
 export type EventUser = {
   __typename?: 'EventUser';
   event_id: Scalars['Int'];
+  joined_date: Scalars['DateTime'];
   subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
   user_id: Scalars['Int'];
@@ -244,6 +245,7 @@ export type EventUserWithAttendanceAndUser = {
   __typename?: 'EventUserWithAttendanceAndUser';
   attendance: Attendance;
   event_id: Scalars['Int'];
+  joined_date: Scalars['DateTime'];
   subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
   user: User;
@@ -255,6 +257,7 @@ export type EventUserWithRelations = {
   attendance: Attendance;
   event_id: Scalars['Int'];
   event_role: EventRole;
+  joined_date: Scalars['DateTime'];
   subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
   user: User;
@@ -265,6 +268,7 @@ export type EventUserWithRolePermissions = {
   __typename?: 'EventUserWithRolePermissions';
   event_id: Scalars['Int'];
   event_role: EventRoleWithPermissions;
+  joined_date: Scalars['DateTime'];
   subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
   user_id: Scalars['Int'];
@@ -720,6 +724,7 @@ export type UserEvent = {
   event: Event;
   event_id: Scalars['Int'];
   event_role: EventRoleWithPermissions;
+  joined_date: Scalars['DateTime'];
   subscribed: Scalars['Boolean'];
   updated_at: Scalars['DateTime'];
   user_id: Scalars['Int'];
@@ -1424,6 +1429,7 @@ export type DashboardEventQuery = {
     event_users: Array<{
       __typename?: 'EventUserWithRelations';
       subscribed: boolean;
+      joined_date: any;
       attendance: { __typename?: 'Attendance'; name: string };
       user: {
         __typename?: 'User';
@@ -3932,6 +3938,7 @@ export const DashboardEventDocument = gql`
           name
         }
         subscribed
+        joined_date
       }
     }
   }

--- a/client/src/modules/dashboard/Events/graphql/queries.ts
+++ b/client/src/modules/dashboard/Events/graphql/queries.ts
@@ -75,6 +75,7 @@ export const DASHBOARD_EVENT = gql`
           name
         }
         subscribed
+        joined_date
       }
     }
   }

--- a/client/src/modules/dashboard/Events/pages/EventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EventPage.tsx
@@ -283,7 +283,7 @@ export const EventPage: NextPageWithLayout = () => {
                 <DataTable
                   title={`${title}: ${users.length}`}
                   data={users}
-                  keys={['user', 'role', 'action'] as const}
+                  keys={['user', 'joined', 'role', 'action'] as const}
                   emptyText="No users"
                   mapper={{
                     user: ({ user }) => <UserName user={user} />,
@@ -308,69 +308,77 @@ export const EventPage: NextPageWithLayout = () => {
                     role: ({ event_role }) => (
                       <Text data-cy="role">{event_role.name}</Text>
                     ),
+                    joined: ({ joined_date }) => <Text>{joined_date}</Text>,
                   }}
                 />
               </Box>
               <Box display={{ base: 'block', lg: 'none' }} marginBlock={'2em'}>
-                {users.map(({ attendance, event_role, user }, index) => (
-                  // For a single event, each user can only have one event_user
-                  // entry, so we can use the user id as the key.
-                  <HStack key={user.id}>
-                    <DataTable
-                      title={
-                        {
-                          [AttendanceNames.confirmed]: 'Attendee',
-                          [AttendanceNames.waitlist]: 'On waitlist',
-                          [AttendanceNames.canceled]: 'Canceled',
-                        }[attendance.name]
-                      }
-                      data={[users[index]]}
-                      keys={['type', 'action'] as const}
-                      showHeader={false}
-                      emptyText="No users"
-                      mapper={{
-                        type: () => (
-                          <VStack
-                            align={'flex-start'}
-                            fontSize={['sm', 'md']}
-                            fontWeight={700}
-                            spacing={'2'}
-                            marginBottom={4}
-                          >
-                            <Text>User</Text>
-                            <Text>Role</Text>
-                            <Text>Actions</Text>
-                          </VStack>
-                        ),
-                        action: () => (
-                          <VStack
-                            align={'flex-start'}
-                            fontSize={['sm', 'md']}
-                            spacing={'2'}
-                            marginBottom={4}
-                          >
-                            <UserName user={user} />
-                            {action.map(({ title, onClick, colorScheme }) => (
-                              <Button
-                                key={title.toLowerCase()}
-                                data-cy={title.toLowerCase()}
-                                size="xs"
-                                colorScheme={colorScheme}
-                                onClick={onClick({ eventId, userId: user.id })}
-                              >
-                                {title}
-                                <Text srOnly as="span">
-                                  {user.name} attendee
-                                </Text>
-                              </Button>
-                            ))}
-                            <Text data-cy="role">{event_role.name}</Text>
-                          </VStack>
-                        ),
-                      }}
-                    />
-                  </HStack>
-                ))}
+                {users.map(
+                  ({ attendance, event_role, joined_date, user }, index) => (
+                    // For a single event, each user can only have one event_user
+                    // entry, so we can use the user id as the key.
+                    <HStack key={user.id}>
+                      <DataTable
+                        title={
+                          {
+                            [AttendanceNames.confirmed]: 'Attendee',
+                            [AttendanceNames.waitlist]: 'On waitlist',
+                            [AttendanceNames.canceled]: 'Canceled',
+                          }[attendance.name]
+                        }
+                        data={[users[index]]}
+                        keys={['type', 'action'] as const}
+                        showHeader={false}
+                        emptyText="No users"
+                        mapper={{
+                          type: () => (
+                            <VStack
+                              align={'flex-start'}
+                              fontSize={['sm', 'md']}
+                              fontWeight={700}
+                              spacing={'2'}
+                              marginBottom={4}
+                            >
+                              <Text>User</Text>
+                              <Text>Joined</Text>
+                              <Text>Role</Text>
+                              <Text>Actions</Text>
+                            </VStack>
+                          ),
+                          action: () => (
+                            <VStack
+                              align={'flex-start'}
+                              fontSize={['sm', 'md']}
+                              spacing={'2'}
+                              marginBottom={4}
+                            >
+                              <UserName user={user} />
+                              <Text>{joined_date}</Text>
+                              {action.map(({ title, onClick, colorScheme }) => (
+                                <Button
+                                  key={title.toLowerCase()}
+                                  data-cy={title.toLowerCase()}
+                                  size="xs"
+                                  colorScheme={colorScheme}
+                                  onClick={onClick({
+                                    eventId,
+                                    userId: user.id,
+                                  })}
+                                >
+                                  {title}
+                                  <Text srOnly as="span">
+                                    {user.name} attendee
+                                  </Text>
+                                </Button>
+                              ))}
+                              <Text data-cy="role">{event_role.name}</Text>
+                            </VStack>
+                          ),
+                        }}
+                      />
+                    </HStack>
+                  ),
+                )}
               </Box>
             </Fragment>
           );

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -387,7 +387,10 @@ export class EventResolver {
       }
 
       eventUser = await prisma.event_users.update({
-        data: { attendance: { connect: { name: newAttendanceName } } },
+        data: {
+          attendance: { connect: { name: newAttendanceName } },
+          joined_date: new Date(),
+        },
         include: eventUserIncludes,
         where: {
           user_id_event_id: {

--- a/server/src/graphql-types/EventUser.ts
+++ b/server/src/graphql-types/EventUser.ts
@@ -31,6 +31,9 @@ export class EventUser {
   @Field(() => Date)
   updated_at: Date;
 
+  @Field(() => Date)
+  joined_date: Date;
+
   @Field(() => Int)
   user_id: number;
 


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Display event_user _joined_date_ in event dashboard.
- Order of the _joining_ can be important for the waitlist processing order.
- Displaying it is intended for the event administrator processing invites, or moving from (overcrowded) attendees back to waitlist.
- It's a bit stretch to be using _joined_date_ with the current name for this purpose. But that's the only existing field that could be used right now.
  - _created_at_ - doesn't change, no matter how many times user will cancel their attendance.
  - _updated_at_ - is changed event if user changes just subscription status. 
  - _joined_date_ - initially starts the same as _created_at_. PR adds updating it every time user _attends_ keeping the track of the last time. So ie. attend at Monday -> cancel at Friday -> attend again at Sunday. Won't push user in the line before those wanting to attend between Monday and Sunday.
- Any particular date format requests?