### PR TITLE
chore: order event_users for waitlist change

### DIFF
--- a/server/src/controllers/ChapterUser/resolver.ts
+++ b/server/src/controllers/ChapterUser/resolver.ts
@@ -52,7 +52,10 @@ async function removeUserFromEventsInChapter({
       event: {
         include: {
           chapter: true,
-          event_users: { include: { attendance: true, user: true } },
+          event_users: {
+            include: { attendance: true, user: true },
+            orderBy: { joined_date: 'asc' },
+          },
           venue: true,
         },
       },

--- a/server/src/controllers/Events/resolver.ts
+++ b/server/src/controllers/Events/resolver.ts
@@ -462,7 +462,10 @@ export class EventResolver {
     const event = await prisma.events.findUniqueOrThrow({
       where: { id: eventId },
       include: {
-        event_users: { include: eventUserIncludes },
+        event_users: {
+          include: eventUserIncludes,
+          orderBy: { joined_date: 'asc' },
+        },
         venue: true,
         chapter: { select: { calendar_id: true } },
       },
@@ -610,7 +613,10 @@ export class EventResolver {
         event: {
           include: {
             chapter: { select: { calendar_id: true } },
-            event_users: { include: { attendance: true, user: true } },
+            event_users: {
+              include: { attendance: true, user: true },
+              orderBy: { joined_date: 'asc' },
+            },
             venue: true,
           },
         },


### PR DESCRIPTION
- [x] I have read [Chapter's contributing guidelines](https://github.com/freeCodeCamp/chapter/blob/main/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `main` branch of Chapter.

---
- Order of event_users is important, as we'd want to move to attendees user that's on waitlist for longest.