### PR TITLE
feat: event transfer

### DIFF
--- a/client/src/hooks/useCancelEvent.ts
+++ b/client/src/hooks/useCancelEvent.ts
@@ -1,0 +1,35 @@
+import { useCancelEventMutation } from '../generated/graphql';
+import {
+  DASHBOARD_EVENT,
+  DASHBOARD_EVENTS,
+} from '../modules/dashboard/Events/graphql/queries';
+import {
+  DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+  EVENT,
+} from '../modules/events/graphql/queries';
+
+export const useCancelEvent = () => {
+  const [cancelEvent] = useCancelEventMutation();
+
+  return async ({ eventId }: { eventId: number }) => {
+    const { data, errors } = await cancelEvent({
+      variables: { eventId },
+      refetchQueries: [
+        { query: DASHBOARD_EVENTS },
+        { query: EVENT, variables: { eventId } },
+        { query: DASHBOARD_EVENT, variables: { eventId } },
+        {
+          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+          variables: { offset: 0, limit: 2 },
+        },
+        {
+          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+          variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
+        },
+      ],
+    });
+    if (errors) throw errors;
+
+    return data;
+  };
+};

--- a/client/src/hooks/useCreateEvent.ts
+++ b/client/src/hooks/useCreateEvent.ts
@@ -1,0 +1,84 @@
+import { useRouter } from 'next/router';
+import { isFuture } from 'date-fns';
+
+import {
+  useCreateEventMutation,
+  useJoinChapterMutation,
+  useSendEventInviteMutation,
+} from '../generated/graphql';
+import { useUser } from '../modules/auth/user';
+import { CHAPTER } from '../modules/chapters/graphql/queries';
+import {
+  EventFormData,
+  parseEventData,
+} from '../modules/dashboard/Events/components/EventFormUtils';
+import { DASHBOARD_EVENTS } from '../modules/dashboard/Events/graphql/queries';
+import { DATA_PAGINATED_EVENTS_TOTAL_QUERY } from '../modules/events/graphql/queries';
+import { useAlert } from './useAlert';
+
+interface CreateEventData {
+  data: EventFormData;
+  success: (eventName: string) => string;
+}
+
+export const useCreateEvent = () => {
+  const router = useRouter();
+  const { user } = useUser();
+  const addAlert = useAlert();
+
+  const [createEvent] = useCreateEventMutation();
+  const [joinChapter] = useJoinChapterMutation();
+  const [publish] = useSendEventInviteMutation();
+
+  return async ({ data, success }: CreateEventData) => {
+    const { chapter_id, attend_event } = data;
+    const { data: createData, errors: createErrors } = await createEvent({
+      variables: {
+        chapterId: chapter_id,
+        data: parseEventData(data),
+        attendEvent: attend_event ?? false,
+      },
+      refetchQueries: [
+        { query: CHAPTER, variables: { chapterId: chapter_id } },
+        {
+          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+          variables: { offset: 0, limit: 2 },
+        },
+        {
+          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+          variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
+        },
+        {
+          query: DASHBOARD_EVENTS,
+        },
+      ],
+    });
+
+    if (createErrors) throw createErrors;
+
+    if (createData) {
+      if (attend_event) joinChapter({ variables: { chapterId: chapter_id } });
+      if (isFuture(data.start_at)) {
+        await publish({ variables: { eventId: createData.createEvent.id } });
+      }
+      await router.replace(
+        `/dashboard/events/[id]`,
+        `/dashboard/events/${createData.createEvent.id}`,
+      );
+      addAlert({
+        title: success(createData.createEvent.name),
+        status: 'success',
+      });
+
+      const hasChapterCalendar = user?.admined_chapters.find(
+        ({ id }) => id === chapter_id,
+      )?.has_calendar;
+      if (hasChapterCalendar && !createData.createEvent.has_calendar_event) {
+        addAlert({
+          title: 'Calendar event was not created.',
+          status: 'warning',
+        });
+      }
+    }
+  };
+};

