### PR TITLE
fix: don't include banned chapters in admined_chapters

### DIFF
--- a/server/src/util/adminedChapters.ts
+++ b/server/src/util/adminedChapters.ts
@@ -29,4 +29,5 @@ export const isChapterAdminWhere = (user_id: number) => ({
       ],
     },
   },
+  user_bans: { none: { user_id } },
 });


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Closes #2345

---
- For consideration - removing chapter admin role when being banned.