--- a/client/src/modules/dashboard/Events/components/Actions.tsx
+++ b/client/src/modules/dashboard/Events/components/Actions.tsx
@@ -153,6 +153,15 @@ const Actions: React.FC<ActionsProps> = ({
           size={['sm', 'md']}
           link={`${process.env.NEXT_PUBLIC_CLIENT_URL}/events/${eventId}?confirm_attendance=true`}
         />
+        {user?.admined_chapters && user.admined_chapters?.length >= 2 && (
+          <LinkButton
+            size={['sm', 'md']}
+            colorScheme="blue"
+            href={`/dashboard/events/${eventId}/transfer`}
+          >
+            Transfer
+          </LinkButton>
+        )}
       </HStack>
     </>
   );

--- a/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
+++ b/client/src/modules/dashboard/Events/components/EventCancelButton.tsx
@@ -2,12 +2,9 @@ import { Button, ButtonProps } from '@chakra-ui/react';
 import { useConfirm } from 'chakra-confirm';
 import React from 'react';
 import { InfoIcon } from '@chakra-ui/icons';
-import { Event, useCancelEventMutation } from '../../../../generated/graphql';
-import { DASHBOARD_EVENT, DASHBOARD_EVENTS } from '../graphql/queries';
-import {
-  DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-  EVENT,
-} from '../../../events/graphql/queries';
+
+import { Event } from '../../../../generated/graphql';
+import { useCancelEvent } from '../../../../hooks/useCancelEvent';
 
 interface EventCancelButtonProps {
   size?: ButtonProps['size'];
@@ -17,9 +14,13 @@ interface EventCancelButtonProps {
 }
 
 const EventCancelButton = (props: EventCancelButtonProps) => {
-  const { isDisabled = false, buttonText, event, ...rest } = props;
-
-  const [cancel] = useCancelEventMutation();
+  const {
+    isDisabled = false,
+    buttonText,
+    event: { id: eventId },
+    ...rest
+  } = props;
+  const cancel = useCancelEvent();
 
   const confirmCancel = useConfirm({
     title: 'Cancel this event?',
@@ -33,27 +34,10 @@ const EventCancelButton = (props: EventCancelButtonProps) => {
     buttonColor: 'orange',
   });
 
-  const data = {
-    variables: { eventId: event.id },
-    refetchQueries: [
-      { query: EVENT, variables: { eventId: event.id } },
-      { query: DASHBOARD_EVENT, variables: { eventId: event.id } },
-      {
-        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-        variables: { offset: 0, limit: 2 },
-      },
-      {
-        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-        variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
-      },
-      { query: DASHBOARD_EVENTS },
-    ],
-  };
-
   const clickCancel = async () => {
     const ok = await confirmCancel();
     if (ok) {
-      await cancel(data);
+      await cancel({ eventId });
     }
   };
   return (

--- a/client/src/modules/dashboard/Events/components/EventChapterSelect.tsx
+++ b/client/src/modules/dashboard/Events/components/EventChapterSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { useUser } from '../../../auth/user';
@@ -9,27 +9,38 @@ interface Chapter {
   name: string;
 }
 interface EventChapterSelectProps {
+  chapter?: Chapter;
   loading: boolean;
 }
 
-const EventChapterSelect: React.FC<EventChapterSelectProps> = ({ loading }) => {
+const EventChapterSelect: React.FC<EventChapterSelectProps> = ({
+  chapter,
+  loading,
+}) => {
   const key = 'chapter_id';
   const { user } = useUser();
-  const adminedChapters: Chapter[] = user?.admined_chapters ?? [];
+  const adminedChapters: Chapter[] = useMemo(
+    () => (user?.admined_chapters ?? []).filter(({ id }) => id !== chapter?.id),
+    [user?.admined_chapters, chapter?.id],
+  );
 
   const {
     register,
     resetField,
-    getValues,
+    setValue,
     formState: { errors },
   } = useFormContext();
   const error = errors[key]?.message as string;
 
   useEffect(() => {
-    resetField(key, {
-      defaultValue: getValues(key) ?? adminedChapters[0]?.id ?? -1,
-    });
-  }, [adminedChapters]);
+    if (chapter?.id) {
+      setValue(key, adminedChapters[0]?.id ?? -1);
+    } else {
+      resetField(key, {
+        defaultValue: adminedChapters[0]?.id ?? -1,
+      });
+    }
+  }, [adminedChapters, chapter?.id]);
 
   return (
     <Select

--- a/client/src/modules/dashboard/Events/components/EventChapterSelect.tsx
+++ b/client/src/modules/dashboard/Events/components/EventChapterSelect.tsx
@@ -20,12 +20,15 @@ const EventChapterSelect: React.FC<EventChapterSelectProps> = ({ loading }) => {
   const {
     register,
     resetField,
+    getValues,
     formState: { errors },
   } = useFormContext();
   const error = errors[key]?.message as string;
 
   useEffect(() => {
-    resetField(key, { defaultValue: adminedChapters[0]?.id ?? -1 });
+    resetField(key, {
+      defaultValue: getValues(key) ?? adminedChapters[0]?.id ?? -1,
+    });
   }, [adminedChapters]);
 
   return (

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -209,7 +209,7 @@ const EventForm: React.FC<EventFormProps> = ({
           >
             {submitText}
           </Button>
-          {data && !data.canceled && formType !== 'transfer' && (
+          {formType === 'edit' && data && !data.canceled && (
             <EventCancelButton
               event={data}
               isDisabled={loading}

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -37,7 +37,8 @@ const minCapacity = (event?: IEventData) => {
 
 const EventForm: React.FC<EventFormProps> = (props) => {
   const { onSubmit, data, submitText, chapter, loadingText, formType } = props;
-  const displayChaptersDropdown = typeof chapter === 'undefined';
+  const displayChaptersDropdown =
+    typeof chapter === 'undefined' || formType === 'transfer';
 
   const sponsorQuery = useSponsorsQuery();
 
@@ -50,6 +51,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
         chapter_id: chapter?.id,
         start_at: add(date, { days: 1 }),
         ends_at: add(date, { days: 1, minutes: 30 }),
+        attend_event: true,
       };
     }
     return {
@@ -70,6 +72,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
         data.event_users?.filter(
           ({ attendance: { name } }) => name === AttendanceNames.confirmed,
         ).length ?? 0,
+      attend_event: true,
     };
   }, []);
 
@@ -103,7 +106,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
         submitLabel={submitText}
         FormHandling={handleSubmit(disableWhileSubmitting)}
       >
-        {!displayChaptersDropdown || data ? (
+        {!displayChaptersDropdown || (data && formType !== 'transfer') ? (
           <Heading>{chapter?.name}</Heading>
         ) : (
           <EventChapterSelect loading={loading} />
@@ -168,7 +171,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
 
         {data?.canceled && <Text color="red.500">Event canceled</Text>}
 
-        {formType === 'new' && (
+        {['new', 'transfer'].includes(formType) && (
           <Grid as="fieldset" width="100%">
             <Text srOnly as="legend">
               Your interaction with the event
@@ -197,7 +200,7 @@ const EventForm: React.FC<EventFormProps> = (props) => {
           >
             {submitText}
           </Button>
-          {data && !data.canceled && (
+          {data && !data.canceled && formType !== 'transfer' && (
             <EventCancelButton
               event={data}
               isDisabled={loading}

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -71,7 +71,7 @@ const EventForm: React.FC<EventFormProps> = ({
       ends_at: new Date(data.ends_at),
       sponsors: data.sponsors,
       venue_type: data.venue_type,
-      venue_id: data.venue_id ?? 0,
+      venue_id: formType === 'transfer' ? 0 : data.venue_id,
       image_url: data.image_url,
       invite_only: data.invite_only,
       chapter_id: chapter?.id,

--- a/client/src/modules/dashboard/Events/components/EventForm.tsx
+++ b/client/src/modules/dashboard/Events/components/EventForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Heading, Grid, Text } from '@chakra-ui/react';
+import { Button, Checkbox, Grid, Heading, Text } from '@chakra-ui/react';
 import React, { useMemo } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { add } from 'date-fns';
@@ -35,8 +35,15 @@ const minCapacity = (event?: IEventData) => {
   );
 };
 
-const EventForm: React.FC<EventFormProps> = (props) => {
-  const { onSubmit, data, submitText, chapter, loadingText, formType } = props;
+const EventForm: React.FC<EventFormProps> = ({
+  chapter,
+  data,
+  formType,
+  header,
+  loadingText,
+  onSubmit,
+  submitText,
+}) => {
   const displayChaptersDropdown =
     typeof chapter === 'undefined' || formType === 'transfer';
 
@@ -106,10 +113,12 @@ const EventForm: React.FC<EventFormProps> = (props) => {
         submitLabel={submitText}
         FormHandling={handleSubmit(disableWhileSubmitting)}
       >
-        {!displayChaptersDropdown || (data && formType !== 'transfer') ? (
-          <Heading>{chapter?.name}</Heading>
-        ) : (
-          <EventChapterSelect loading={loading} />
+        <Heading>{header}</Heading>
+        {chapter && (
+          <Text fontSize={['md', 'lg', 'xl']}>Chapter: {chapter?.name}</Text>
+        )}
+        {displayChaptersDropdown && (
+          <EventChapterSelect chapter={chapter} loading={loading} />
         )}
         {fields.map(({ isRequired, key, label, placeholder, type }) => {
           const Component = fieldTypeToComponent(type);

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -197,12 +197,13 @@ export const fields: Field[] = [
 ];
 
 export interface EventFormProps {
-  onSubmit: (data: EventFormData) => Promise<void>;
-  data?: IEventData;
-  submitText: string;
   chapter?: { id: number; name: string };
-  loadingText: string;
+  data?: IEventData;
   formType: 'new' | 'edit' | 'transfer';
+  header: string;
+  loadingText: string;
+  onSubmit: (data: EventFormData) => Promise<void>;
+  submitText: string;
 }
 
 const getSelectedFieldIdForSponsor = (

--- a/client/src/modules/dashboard/Events/components/EventFormUtils.ts
+++ b/client/src/modules/dashboard/Events/components/EventFormUtils.ts
@@ -202,7 +202,7 @@ export interface EventFormProps {
   submitText: string;
   chapter?: { id: number; name: string };
   loadingText: string;
-  formType: 'new' | 'edit';
+  formType: 'new' | 'edit' | 'transfer';
 }
 
 const getSelectedFieldIdForSponsor = (

--- a/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/EditEventPage.tsx
@@ -77,16 +77,17 @@ export const EditEventPage: NextPageWithLayout = () => {
   });
   return (
     <EventForm
+      chapter={data.dashboardEvent.chapter}
       data={{
         ...rest,
         sponsors: sponsorData || [],
         venue_id: data.dashboardEvent?.venue?.id,
       }}
-      onSubmit={onSubmit}
-      loadingText={'Saving Event Changes'}
-      submitText={'Save Event Changes'}
-      chapter={data.dashboardEvent.chapter}
       formType="edit"
+      header="Edit Event"
+      loadingText={'Saving Event Changes'}
+      onSubmit={onSubmit}
+      submitText={'Save Event Changes'}
     />
   );
 };

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -1,35 +1,17 @@
-import { useRouter } from 'next/router';
 import NextError from 'next/error';
 import React, { ReactElement } from 'react';
-import { isFuture } from 'date-fns';
 
-import {
-  useCreateEventMutation,
-  useJoinChapterMutation,
-  useSendEventInviteMutation,
-} from '../../../../generated/graphql';
-import { useAlert } from '../../../../hooks/useAlert';
 import { DashboardLayout } from '../../shared/components/DashboardLayout';
 import EventForm from '../components/EventForm';
-import { EventFormData, parseEventData } from '../components/EventFormUtils';
-import { CHAPTER } from '../../../chapters/graphql/queries';
-import { DASHBOARD_EVENTS } from '../graphql/queries';
+import { EventFormData } from '../components/EventFormUtils';
 import { NextPageWithLayout } from '../../../../pages/_app';
 import { useUser } from '../../../auth/user';
-import { DATA_PAGINATED_EVENTS_TOTAL_QUERY } from 'modules/events/graphql/queries';
+import { useCreateEvent } from '../../../../hooks/useCreateEvent';
 
 export const NewEventPage: NextPageWithLayout<{
   chapterId?: number;
 }> = ({ chapterId }) => {
-  const router = useRouter();
-
-  const [createEvent] = useCreateEventMutation();
-
-  const [publish] = useSendEventInviteMutation();
-
-  const addAlert = useAlert();
-
-  const [joinChapter] = useJoinChapterMutation();
+  const createEvent = useCreateEvent();
 
   const { user } = useUser();
   const chapter = user?.admined_chapters.find(({ id }) => id === chapterId);
@@ -37,57 +19,11 @@ export const NewEventPage: NextPageWithLayout<{
     return <NextError statusCode={403} title="Access denied" />;
   }
 
-  const onSubmit = async (data: EventFormData) => {
-    const { chapter_id, attend_event } = data;
-    const { data: eventData, errors } = await createEvent({
-      variables: {
-        chapterId: chapter_id,
-        data: parseEventData(data),
-        attendEvent: attend_event ?? false,
-      },
-      refetchQueries: [
-        { query: CHAPTER, variables: { chapterId: chapter_id } },
-        {
-          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-          variables: { offset: 0, limit: 2 },
-        },
-        {
-          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-          variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
-        },
-        {
-          query: DASHBOARD_EVENTS,
-        },
-      ],
+  const onSubmit = async (data: EventFormData) =>
+    await createEvent({
+      data,
+      success: (eventName) => `Event "${eventName}" created!`,
     });
-
-    if (errors) throw errors;
-
-    if (eventData) {
-      if (attend_event) joinChapter({ variables: { chapterId: chapter_id } });
-      if (isFuture(data.start_at)) {
-        await publish({ variables: { eventId: eventData.createEvent.id } });
-      }
-      await router.replace(
-        `/dashboard/events/[id]`,
-        `/dashboard/events/${eventData.createEvent.id}`,
-      );
-      addAlert({
-        title: `Event "${eventData.createEvent.name}" created!`,
-        status: 'success',
-      });
-
-      const hasChapterCalendar = user?.admined_chapters.find(
-        ({ id }) => id === chapter_id,
-      )?.has_calendar;
-      if (hasChapterCalendar && !eventData.createEvent.has_calendar_event) {
-        addAlert({
-          title: 'Calendar event was not created.',
-          status: 'warning',
-        });
-      }
-    }
-  };
 
   return (
     <EventForm

--- a/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/NewEventPage.tsx
@@ -91,11 +91,12 @@ export const NewEventPage: NextPageWithLayout<{
 
   return (
     <EventForm
-      onSubmit={onSubmit}
-      submitText="Add event"
-      loadingText="Adding Event"
       chapter={chapter}
       formType="new"
+      header="Create Event"
+      loadingText="Adding Event"
+      onSubmit={onSubmit}
+      submitText="Add event"
     />
   );
 };

--- a/client/src/modules/dashboard/Events/pages/TransferEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/TransferEventPage.tsx
@@ -1,0 +1,148 @@
+import NextError from 'next/error';
+import { useRouter } from 'next/router';
+import React, { ReactElement } from 'react';
+import { isFuture } from 'date-fns';
+
+import {
+  useCancelEventMutation,
+  useCreateEventMutation,
+  useDashboardEventQuery,
+  useJoinChapterMutation,
+  useSendEventInviteMutation,
+} from '../../../../generated/graphql';
+import { useAlert } from '../../../../hooks/useAlert';
+import { useParam } from '../../../../hooks/useParam';
+import { DashboardLayout } from '../../shared/components/DashboardLayout';
+import EventForm from '../components/EventForm';
+import { EventFormData, parseEventData } from '../components/EventFormUtils';
+import { DASHBOARD_EVENTS, DASHBOARD_EVENT } from '../graphql/queries';
+import {
+  DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+  EVENT,
+} from '../../../events/graphql/queries';
+import { DashboardLoading } from '../../shared/components/DashboardLoading';
+import { NextPageWithLayout } from '../../../../pages/_app';
+import { CHAPTER } from '../../../chapters/graphql/queries';
+import { useUser } from '../../../auth/user';
+
+export const TransferEventPage: NextPageWithLayout = () => {
+  const router = useRouter();
+  const { param: eventId } = useParam();
+  const { user } = useUser();
+
+  const { loading, error, data } = useDashboardEventQuery({
+    variables: { eventId: eventId },
+  });
+
+  const addAlert = useAlert();
+
+  // TODO: update the cache directly:
+  // https://www.apollographql.com/docs/react/data/mutations/#updating-the-cache-directly
+  const [cancelEvent] = useCancelEventMutation({
+    refetchQueries: [
+      { query: DASHBOARD_EVENTS },
+      { query: EVENT, variables: { eventId } },
+      { query: DASHBOARD_EVENT, variables: { eventId } },
+      {
+        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+        variables: { offset: 0, limit: 2 },
+      },
+      {
+        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+        variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
+      },
+    ],
+  });
+  const [createEvent] = useCreateEventMutation();
+  const [joinChapter] = useJoinChapterMutation();
+  const [publish] = useSendEventInviteMutation();
+
+  const onSubmit = async (data: EventFormData) => {
+    const { chapter_id, attend_event } = data;
+    const { data: cancelData, errors: cancelErrors } = await cancelEvent({
+      variables: { eventId },
+    });
+
+    if (cancelErrors) throw cancelErrors;
+
+    const { data: createData, errors: createErrors } = await createEvent({
+      variables: {
+        chapterId: chapter_id,
+        data: parseEventData(data),
+        attendEvent: attend_event ?? false,
+      },
+      refetchQueries: [
+        { query: CHAPTER, variables: { chapterId: chapter_id } },
+        {
+          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+          variables: { offset: 0, limit: 2 },
+        },
+        {
+          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
+          variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
+        },
+        {
+          query: DASHBOARD_EVENTS,
+        },
+      ],
+    });
+
+    if (createErrors) throw createErrors;
+
+    if (cancelData && createData) {
+      if (attend_event) joinChapter({ variables: { chapterId: chapter_id } });
+      if (isFuture(data.start_at)) {
+        await publish({ variables: { eventId: createData.createEvent.id } });
+      }
+      await router.replace(
+        `/dashboard/events/[id]`,
+        `/dashboard/events/${createData.createEvent.id}`,
+      );
+      addAlert({
+        title: `Event "${createData.createEvent.name}" transferred successfully!`,
+        status: 'success',
+      });
+
+      const hasChapterCalendar = user?.admined_chapters.find(
+        ({ id }) => id === chapter_id,
+      )?.has_calendar;
+      if (hasChapterCalendar && !createData.createEvent.has_calendar_event) {
+        addAlert({
+          title: 'Calendar event was not created.',
+          status: 'warning',
+        });
+      }
+    }
+  };
+
+  const isLoading = loading || !data;
+  if (isLoading || error) return <DashboardLoading error={error} />;
+  if (!data.dashboardEvent)
+    return <NextError statusCode={404} title="Event not found" />;
+
+  const { sponsors, ...rest } = data.dashboardEvent;
+  const sponsorData = sponsors?.map((s) => {
+    return {
+      id: s.sponsor.id,
+      type: s.sponsor.type,
+    };
+  });
+  return (
+    <EventForm
+      data={{
+        ...rest,
+        sponsors: sponsorData || [],
+        venue_id: data.dashboardEvent?.venue?.id,
+      }}
+      onSubmit={onSubmit}
+      loadingText={'Transfering Event'}
+      submitText={'Transfer Event'}
+      chapter={data.dashboardEvent.chapter}
+      formType="transfer"
+    />
+  );
+};
+
+TransferEventPage.getLayout = function getLayout(page: ReactElement) {
+  return <DashboardLayout>{page}</DashboardLayout>;
+};

--- a/client/src/modules/dashboard/Events/pages/TransferEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/TransferEventPage.tsx
@@ -18,8 +18,6 @@ export const TransferEventPage: NextPageWithLayout = () => {
     variables: { eventId: eventId },
   });
 
-  // TODO: update the cache directly:
-  // https://www.apollographql.com/docs/react/data/mutations/#updating-the-cache-directly
   const cancelEvent = useCancelEvent();
   const createEvent = useCreateEvent();
 

--- a/client/src/modules/dashboard/Events/pages/TransferEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/TransferEventPage.tsx
@@ -129,16 +129,17 @@ export const TransferEventPage: NextPageWithLayout = () => {
   });
   return (
     <EventForm
+      chapter={data.dashboardEvent.chapter}
       data={{
         ...rest,
         sponsors: sponsorData || [],
         venue_id: data.dashboardEvent?.venue?.id,
       }}
-      onSubmit={onSubmit}
-      loadingText={'Transfering Event'}
-      submitText={'Transfer Event'}
-      chapter={data.dashboardEvent.chapter}
       formType="transfer"
+      header="Transfer Event"
+      loadingText="Transfering Event"
+      onSubmit={onSubmit}
+      submitText="Transfer Event"
     />
   );
 };

--- a/client/src/modules/dashboard/Events/pages/TransferEventPage.tsx
+++ b/client/src/modules/dashboard/Events/pages/TransferEventPage.tsx
@@ -1,117 +1,37 @@
 import NextError from 'next/error';
-import { useRouter } from 'next/router';
 import React, { ReactElement } from 'react';
-import { isFuture } from 'date-fns';
 
-import {
-  useCancelEventMutation,
-  useCreateEventMutation,
-  useDashboardEventQuery,
-  useJoinChapterMutation,
-  useSendEventInviteMutation,
-} from '../../../../generated/graphql';
-import { useAlert } from '../../../../hooks/useAlert';
+import { useDashboardEventQuery } from '../../../../generated/graphql';
 import { useParam } from '../../../../hooks/useParam';
 import { DashboardLayout } from '../../shared/components/DashboardLayout';
 import EventForm from '../components/EventForm';
-import { EventFormData, parseEventData } from '../components/EventFormUtils';
-import { DASHBOARD_EVENTS, DASHBOARD_EVENT } from '../graphql/queries';
-import {
-  DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-  EVENT,
-} from '../../../events/graphql/queries';
+import { EventFormData } from '../components/EventFormUtils';
 import { DashboardLoading } from '../../shared/components/DashboardLoading';
 import { NextPageWithLayout } from '../../../../pages/_app';
-import { CHAPTER } from '../../../chapters/graphql/queries';
-import { useUser } from '../../../auth/user';
+import { useCancelEvent } from 'hooks/useCancelEvent';
+import { useCreateEvent } from 'hooks/useCreateEvent';
 
 export const TransferEventPage: NextPageWithLayout = () => {
-  const router = useRouter();
   const { param: eventId } = useParam();
-  const { user } = useUser();
 
   const { loading, error, data } = useDashboardEventQuery({
     variables: { eventId: eventId },
   });
 
-  const addAlert = useAlert();
-
   // TODO: update the cache directly:
   // https://www.apollographql.com/docs/react/data/mutations/#updating-the-cache-directly
-  const [cancelEvent] = useCancelEventMutation({
-    refetchQueries: [
-      { query: DASHBOARD_EVENTS },
-      { query: EVENT, variables: { eventId } },
-      { query: DASHBOARD_EVENT, variables: { eventId } },
-      {
-        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-        variables: { offset: 0, limit: 2 },
-      },
-      {
-        query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-        variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
-      },
-    ],
-  });
-  const [createEvent] = useCreateEventMutation();
-  const [joinChapter] = useJoinChapterMutation();
-  const [publish] = useSendEventInviteMutation();
+  const cancelEvent = useCancelEvent();
+  const createEvent = useCreateEvent();
 
   const onSubmit = async (data: EventFormData) => {
-    const { chapter_id, attend_event } = data;
-    const { data: cancelData, errors: cancelErrors } = await cancelEvent({
-      variables: { eventId },
-    });
+    const cancelData = await cancelEvent({ eventId });
 
-    if (cancelErrors) throw cancelErrors;
-
-    const { data: createData, errors: createErrors } = await createEvent({
-      variables: {
-        chapterId: chapter_id,
-        data: parseEventData(data),
-        attendEvent: attend_event ?? false,
-      },
-      refetchQueries: [
-        { query: CHAPTER, variables: { chapterId: chapter_id } },
-        {
-          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-          variables: { offset: 0, limit: 2 },
-        },
-        {
-          query: DATA_PAGINATED_EVENTS_TOTAL_QUERY,
-          variables: { offset: 0, limit: 5, showOnlyUpcoming: false },
-        },
-        {
-          query: DASHBOARD_EVENTS,
-        },
-      ],
-    });
-
-    if (createErrors) throw createErrors;
-
-    if (cancelData && createData) {
-      if (attend_event) joinChapter({ variables: { chapterId: chapter_id } });
-      if (isFuture(data.start_at)) {
-        await publish({ variables: { eventId: createData.createEvent.id } });
-      }
-      await router.replace(
-        `/dashboard/events/[id]`,
-        `/dashboard/events/${createData.createEvent.id}`,
-      );
-      addAlert({
-        title: `Event "${createData.createEvent.name}" transferred successfully!`,
-        status: 'success',
+    if (cancelData) {
+      await createEvent({
+        data,
+        success: (eventName) =>
+          `Event "${eventName}" transferred successfully!`,
       });
-
-      const hasChapterCalendar = user?.admined_chapters.find(
-        ({ id }) => id === chapter_id,
-      )?.has_calendar;
-      if (hasChapterCalendar && !createData.createEvent.has_calendar_event) {
-        addAlert({
-          title: 'Calendar event was not created.',
-          status: 'warning',
-        });
-      }
     }
   };
 

--- a/client/src/pages/dashboard/events/[id]/transfer.tsx
+++ b/client/src/pages/dashboard/events/[id]/transfer.tsx
@@ -1,0 +1,2 @@
+import { TransferEventPage } from '../../../../modules/dashboard/Events/pages/TransferEventPage';
+export default TransferEventPage;


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

Ref #1927 

---
- Fully reusing existing mutations. That's pretty cool (:sunglasses:), but let me know if I should rather create separate mutation for it in resolver, and offload logic there.
- I've added custom hooks to reuse canceling and event creating logic from client as much as possible.
- Original chapter is filtered out from the list of available chapters when transferring.
- Button to transfer is displayed only if user has admined `>= 2` chapters.
- Added header to the form, to make clearer what page is that (_Create Event_, _Edit Event_, _Transfer Event_).
- I'm going to still add tests, either to this PR or separate. But it can be looked at already.